### PR TITLE
禁止使用子查询，避免inception数据脱敏效果被子查询击穿

### DIFF
--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -185,6 +185,10 @@ class MysqlEngine(EngineBase):
         if '*' in sql:
             result['has_star'] = True
             result['msg'] = 'SQL语句中含有 * '
+        # 严禁select语句使用子查询，防止inception的脱敏功能被子查询击穿
+        if len(re.findall('select', sql.lower())) >= 2:
+            result['bad_query'] = True
+            result['msg'] = '当前版本的Archery禁止使用子查询'
         # select语句先使用Explain判断语法是否正确
         if re.match(r"^select", sql, re.I):
             explain_result = self.query(db_name=db_name, sql=f"explain {sql}")


### PR DESCRIPTION
本次提交内容用于从代码层面限制 Archery 的子查询功能，避免 Inception 组件的脱敏功能被子查询语法击穿，由此屏蔽数据泄露风险，其具体效果如下图所示：
![捕获](https://user-images.githubusercontent.com/43627142/137518285-ded2458e-6953-4ce1-b005-d2a61073d95e.PNG)