### PR TITLE
数据库管理页面-添加mysql/pgsql/mongo实例选择下拉菜单-并添加pgsql/mongo创建数据库功能

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -260,8 +260,8 @@ class MongoEngine(EngineBase):
             auth_db = self.instance.db_name or 'admin'
             try:
                 if not sql.startswith('var host='): #在master节点执行的情况
-                    cmd = "{mongo} --quiet -u {uname} -p '{password}' {host}:{port}/{auth_db} <<\\EOF\ndb=db.getSiblingDB(\"{db_name}\");{slave_ok}printjson({sql})\nEOF".format(
-                        mongo=mongo, uname=self.user, password=self.password, host=self.host, port=self.port, db_name=db_name, sql=sql, auth_db=auth_db, slave_ok=slave_ok)
+                    cmd = "{mongo} --quiet mongodb://{uname}:'{password}'@{host}:{port}/{auth_db} <<\\EOF\ndb=db.getSiblingDB(\"{db_name}\");{slave_ok}printjson({sql})\nEOF".format(
+                        mongo=mongo, uname=self.user, password=self.password, host=self.host, port=self.port, db_name=db_name, sql=sql, auth_db=auth_db, slave_ok=slave_ok)                        
                 else:
                     cmd = "{mongo} --quiet -u {user} -p '{password}' {host}:{port}/{auth_db} <<\\EOF\nrs.slaveOk();{sql}\nEOF".format(
                         mongo=mongo, user=self.user, password=self.password, host=self.host, port=self.port, db_name=db_name, sql=sql, auth_db=auth_db)

--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -320,13 +320,18 @@ class MongoEngine(EngineBase):
         """执行上线单，返回Review set"""
         return self.execute(db_name=workflow.db_name, sql=workflow.sqlworkflowcontent.sql_content)
 
-    def execute(self, db_name=None, sql=''):
+    def execute(self, db_name=None, sql='', ddl=''):
         """mongo命令执行语句"""
         self.get_master()
         execute_result = ReviewSet(full_sql=sql)
         sql = sql.strip()
-        # 以；切分语句，逐句执行
-        sp_sql = sql.split(";")
+        #ddl create database语句
+        if ddl.lower() == 'true':
+          sp_sql = sql.split(";")
+          logger.debug("ddl:" + str(sp_sql))
+        else:       
+          # 以；切分语句，逐句执行
+          sp_sql = sql.split(";")
         line = 0
         for exec_sql in sp_sql:
             if not exec_sql == '':

--- a/sql/templates/database.html
+++ b/sql/templates/database.html
@@ -3,6 +3,15 @@
 {% block content %}
     <!-- 自定义操作按钮-->
     <div id="toolbar" class="form-inline pull-left">
+        <div class="form-group">
+            <select id="db_type1" class="form-control selectpicker" name="db_type"
+                    title="请选择数据库类型"
+                    data-live-search="true">
+                <option value="mysql">mysql</option>
+                <option value="pgsql">pgsql</option>
+                <option value="mongo">mongo</option>
+            </select>
+        </div>        
         <div class="form-group ">
             <select id=instance class="form-control selectpicker" name="instance_list"
                     title="请选择实例"
@@ -68,11 +77,11 @@
                         </div>
                     </div>
                     <div class="form-group row">
-                        <label for="remark" class="col-sm-3 col-form-label">备注</label>
+                        <label for="remark" class="col-sm-3 col-form-label">备注/mongo密码</label>
                         <div class="col-sm-9">
                             <input type="text" id="remark" class="form-control"
                                    autocomplete="off"
-                                   placeholder="请输入备注">
+                                   placeholder="请输入备注/mongo密码">
                         </div>
                     </div>
                 </div>
@@ -178,11 +187,12 @@
                 //请求服务数据时所传参数
                 queryParams:
                     function (params) {
-                        if ($("#instance").val()) {
+                        if ($("#instance").val() && $("#db_type1").val()) {
                             return {
                                 search: params.search,
                                 instance_id: $("#instance").val(),
-                                saved: $("#saved").val()
+                                saved: $("#saved").val(),
+                                db_type1: $("#db_type1").val()                                
                             }
                         }
                     },
@@ -200,11 +210,18 @@
                         title: '授权账号',
                         field: 'grantees',
                         formatter: function (value, row, index) {
+                          if ( $("#db_type1").val() == 'mysql' ) {
                             let grantee = '';
                             for (let i = 0; i < value.length; i++) {
                                 grantee = grantee + value[i] + '</br>'
                             }
                             return grantee
+                          } 
+                          else {
+                            let grantee = '';
+                            grantee = value
+                            return grantee
+                          } 
                         }
                     }, {
                         title: '负责人',
@@ -214,7 +231,7 @@
                         title: '负责人',
                         field: 'owner_display'
                     }, {
-                        title: '备注',
+                        title: '备注/mongo密码',
                         field: 'remark'
                     }, {
                         title: '操作',
@@ -261,7 +278,7 @@
 
         //创建数据库
         function create_database() {
-            if (!$("#instance").val()) {
+            if (!$("#instance").val() || !$("#db_type1").val()) {
                 alert("请选择实例！");
             } else {
                 $.ajax({
@@ -272,7 +289,8 @@
                         instance_id: $("#instance").val(),
                         db_name: $("#db_name").val(),
                         owner: $("#owner").val(),
-                        remark: $("#remark").val()
+                        remark: $("#remark").val(),
+                        db_type1: $("#db_type1").val()                        
                     },
                     complete: function () {
                     },
@@ -339,13 +357,13 @@
         $(document).ready(function () {
             database_list();
             //获取用户实例列表
-            $(function () {
+            $("#db_type1").change(function () {
                 $.ajax({
                     type: "get",
                     url: "/group/user_all_instances/",
                     dataType: "json",
                     data: {
-                        db_type: ['mysql']
+                        db_type: [$("#db_type1").val()]
                     },
                     complete: function () {
                     },


### PR DESCRIPTION
commits:数据库管理页面-添加pgsql实例选择下拉菜单-并添加pgsql创建数据库功
1. sql/templates/database.html 添加db_type类型选择下拉菜单，自动生成对应实例和数据库列表
2. sql/instance_database.py 添加db_type=pgsql/mongo的数据库查询和创建
3. sql/engine/pgsql.py 添加execute方法支持pgsql create database ddl
4. sql/engine/mongo.py 添加execute ddl参数和打印，remark字段为mongo数据库密码