### PR TITLE
修复Oracle 19c备份时报错不支持CONTINOUS_MINE

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -169,7 +169,7 @@ class OracleEngine(EngineBase):
 
     def get_group_tables_by_db(self, db_name):
         data = {}
-        table_list_sql = f"""SELECT table_name, comments FROM  dba_tab_comments  WHERE owner = :db_name"""
+        table_list_sql = f"""SELECT a.table_name,a.comments FROM dba_tab_comments a,all_tables b WHERE a.table_name=b.table_name AND a.owner=b.owner AND a.owner=:db_name"""
         result = self.query(
             db_name=db_name, sql=table_list_sql, parameters={"db_name": db_name}
         )


### PR DESCRIPTION
解决Oracle 19c 非CDB容器部署，生成回滚语句报不支持CONTINOUS_MINE的问题，若是CDB容器部署，暂不支持备份