### PR TITLE
增加离线导出工单，可通过查询页面右侧切换

### DIFF
--- a/common/check.py
+++ b/common/check.py
@@ -141,28 +141,28 @@ def file_storage_connect(request):
     result = {"status": 0, "msg": "ok", "data": []}
     storage_type = request.POST.get("storage_type")
     # 检查是否存在该变量
-    max_export_rows = request.POST.get("max_export_rows", '10000')
-    max_export_exec_time = request.POST.get("max_export_exec_time", '60')
-    files_expire_with_days = request.POST.get("files_expire_with_days", '0')
+    max_export_rows = request.POST.get("max_export_rows", "10000")
+    max_export_exec_time = request.POST.get("max_export_exec_time", "60")
+    files_expire_with_days = request.POST.get("files_expire_with_days", "0")
     # 若变量已经定义，检查是否为空
-    max_export_rows = max_export_rows if max_export_rows else '10000'
-    max_export_exec_time = max_export_exec_time if max_export_exec_time else '60'
-    files_expire_with_days = files_expire_with_days if files_expire_with_days else '0'
-    check_list = {"max_export_rows": max_export_rows,
-                  "max_export_exec_time": max_export_exec_time,
-                  "files_expire_with_days": files_expire_with_days}
+    max_export_rows = max_export_rows if max_export_rows else "10000"
+    max_export_exec_time = max_export_exec_time if max_export_exec_time else "60"
+    files_expire_with_days = files_expire_with_days if files_expire_with_days else "0"
+    check_list = {
+        "max_export_rows": max_export_rows,
+        "max_export_exec_time": max_export_exec_time,
+        "files_expire_with_days": files_expire_with_days,
+    }
     try:
-        # if not isinstance(files_expire_with_days, int):
         # 遍历字典，判断是否只有数字
         for key, value in check_list.items():
-            print(value)
             if not value.isdigit():
                 raise TypeError(f"Value: {key} \nmust be an integer.")
     except TypeError as e:
         result["status"] = 1
         result["msg"] = "参数类型错误,\n{}".format(str(e))
 
-    if storage_type == 'sftp':
+    if storage_type == "sftp":
         sftp_host = request.POST.get("sftp_host")
         sftp_port = int(request.POST.get("sftp_port"))
         sftp_user = request.POST.get("sftp_user")
@@ -177,15 +177,13 @@ def file_storage_connect(request):
                 remote_path = sftp_path
                 try:
                     sftp.listdir(remote_path)
-                    # files = sftp.listdir(remote_path)
-                    # print(f"SFTP 远程路径 '{remote_path}' 存在，包含文件/文件夹: {files}")
                 except FileNotFoundError:
                     raise Exception(f"SFTP 远程路径 '{remote_path}' 不存在")
 
         except Exception as e:
             result["status"] = 1
             result["msg"] = "无法连接,\n{}".format(str(e))
-    elif storage_type == 'oss':
+    elif storage_type == "oss":
         access_key_id = request.POST.get("access_key_id")
         access_key_secret = request.POST.get("access_key_secret")
         endpoint = request.POST.get("endpoint")
@@ -205,11 +203,13 @@ def file_storage_connect(request):
         except Exception as e:
             result["status"] = 1
             result["msg"] = "无法连接,\n{}".format(str(e))
-    elif storage_type == 'local':
-        local_path = r'{}'.format(request.POST.get("local_path"))
+    elif storage_type == "local":
+        local_path = r"{}".format(request.POST.get("local_path"))
         try:
             if not os.path.exists(local_path):
-                raise FileNotFoundError(f"Destination directory '{local_path}' not found.")
+                raise FileNotFoundError(
+                    f"Destination directory '{local_path}' not found."
+                )
         except Exception as e:
             result["status"] = 1
             result["msg"] = "本地路径不存在,\n{}".format(str(e))

--- a/common/templates/config.html
+++ b/common/templates/config.html
@@ -399,6 +399,169 @@
                                            placeholder="管理员/DBA查询结果集限制" />
                                 </div>
                             </div>
+                            <h5 style="color: darkgrey"><b>SQL离线导出配置</b></h5>
+                            <hr/>
+                            <div class="form-group">
+                                <label for="sqlfile_storage"
+                                       class="col-sm-4 control-label">离线导出文件存储服务</label>
+                                <div class="col-sm-5">
+                                    <select id="sqlfile_storage" key="sqlfile_storage"
+                                            class="selectpicker show-tick form-control bs-select-hidden"
+                                            data-live-search="true"
+                                            data-none-selected-text="离线导出文件存储服务"
+                                            required>
+                                    </select>
+                                </div>
+                                <button id='check_storage_conn' class='btn-sm btn-info'>测试连接</button>
+                            </div>
+                            <div id="local_storage" style="display: none">
+                                <div class="form-group">
+                                    <label for="local_path"
+                                           class="col-sm-4 control-label">LOCAL_PATH</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control" id="local_path"
+                                               key="local_path"
+                                               value="{{ config.local_path }}"
+                                               placeholder="本地保存路径">
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="sftp_storage" style="display: none">
+                                <div class="form-group">
+                                    <label for="sftp_host"
+                                           class="col-sm-4 control-label">SFTP_HOST</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control" id="sftp_host"
+                                               key="sftp_host"
+                                               value="{{ config.sftp_host }}"
+                                               placeholder="SFTP服务访问IP">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="sftp_port"
+                                           class="col-sm-4 control-label">SFTP_PORT</label>
+                                    <div class="col-sm-5">
+                                        <input type="number" class="form-control" id="sftp_port"
+                                               key="sftp_port"
+                                               value="{{ config.sftp_port }}"
+                                               placeholder="SFTP服务端口，亦为SSH服务端口，默认22">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="sftp_user"
+                                           class="col-sm-4 control-label">SFTP_USER</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control" id="sftp_user"
+                                               key="sftp_user"
+                                               value="{{ config.sftp_user }}"
+                                               placeholder="SFTP服务访问用户">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="sftp_password"
+                                           class="col-sm-4 control-label">SFTP_PASSWORD</label>
+                                    <div class="col-sm-5">
+                                        <input type="password" class="form-control" id="sftp_password"
+                                               key="sftp_password"
+                                               value="{{ config.sftp_password }}"
+                                               placeholder="SFTP服务访问密码">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="sftp_path"
+                                           class="col-sm-4 control-label">SFTP_PATH</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control" id="sftp_path"
+                                               key="sftp_path"
+                                               value="{{ config.sftp_path }}"
+                                               placeholder="SFTP服务存储路径，必须以 / 结尾, 若存储到根下的tmp目录: /tmp/">
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="oss_storage" style="display: none">
+                                <div class="form-group">
+                                    <label for="oss_access_key_id"
+                                           class="col-sm-4 control-label">OSS_ACCESS_KEY_ID</label>
+                                    <div class="col-sm-5">
+                                        <input type="password" class="form-control" id="oss_access_key_id"
+                                               key="oss_access_key_id"
+                                               value="{{ config.oss_access_key_id }}"
+                                               placeholder="OSS AK信息">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="oss_access_key_secret"
+                                           class="col-sm-4 control-label">OSS_ACCESS_KEY_SECRET</label>
+                                    <div class="col-sm-5">
+                                        <input type="password" class="form-control" id="oss_access_key_secret"
+                                               key="oss_access_key_secret"
+                                               value="{{ config.oss_access_key_secret }}"
+                                               placeholder="OSS SK信息">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="oss_endpoint"
+                                           class="col-sm-4 control-label">OSS_ENDPOINT</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control" id="oss_endpoint"
+                                               key="oss_endpoint"
+                                               value="{{ config.oss_endpoint }}"
+                                               placeholder="OSS Endpoint">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="oss_bucket_name"
+                                           class="col-sm-4 control-label">OSS_BUCKET_NAME</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control" id="oss_bucket_name"
+                                               key="oss_bucket_name"
+                                               value="{{ config.oss_bucket_name }}"
+                                               placeholder="OSS Bucket，无 / 斜线">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="oss_path"
+                                           class="col-sm-4 control-label">OSS_PATH</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control" id="oss_path"
+                                               key="oss_path"
+                                               value="{{ config.oss_path }}"
+                                               placeholder="OSS 存储路径，开头没有 / ，若存储到tmp目录: tmp/">
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="offline_download_export_msg" style="display: none">
+                                <div class="form-group">
+                                    <label for="max_export_rows"
+                                           class="col-sm-4 control-label">MAX_EXPORT_ROWS</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control" id="max_export_rows"
+                                               key="max_export_rows"
+                                               value="{{ config.max_export_rows }}"
+                                               placeholder="导出数据量阈值限制，单位: 行，默认值: 10000">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="max_export_exec_time"
+                                           class="col-sm-4 control-label">MAX_EXPORT_EXEC_TIME</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control" id="max_export_exec_time"
+                                               key="max_export_exec_time"
+                                               value="{{ config.max_export_exec_time }}"
+                                               placeholder="导出工单超时时间，单位: 秒，默认值: 60">
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <label for="files_expire_with_days"
+                                           class="col-sm-4 control-label">FILES_EXPIRE_WITH_DAYS</label>
+                                    <div class="col-sm-5">
+                                        <input type="text" class="form-control" id="files_expire_with_days"
+                                               key="files_expire_with_days"
+                                               value="{{ config.files_expire_with_days }}"
+                                               placeholder="文件过期时间，单位: 天，默认值: 0 不过期">
+                                    </div>
+                                </div>
+                            </div>
                             <h5 style="color: darkgrey"><b>SQL优化</b></h5>
                             <hr/>
                             <div class="form-group">
@@ -1213,6 +1376,56 @@
                 }
             });
 
+            // sqlfile_storage参数处理
+            function storage_display(storage) {
+                if (storage === 'disabled') {
+                    return '关闭'
+                } else if (storage === 'sftp') {
+                    return 'SFTP'
+                } else if (storage === 'oss') {
+                    return 'OSS'
+                } else if (storage === 'local') {
+                    return '本地存储'
+                }
+            }
+            let sqlfile_storage = "{{ config.sqlfile_storage }}";
+            if (sqlfile_storage === 'disabled' || sqlfile_storage === '') {
+                $("#local_storage").hide();
+                $("#sftp_storage").hide();
+                $("#oss_storage").hide();
+                $("#offline_download_export_msg").hide();
+                $("#check_storage_conn").hide();
+            } else if (sqlfile_storage === 'sftp') {
+                $("#local_storage").hide();
+                $("#sftp_storage").show();
+                $("#oss_storage").hide();
+                $("#offline_download_export_msg").show();
+                $("#check_storage_conn").show();
+            } else if (sqlfile_storage === 'oss') {
+                $("#local_storage").hide();
+                $("#sftp_storage").hide();
+                $("#oss_storage").show();
+                $("#offline_download_export_msg").show();
+                $("#check_storage_conn").show();
+            } else if (sqlfile_storage === 'local') {
+                $("#local_storage").show();
+                $("#sftp_storage").hide();
+                $("#oss_storage").hide();
+                $("#offline_download_export_msg").show();
+                $("#check_storage_conn").show();
+
+            }
+            let storages = ['disabled', 'sftp', 'oss', 'local'];
+            for (let i=0;i<storages.length;i++) {
+                let storage;
+                if (storages[i] === sqlfile_storage) {
+                    storage = "<option value=\"" + storages[i]+ "\" selected>" + storage_display(storages[i]) + "</option>"
+                } else {
+                    storage = "<option value=\"" + storages[i]+ "\">" + storage_display(storages[i]) + "</option>"
+                }
+                $("#sqlfile_storage").append(storage)
+            }
+            
             // sms_provider参数处理
             function provider_display(provider) {
                 if (provider === 'disabled') {
@@ -1557,6 +1770,66 @@
                 }
             });
         });
+        
+        // 检查sftp或oss的连通性
+        $("#check_storage_conn").click(function () {
+            $(this).addClass('disabled');
+            $(this).prop('disabled', true);
+            var SqlfileStorageType = $("#sqlfile_storage").val();
+            if (SqlfileStorageType === 'sftp') {
+                var formData = {
+                    max_export_rows: $("#max_export_rows").val(),
+                    max_export_exec_time: $("#max_export_exec_time").val(),
+                    files_expire_with_days: $("#files_expire_with_days").val(),
+                    storage_type: $("#sqlfile_storage").val(),
+                    sftp_host: $("#sftp_host").val(),
+                    sftp_user: $("#sftp_user").val(),
+                    sftp_password: $("#sftp_password").val(),
+                    sftp_port: $("#sftp_port").val(),
+                    sftp_path: $("#sftp_path").val(),
+                }
+            } else if (SqlfileStorageType === 'oss') {
+                var formData = {
+                    max_export_rows: $("#max_export_rows").val(),
+                    max_export_exec_time: $("#max_export_exec_time").val(),
+                    files_expire_with_days: $("#files_expire_with_days").val(),
+                    storage_type: $("#sqlfile_storage").val(),
+                    access_key_id: $("#oss_access_key_id").val(),
+                    access_key_secret: $("#oss_access_key_secret").val(),
+                    endpoint: $("#oss_endpoint").val(),
+                    bucket_name: $("#oss_bucket_name").val(),
+                    oss_path: $("#oss_path").val(),
+                }
+            } else if (SqlfileStorageType === 'local') {
+                var formData = {
+                    max_export_rows: $("#max_export_rows").val(),
+                    max_export_exec_time: $("#max_export_exec_time").val(),
+                    files_expire_with_days: $("#files_expire_with_days").val(),
+                    storage_type: $("#sqlfile_storage").val(),
+                    local_path: $("#local_path").val(),
+                }
+            }
+            $.ajax({
+                type: "post",
+                url: "/check/file_storage_connect/",
+                dataType: "json",
+                data: formData,
+                complete: function () {
+                    $("#check_storage_conn").removeClass('disabled');
+                    $("#check_storage_conn").prop('disabled', false);
+                },
+                success: function (data) {
+                    if (data.status === 0) {
+                        alert('连接测试成功，请点击页面下方的保存按钮生效！')
+                    } else {
+                        alert(data.msg);
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            });
+        });
 
         // 同步钉钉用户信息
         $("#sync_ding_user").click(function () {
@@ -1595,6 +1868,36 @@
             });
         });
 
+        // 离线文件存储切换
+        $("#sqlfile_storage").change(function () {
+            let storage = this.value;
+            if (storage === 'disabled') {
+                $("#local_storage").hide();
+                $("#sftp_storage").hide();
+                $("#oss_storage").hide();
+                $("#offline_download_export_msg").hide();
+                $("#check_storage_conn").hide();
+            } else if (storage === 'sftp') {
+                $("#local_storage").hide();
+                $("#sftp_storage").show();
+                $("#oss_storage").hide();
+                $("#offline_download_export_msg").show();
+                $("#check_storage_conn").show();
+            } else if (storage === 'oss') {
+                $("#local_storage").hide();
+                $("#sftp_storage").hide();
+                $("#oss_storage").show();
+                $("#offline_download_export_msg").show();
+                $("#check_storage_conn").show();
+            } else if (storage === 'local') {
+                $("#local_storage").show();
+                $("#sftp_storage").hide();
+                $("#oss_storage").hide();
+                $("#offline_download_export_msg").show();
+                $("#check_storage_conn").show();
+            }
+        })
+        
         // 短信服务商切换
         $("#sms_provider").change(function () {
             let provider = this.value;

--- a/conftest.py
+++ b/conftest.py
@@ -73,6 +73,7 @@ def sql_workflow(db_instance):
         instance=db_instance,
         db_name="some_db",
         syntax_type=1,
+        is_offline_export="no",
     )
     wf_content = SqlWorkflowContent.objects.create(
         workflow=wf, sql_content="some_sql", execute_result=""

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,7 @@ mozilla-django-oidc==3.0.0
 django-auth-dingding==0.0.3
 django-cas-ng==4.3.0
 cassandra-driver
+sqlparse==0.4.4
+paramiko==3.4.0
+oss2==2.18.3
+openpyxl==3.1.2

--- a/sql/engines/goinception.py
+++ b/sql/engines/goinception.py
@@ -68,7 +68,9 @@ class GoInceptionEngine(EngineBase):
         """字符串参数转义"""
         return pymysql.escape_string(value)
 
-    def execute_check(self, instance=None, db_name=None, sql="", is_offline_export=None):
+    def execute_check(
+        self, instance=None, db_name=None, sql="", is_offline_export=None
+    ):
         """inception check"""
         # 判断如果配置了隧道则连接隧道
         host, port, user, password = self.remote_instance_conn(instance)

--- a/sql/engines/goinception.py
+++ b/sql/engines/goinception.py
@@ -68,7 +68,7 @@ class GoInceptionEngine(EngineBase):
         """字符串参数转义"""
         return pymysql.escape_string(value)
 
-    def execute_check(self, instance=None, db_name=None, sql=""):
+    def execute_check(self, instance=None, db_name=None, sql="", is_offline_export=None):
         """inception check"""
         # 判断如果配置了隧道则连接隧道
         host, port, user, password = self.remote_instance_conn(instance)
@@ -99,6 +99,8 @@ class GoInceptionEngine(EngineBase):
             if check_result.syntax_type == 2:
                 if get_syntax_type(r[5], parser=False, db_type="mysql") == "DDL":
                     check_result.syntax_type = 1
+        if is_offline_export == "yes":
+            check_result.syntax_type = 3
         check_result.column_list = inception_result.column_list
         check_result.checked = True
         check_result.error = inception_result.error

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -626,11 +626,16 @@ class MysqlEngine(EngineBase):
     def execute_check(self, db_name=None, sql="", offline_data=None):
         """上线单执行前的检查, 返回Review set"""
         # 获取离线导出工单参数
-        offline_exp = offline_data["is_offline_export"] if offline_data is not None else "0"
+        offline_exp = (
+            offline_data["is_offline_export"] if offline_data is not None else "0"
+        )
         # 进行Inception检查，获取检测结果
         try:
             check_result = self.inc_engine.execute_check(
-                instance=self.instance, db_name=db_name, sql=sql, is_offline_export=offline_exp
+                instance=self.instance,
+                db_name=db_name,
+                sql=sql,
+                is_offline_export=offline_exp,
             )
         except Exception as e:
             logger.debug(

--- a/sql/engines/offlinedownload.py
+++ b/sql/engines/offlinedownload.py
@@ -1,0 +1,542 @@
+# -*- coding: UTF-8 -*-
+import logging
+import re
+import traceback
+import os
+import tempfile
+import csv
+from io import BytesIO
+import hashlib
+import shutil
+import datetime
+import xml.etree.ElementTree as ET
+import zipfile
+import sqlparse
+from threading import Thread
+import queue
+import time
+
+import MySQLdb
+import simplejson as json
+from paramiko import Transport, SFTPClient
+import oss2
+import pandas as pd
+from django.http import HttpResponse
+from urllib.parse import quote
+
+from sql.models import SqlWorkflow, AuditEntry, Config
+from . import EngineBase
+from .models import ResultSet, ReviewSet, ReviewResult
+from common.config import SysConfig
+from sql.utils.sql_utils import get_syntax_type
+
+
+logger = logging.getLogger("default")
+
+
+class TimeoutException(Exception):
+    pass
+
+
+class OffLineDownLoad(EngineBase):
+    def execute_offline_download(self, workflow):
+        if workflow.is_offline_export == "yes":
+            # 创建一个临时目录用于存放文件
+            temp_dir = tempfile.mkdtemp()
+            # 获取系统配置
+            config = get_sys_config()
+            # 先进行 max_export_exec_time 变量的判断是否存在以及是否为空,默认值60
+            timeout_str = config.get('max_export_exec_time', '60')
+            timeout = int(timeout_str) if timeout_str else 60
+            storage_type = config['sqlfile_storage']
+            # 获取前端提交的 SQL 和其他工单信息
+            full_sql = workflow.sqlworkflowcontent.sql_content
+            full_sql = sqlparse.format(full_sql, strip_comments=True)
+            full_sql = sqlparse.split(full_sql)[0]
+            sql = full_sql.strip()
+            instance = workflow.instance
+            host, port, user, password = self.remote_instance_conn(instance)
+            execute_result = ReviewSet(full_sql=sql)
+            # 定义数据库连接
+            conn = MySQLdb.connect(
+                host=host,
+                port=port,
+                user=user,
+                password=password,
+                db=workflow.db_name,
+                charset='utf8mb4'
+            )
+
+            start_time = time.time()
+            try:
+                check_result = execute_check_sql(conn, sql, config)
+                if isinstance(check_result, Exception):
+                    raise check_result
+            except Exception as e:
+                execute_result.rows = [
+                    ReviewResult(
+                        stage="Execute failed",
+                        error=1,
+                        errlevel=2,
+                        stagestatus='异常终止',
+                        errormessage=f"{e}",
+                        sql=full_sql,
+                    )
+                ]
+                execute_result.error = e
+                return execute_result
+
+            try:
+                # 执行 SQL 查询
+                results = self.execute_with_timeout(conn, workflow.sqlworkflowcontent.sql_content, timeout)
+                if results:
+                    columns = results['columns']
+                    result = results['data']
+
+                # 保存查询结果为 CSV or JSON or XML or XLSX or SQL 文件
+                get_format_type = workflow.export_format
+                file_name = save_to_format_file(get_format_type, result, workflow, columns, temp_dir)
+
+                # 将导出的文件上传至 OSS 或 FTP 或 本地保存
+                upload_file_to_storage(file_name, storage_type, temp_dir)
+
+                end_time = time.time()  # 记录结束时间
+                elapsed_time = round(end_time - start_time, 3)
+                execute_result.rows = [
+                    ReviewResult(
+                        stage="Executed",
+                        errlevel=0,
+                        stagestatus='执行正常',
+                        errormessage=f"保存文件: {file_name}",
+                        sql=full_sql,
+                        execute_time=elapsed_time,
+                        affected_rows=check_result
+                    )
+                ]
+
+                change_workflow = SqlWorkflow.objects.get(id=workflow.id)
+                change_workflow.file_name = file_name
+                # change_workflow.syntax_type = '0'
+                change_workflow.save()
+
+                return execute_result
+            except Exception as e:
+                # 返回工单执行失败的状态和错误信息
+                # execute_result.rows['errormessage'] = str(e)
+                execute_result.rows = [
+                    ReviewResult(
+                        stage="Execute failed",
+                        error=1,
+                        errlevel=2,
+                        stagestatus='异常终止',
+                        errormessage=f"{e}",
+                        sql=full_sql,
+                    )
+                ]
+                execute_result.error = e
+                return execute_result
+            finally:
+                # 清理本地文件和临时目录
+                clean_local_files(temp_dir)
+                # 关闭游标和数据库连接
+                # cursor.close()
+                conn.close()
+
+    @staticmethod
+    def execute_query(conn, sql):
+        try:
+            cursor = conn.cursor()
+            cursor.execute(sql)
+            columns = [column[0] for column in cursor.description]
+            result = {
+                'columns': columns,
+                'data': cursor.fetchall()
+            }
+            cursor.close()
+            return result
+        except Exception as e:
+            raise Exception(f"Query execution failed: {e}")
+
+    def worker(self, conn, sql, result_queue):
+        try:
+            result = self.execute_query(conn, sql)
+            result_queue.put(result)
+        except Exception as e:
+            result_queue.put(e)
+
+    def execute_with_timeout(self, conn, sql, timeout):
+        result_queue = queue.Queue()
+        thread = Thread(target=self.worker, args=(conn, sql, result_queue))
+        thread.start()
+        thread.join(timeout)
+
+        if thread.is_alive():
+            thread.join()
+            raise TimeoutException(f"Query execution timed out after {timeout} seconds.")
+        else:
+            result = result_queue.get()
+            if isinstance(result, Exception):
+                raise result
+            else:
+                return result
+
+
+def get_sys_config():
+    all_config = Config.objects.all().values("item", "value")
+    sys_config = {}
+    for items in all_config:
+        sys_config[items["item"]] = items["value"]
+    return sys_config
+
+
+def save_to_format_file(format_type=None, result=None, workflow=None, columns=None, temp_dir=None):
+    # 生成唯一的文件名（包含工单ID、日期和随机哈希值）
+    timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+    hash_value = hashlib.sha256(os.urandom(32)).hexdigest()[:8]  # 使用前8位作为哈希值
+    base_name = f'{workflow.db_name}_{timestamp}_{hash_value}'
+    file_name = f'{base_name}.{format_type}'
+    file_path = os.path.join(temp_dir, file_name)
+    # 将查询结果写入 CSV 文件
+    if format_type == 'csv':
+        save_csv(file_path, result, columns)
+    elif format_type == 'json':
+        save_json(file_path, result, columns)
+    elif format_type == 'xml':
+        save_xml(file_path, result, columns)
+    elif format_type == 'xlsx':
+        save_xlsx(file_path, result, columns)
+    elif format_type == 'sql':
+        save_sql(file_path, result, columns)
+    else:
+        raise ValueError(f"Unsupported format type: {format_type}")
+
+    zip_file_name = f'{base_name}.zip'
+    zip_file_path = os.path.join(temp_dir, zip_file_name)
+    with zipfile.ZipFile(zip_file_path, 'w', zipfile.ZIP_DEFLATED) as zipf:
+        zipf.write(file_path, os.path.basename(file_path))
+    # return temp_dir, file_name
+    return zip_file_name
+
+
+def upload_file_to_storage(file_name=None, storage_type=None, temp_dir=None):
+    action_exec = StorageControl(file_name=file_name,
+                                 storage_type=storage_type,
+                                 temp_dir=temp_dir)
+    try:
+        if storage_type == 'oss':
+            # 使用阿里云 OSS 进行上传
+            action_exec.upload_to_oss()
+        elif storage_type == 'sftp':
+            # 使用 SFTP 进行上传
+            action_exec.upload_to_sftp()
+        elif storage_type == 'local':
+            # 本地存储
+            action_exec.upload_to_local()
+        else:
+            # 未知存储类型，可以抛出异常或处理其他逻辑
+            raise ValueError(f"Unknown storage type: {storage_type}")
+    except Exception as e:
+        raise e
+
+
+def clean_local_files(temp_dir):
+    # 删除临时目录及其内容
+    shutil.rmtree(temp_dir)
+
+
+def datetime_serializer(obj):
+    """JSON serializer for objects not serializable by default json code"""
+    if isinstance(obj, (datetime.date, datetime.datetime)):
+        return obj.isoformat()
+    raise TypeError("Type %s not serializable" % type(obj))
+
+
+def save_csv(file_path, result, columns):
+    with open(file_path, 'w', newline='', encoding='utf-8') as csv_file:
+        csv_writer = csv.writer(csv_file, quoting=csv.QUOTE_ALL)
+
+        if columns:
+            csv_writer.writerow(columns)
+
+        for row in result:
+            csv_row = ['null' if value is None else value for value in row]
+            csv_writer.writerow(csv_row)
+
+
+def save_json(file_path, result, columns):
+    with open(file_path, 'w', encoding='utf-8') as json_file:
+        # json.dump(result, json_file, indent=2)
+        json.dump(
+            [
+                dict(zip(columns, row))
+                for row in result
+            ],
+            json_file,
+            indent=2,
+            default=datetime_serializer,
+            ensure_ascii=False
+        )
+
+
+def save_xml(file_path, result, columns):
+    root = ET.Element("tabledata")
+
+    # Create fields element
+    fields_elem = ET.SubElement(root, "fields")
+    for column in columns:
+        field_elem = ET.SubElement(fields_elem, "field")
+        field_elem.text = column
+
+    # Create data element
+    data_elem = ET.SubElement(root, "data")
+    for row_id, row in enumerate(result, start=1):
+        row_elem = ET.SubElement(data_elem, "row", id=str(row_id))
+        for col_idx, value in enumerate(row, start=1):
+            col_elem = ET.SubElement(row_elem, f"column-{col_idx}")
+            if value is None:
+                col_elem.text = "(null)"
+            elif isinstance(value, (datetime.date, datetime.datetime)):
+                col_elem.text = value.isoformat()
+            else:
+                col_elem.text = str(value)
+
+    tree = ET.ElementTree(root)
+    tree.write(file_path, encoding='utf-8', xml_declaration=True)
+
+
+def save_xlsx(file_path, result, columns):
+    try:
+        df = pd.DataFrame([[str(value) if value is not None and value != 'NULL' else ''
+                            for value in row] for row in result], columns=columns)
+        df.to_excel(file_path, index=False, header=True)
+    except ValueError as e:
+        raise ValueError(f"Excel最大支持行数为1048576,已超出!")
+
+
+def save_sql(file_path, result, columns):
+    with open(file_path, 'w') as sql_file:
+        for row in result:
+            table_name = "your_table_name"
+            if columns:
+                sql_file.write(f"INSERT INTO {table_name} ({', '.join(columns)}) VALUES ")
+
+            values = ', '.join(["'{}'".format(str(value).replace('\'', '\'\''))
+                                if isinstance(value, str) or isinstance(value, datetime.date) or isinstance(value,
+                                    datetime.datetime) else 'NULL'
+                                if value is None or value == '' else str(value) for value in row])
+            sql_file.write(f"({values});\n")
+
+
+def offline_file_download(request):
+    file_name = request.GET.get('file_name', ' ')
+    workflow_id = request.GET.get('workflow_id', ' ')
+    action = '离线下载'
+    extra_info = f"工单id：{workflow_id},文件：{file_name}"
+    config = get_sys_config()
+    storage_type = config['sqlfile_storage']
+
+    try:
+        action_exec = StorageControl(storage_type=storage_type,
+                                     file_name=file_name)
+        if storage_type == 'sftp':
+            response = action_exec.download_from_sftp()
+            return response
+        elif storage_type == 'oss':
+            response = action_exec.download_from_oss()
+            return response
+        elif storage_type == 'local':
+            response = action_exec.download_from_local()
+            return response
+
+    except Exception as e:
+        action = '离线下载失败'
+        return HttpResponse(f'下载失败：{e}', status=500)
+    finally:
+        AuditEntry.objects.create(
+            user_id=request.user.id,
+            user_name=request.user.username,
+            user_display=request.user.display,
+            action=action,
+            extra_info=extra_info,
+        )
+
+
+class StorageControl:
+    def __init__(self, storage_type=None, do_action=None, file_name=None, temp_dir=None):
+        """根据存储服务进行文件的上传下载"""
+        # 存储类型
+        self.storage_type = storage_type
+        # 暂时无用，可考虑删除
+        self.do_action = do_action
+        # 导出文件的压缩包名称
+        self.file_name = file_name
+        # 导出文件的本地临时目录，上传完成后会自动清理
+        self.temp_dir = temp_dir
+
+        # 获取系统配置
+        self.config = get_sys_config()
+        # 先进行系统管理内配置的 files_expire_with_days 参数的判断是否存在以及是否为空,默认值 0-不过期
+        self.expire_time_str = self.config.get('files_expire_with_days', '0')
+        self.expire_time_with_days = int(self.expire_time_str) if self.expire_time_str else 0
+        # 获取当前时间
+        self.current_time = datetime.datetime.now()
+        # 获取过期的时间
+        self.expire_time = self.current_time - datetime.timedelta(days=self.expire_time_with_days)
+
+        # SFTP 存储相关配置信息
+        self.sftp_host = self.config['sftp_host']
+        self.sftp_user = self.config['sftp_user']
+        self.sftp_password = self.config['sftp_password']
+        self.sftp_port_str = self.config.get('sftp_port', '22')
+        self.sftp_port = int(self.sftp_port_str) if self.sftp_port_str else 22
+        self.sftp_path = self.config['sftp_path']
+
+        # OSS 存储相关配置信息
+        self.access_key_id = self.config['oss_access_key_id']
+        self.access_key_secret = self.config['oss_access_key_secret']
+        self.endpoint = self.config['oss_endpoint']
+        self.bucket_name = self.config['oss_bucket_name']
+        self.oss_path = self.config['oss_path']
+
+        # 本地存储相关配置信息
+        # self.local_path = r'{}'.format(self.config['local_path'])
+        self.local_path = r'{}'.format(self.config.get('local_path', '/tmp'))
+
+    def upload_to_sftp(self):
+        # SFTP 配置
+        try:
+            with Transport((self.sftp_host, self.sftp_port)) as transport:
+                transport.connect(username=self.sftp_user, password=self.sftp_password)
+                with SFTPClient.from_transport(transport) as sftp:
+                    remote_file = os.path.join(self.sftp_path, os.path.basename(self.file_name))
+                    # 判断时间是否配置，为 0 则默认不删除，大于 0 则调用删除方法进行删除过期文件
+                    if self.expire_time_with_days > 0:
+                        self.del_file_before_upload_to_sftp(sftp)
+                    # 上传离线导出的文件压缩包到SFTP
+                    sftp.put(os.path.join(self.temp_dir, self.file_name), remote_file)
+
+        except Exception as e:
+            upload_to_sftp_exception = Exception(f"上传失败: {e}")
+            raise upload_to_sftp_exception
+
+    def download_from_sftp(self):
+        file_path = os.path.join(self.sftp_path, self.file_name)
+
+        with Transport((self.sftp_host, self.sftp_port)) as transport:
+            transport.connect(username=self.sftp_user, password=self.sftp_password)
+            with SFTPClient.from_transport(transport) as sftp:
+                # 获取压缩包内容
+                file_content = BytesIO()
+                sftp.getfo(file_path, file_content)
+
+        # 构造 HttpResponse 返回 ZIP 文件内容
+        response = HttpResponse(file_content.getvalue(), content_type='application/zip')
+        response['Content-Disposition'] = f'attachment; filename={quote(self.file_name)}'
+        return response
+
+    def del_file_before_upload_to_sftp(self, sftp):
+        for file_info in sftp.listdir_attr(self.sftp_path):
+            file_path = os.path.join(self.sftp_path, file_info.filename)
+
+            # 获取文件的修改时间
+            modified_time = datetime.datetime.fromtimestamp(file_info.st_mtime)
+
+            # 如果文件过期，则删除
+            if modified_time < self.expire_time:
+                sftp.remove(file_path)
+
+    def upload_to_oss(self):
+        # 创建 OSS 认证
+        auth = oss2.Auth(self.access_key_id, self.access_key_secret)
+
+        # 创建 OSS Bucket 对象
+        bucket = oss2.Bucket(auth, self.endpoint, self.bucket_name)
+
+        # 上传文件到 OSS
+        remote_key = os.path.join(self.oss_path, os.path.basename(self.file_name))
+        # 判断时间是否配置，为 0 则默认不删除，大于 0 则调用删除方法进行删除过期文件
+        if self.expire_time_with_days > 0:
+            self.del_file_before_upload_to_oss(bucket)
+        # 读取并上传离线导出的文件压缩包到OSS
+        with open(os.path.join(self.temp_dir, self.file_name), 'rb') as file:
+            bucket.put_object(remote_key, file)
+
+    def download_from_oss(self):
+        # 创建 OSS 认证
+        auth = oss2.Auth(self.access_key_id, self.access_key_secret)
+
+        # 创建 OSS Bucket 对象
+        bucket = oss2.Bucket(auth, self.endpoint, self.bucket_name)
+
+        # 从OSS下载文件
+        remote_path = self.oss_path
+        remote_key = os.path.join(remote_path, self.file_name)
+        object_stream = bucket.get_object(remote_key)
+        response = HttpResponse(object_stream.read(), content_type='application/zip')
+        response['Content-Disposition'] = f'attachment; filename={quote(self.file_name)}'
+        return response
+
+    def del_file_before_upload_to_oss(self, bucket):
+        for object_info in oss2.ObjectIterator(bucket, prefix=self.oss_path):
+            # 获取 bucket 存储路径下的文件名
+            file_path = object_info.key
+
+            # 获取文件的修改时间
+            modified_time = datetime.datetime.fromtimestamp(object_info.last_modified)
+
+            # 如果文件过期，则删除
+            if modified_time < self.expire_time:
+                bucket.delete_object(file_path)
+
+    def upload_to_local(self):
+        try:
+            source_path = os.path.join(self.temp_dir, self.file_name)
+            # 判断配置内的本地存储路径是否存在，若不存在则抛出报错
+            if not os.path.exists(self.local_path):
+                raise FileNotFoundError(f"Destination directory '{self.local_path}' not found.")
+            # 判断时间是否配置，为 0 则默认不删除，大于 0 则调用删除方法进行删除过期文件
+            if self.expire_time_with_days > 0:
+                self.del_file_before_upload_to_local()
+            # 拷贝离线导出的文件压缩包到指定路径
+            shutil.copy(source_path, self.local_path)
+        except Exception as e:
+            raise e
+
+    def download_from_local(self):
+        file_path = os.path.join(self.local_path, self.file_name)
+
+        with open(file_path, 'rb') as file:
+            response = HttpResponse(file.read(), content_type='application/zip')
+            response['Content-Disposition'] = f'attachment; filename={quote(self.file_name)}'
+            return response
+
+    def del_file_before_upload_to_local(self):
+        for local_file_info in os.listdir(self.local_path):
+            file_path = os.path.join(self.local_path, local_file_info)
+            if os.path.isfile(file_path) and os.path.getmtime(file_path) < self.expire_time.timestamp():
+                os.remove(file_path)
+
+
+def execute_check_sql(conn, sql, config):
+    # 先进行 max_export_rows 变量的判断是否存在以及是否为空,默认值10000
+    max_export_rows_str = config.get('max_export_rows', '10000')
+    max_export_rows = int(max_export_rows_str) if max_export_rows_str else 10000
+
+    # 判断sql是否以 select 开头
+    if not sql.strip().lower().startswith('select'):
+        return Exception(f"违规语句：{sql}")
+    sql = 'explain ' + sql
+    cursor = conn.cursor()
+    try:
+        cursor.execute(sql)
+        check_result = cursor.fetchall()
+        total_explain_scan_rows = sum(row[9] if row[9] is not None else 0 for row in check_result)
+        if int(total_explain_scan_rows) > max_export_rows:
+            return Exception(f"扫描行数超出阈值: {max_export_rows}")
+        else:
+            return total_explain_scan_rows
+    except Exception as e:
+        return e
+    finally:
+        # 关闭游标和数据库连接
+        cursor.close()

--- a/sql/models.py
+++ b/sql/models.py
@@ -290,8 +290,8 @@ class SqlWorkflow(models.Model, WorkflowAuditMixin):
     instance = models.ForeignKey(Instance, on_delete=models.CASCADE)
     db_name = models.CharField("数据库", max_length=64)
     syntax_type = models.IntegerField(
-        "工单类型 0、未知，1、DDL，2、DML",
-        choices=((0, "其他"), (1, "DDL"), (2, "DML")),
+        "工单类型 0、未知，1、DDL，2、DML，3、离线导出工单",
+        choices=((0, "其他"), (1, "DDL"), (2, "DML"), (3, "离线导出工单")),
         default=0,
     )
     is_backup = models.BooleanField(
@@ -312,6 +312,38 @@ class SqlWorkflow(models.Model, WorkflowAuditMixin):
     finish_time = models.DateTimeField("结束时间", null=True, blank=True)
     is_manual = models.IntegerField(
         "是否原生执行", choices=((0, "否"), (1, "是")), default=0
+    )
+    is_offline_export = models.CharField(
+        "是否为离线导出工单",
+        max_length=3,
+        choices=(
+            ("no", "否"),
+            ("yes", "是"),
+        ),
+        default="no",
+    )
+
+    # 导出格式
+    export_format = models.CharField(
+        "导出格式",
+        max_length=10,
+        choices=(
+            ("csv", "CSV"),
+            ("xlsx", "Excel"),
+            ("sql", "SQL"),
+            ("json", "JSON"),
+            ("xml", "XML"),
+        ),
+        # default="csv",
+        null=True,
+        blank=True,
+    )
+
+    file_name = models.CharField(
+        "文件名",
+        max_length=255,  # 适当调整最大长度
+        null=True,  # 允许为空
+        blank=True,  # 允许为空字符串
     )
 
     def __str__(self):
@@ -965,6 +997,7 @@ class Permission(models.Model):
             ("archive_mgt", "管理归档申请"),
             ("audit_user", "审计权限"),
             ("query_download", "在线查询下载权限"),
+            ("offline_download", "离线下载权限"),
         )
 
 

--- a/sql/sql_workflow.py
+++ b/sql/sql_workflow.py
@@ -116,6 +116,7 @@ def _sql_workflow_list(request):
         "db_name",
         "group_name",
         "syntax_type",
+        "export_format",
     )
 
     # QuerySet 序列化

--- a/sql/templates/detail.html
+++ b/sql/templates/detail.html
@@ -9,11 +9,13 @@
                href="{{ workflow_detail.demand_url }}">{{ workflow_detail.workflow_name }}</a>
         </h4>
         <!--只允许发起人提交其他实例-->
-        {% if user.username == workflow_detail.engineer %}
+        {% if user.username == workflow_detail.engineer and workflow_detail.is_offline_export != "yes" %}
             <a type='button' id="btnSubmitOtherCluster" class='btn btn-warning' href="/submitotherinstance/">上线其他实例</a>
         {% endif %}
         {% if is_can_review or is_can_execute or is_can_rollback or user.is_superuser %}
-            <a type='button' id="btnViewSql" class='btn btn-default' onclick="loading(this)" href="/editsql/">查看提交信息</a>
+            {% if workflow_detail.is_offline_export != "yes" %}
+                <a type='button' id="btnViewSql" class='btn btn-default' onclick="loading(this)" href="/editsql/">查看提交信息</a>
+            {% endif %}
         {% endif %}
     </div>
     <input type="hidden" id="sqlMaxRowNumber" value="{{ rows|length }}">
@@ -223,6 +225,14 @@
             <input type="hidden" name="workflow_id" value="{{ workflow_detail.id }}">
             <input type="hidden" id="cancel_remark" name="cancel_remark" value="">
             <input type="button" id="btnCancel" class="btn btn-default" value="终止流程"/>
+        </form>
+    {% endif %}
+    {% if workflow_detail.status == 'workflow_finish' and workflow_detail.is_offline_export == 'yes' %}
+        <form id="form-download" class="form-horizontal">
+            <button type="button" id="btnDownload" data-loading-text="下载中..."
+                     class="btn btn-info">
+                下载文件
+            </button>
         </form>
     {% endif %}
     <!--查看回滚按钮-->
@@ -458,7 +468,8 @@
 
         // 执行确认
         $("#btnExecuteOnly").click(function () {
-            if ("{{ workflow_detail.is_backup }}" === 'False') {
+            if ("{{ workflow_detail.is_backup }}" === 'False' &&
+            "{{workflow_detail.is_offline_export}}" !== "yes") {
                 var isContinue = confirm("该工单未选择备份，将不会自动备份数据，请确认是否立即执行？");
             } else {
                 var isContinue = confirm("请确认是否立即执行？");
@@ -961,6 +972,47 @@
                 } else if (active_li_id === 'logs_tab') {
                     get_logs();
                 }
+            });
+        });
+    </script>
+    <!--下载导出文件-->
+    <script>
+        $(document).ready(function () {
+            // $('#btnDownload').prop('disabled', false);
+            $('#btnDownload').click(function () {
+                // 禁用按钮
+                $('#btnDownload').prop('disabled', true);
+                let workflow_id = "{{ workflow_detail.id }}"
+                let file_name = "{{ workflow_detail.file_name }}";
+                let filePath = `/downloadfile/?file_name=${file_name}&workflow_id=${workflow_id}`;
+
+                var xhr = new XMLHttpRequest();
+                xhr.open('GET', filePath, true);
+                xhr.responseType = 'arraybuffer';
+
+                xhr.onload = function () {
+                    if (xhr.status === 200) {
+                        var blob = new Blob([xhr.response], { type: 'application/zip' });
+                        // 创建下载链接
+                        var downloadLink = document.createElement('a');
+                        downloadLink.href = window.URL.createObjectURL(blob);
+                        downloadLink.download = file_name;  // 替换为实际下载文件的名称
+                        // 触发点击下载链接
+                        downloadLink.click();
+                    } else {
+                        alert('下载失败，文件可能已过期失效')
+                        console.error('下载失败', xhr.statusText);
+                    }
+                    // 重新启用按钮
+                    $('#btnDownload').prop('disabled', false);
+                };
+
+                xhr.onerror = function () {
+                    console.error('网络错误');
+                    // 重新启用按钮
+                    $('#btnDownload').prop('disabled', false);
+                };
+                xhr.send();
             });
         });
     </script>

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -65,6 +65,38 @@
                             <pre id="sql_content_editor" class="ace_editor " style="min-height:350px"></pre>
                         </div>
                         <div class="col-md-3 column">
+                            <div class="form-group toggleable">
+                                <input id="workflow_name" type="text" autocomplete="off" name="workflow_name"
+                                       class="form-control"
+                                       data-name="导出单名称" data-placeholder="请输入导出单名称！"
+                                       placeholder="请输入导出单名称，如:XX项目数据分析需求"
+                                       required>
+                            </div>
+                            <div class="form-group toggleable">
+                                <select id="export_format" name="export_format"
+                                        class="selectpicker show-tick form-control bs-select-hidden"
+                                        data-name="离线导出数据格式" data-placeholder="请选择导出数据格式！"
+                                        title="请选择导出数据格式"
+                                        data-live-search="true" data-live-search-placeholder="搜索您所在的组" required>
+                                    <option value="csv">CSV</option>
+                                    <option value="xlsx">Excel</option>
+                                    <option value="sql">SQL</option>
+                                    <option value="json">JSON</option>
+                                    <option value="xml">XML</option>
+                                </select>
+                            </div>
+                            <div class="form-group toggleable">
+                                <select id="group_name" name="group_name"
+                                        class="selectpicker show-tick form-control bs-select-hidden"
+                                        data-name="组" data-placeholder="请选择组！"
+                                        title="请选择组"
+                                        data-live-search="true" data-live-search-placeholder="搜索您所在的组" required>
+                                    {% for group in group_list %}
+                                        <option value="{{ group.group_name }}"
+                                                group-id="{{ group.group_id }}">{{ group.group_name }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
                             <div class="form-group">
                                 <select id="instance_name" name="instance_name"
                                         class="selectpicker show-tick form-control bs-select-hidden"
@@ -92,7 +124,7 @@
                                         data-placeholder="请选择模式:" required>
                                 </select>
                             </div>
-                            <div id="div-table_name" class="form-group">
+                            <div id="div-table_name" class="form-group toggleableother">
                                 <select id="table_name" name="table_name"
                                         class="form-control selectpicker show-tick bs-select-hidden"
                                         data-live-search="true" data-live-search-placeholder="搜索您要查询的表"
@@ -101,7 +133,7 @@
                                         data-placeholder="查看表结构:" required>
                                 </select>
                             </div>
-                            <div class="form-group">
+                            <div class="form-group toggleableother">
                                 <select id="limit_num" name="limit_num"
                                         class="form-control selectpicker show-tick bs-select-hidden"
                                         data-placeholder="返回行数:" required>
@@ -112,16 +144,46 @@
                                     <option value=0>max(最大限制行数)</option>
                                 </select>
                             </div>
+                            <!--审批流程-->
+                            <input type="hidden" id="workflow_auditors" name="workflow_auditors" data-name="审批流程"
+                                   data-placeholder="请配置审批流程！" required>
+                            <div id="div-workflow_auditors" class="form-group toggleable" style="display: none">
+                                <p class="bg-primary">&nbsp&nbsp&nbsp审批流程：<b id="workflow_auditors_display"></b></p>
+                            </div>
                             <div class="form-group">
                                 <input id="btn-format" type="button" class="btn btn-info" value="美化"/>
                                 <input id="btn-explain" type="button" class="btn btn-warning" value="执行计划"/>
-                                <input id="btn-sqlquery" type="button" class="btn btn-success" value="SQL查询"/>
+                                <input id="btn-sqlquery" type="button" class="btn btn-success toggleableother" value="SQL查询"/>
+                                <button type="button" id="btn-submitdownload" data-loading-text="提交中..."
+                                        class="btn btn-danger toggleable" disabled>
+                                    提交导出
+                                </button>
+                                {% if config.sqlfile_storage == "sftp" or config.sqlfile_storage == "oss" or config.sqlfile_storage == "local"%}
+                                    {% if can_offline_download == 1 %}
+                                        <input id="btn-offlinedownload" type="button" class="btn btn-primary" value="切换至导出"/>
+                                    {% endif %}
+                                {% endif %}
                             </div>
                         </div>
-                        <div class="text-info">
+                        <div class="text-info toggleableother">
                             <li>支持注释行，可选择指定语句执行，默认执行第一条;</li>
                             <li>查询结果行数限制见权限管理，会选择查询涉及表的最小limit值</li>
                         </div>
+                        <div class="text-info toggleable">
+                            <li>导出工单仅支持导出一条查询语句</li>
+                            <li>导出请先看执行计划，若扫描行数过多将禁止执行，阈值: {{ config.max_export_rows }}</li>
+                        </div>
+                        <style>
+                            .toggleable {
+                                display: none;
+                            }
+                            .toggleableother {
+
+                            }
+                            .hidden {
+                                display: none;
+                            }
+                        </style>
                     </form>
                 </div>
             </div>
@@ -255,6 +317,190 @@
     <script src="{% static 'bootstrap-table/export-libs/js-xlsx/xlsx.core.min.js' %}"></script>
     <script src="{% static 'bootstrap-table/js/bootstrap-table-export.min.js' %}"></script>
     <script src="{% static 'bootstrap-table/js/tableExport.min.js' %}"></script>
+
+    <!-- 导出表单展示切换  -->
+    <script>
+        (function() {
+            // 初始状态为隐藏
+            let isHidden = true;
+            var toggleableElement = $(".toggleableother");
+
+            // 在按钮点击事件中处理显示/隐藏逻辑
+            $("#btn-offlinedownload").click(function () {
+                // 进行二次确认
+                if (confirm("是否确定要进行查询/导出功能切换？")) {
+                    // 切换状态
+                    isHidden = !isHidden;
+
+                    // 根据状态执行显示或隐藏
+                    if (isHidden) {
+                        $(".toggleable").hide();
+                        // $(".toggleableother").css("display", "");
+                        toggleableElement.removeClass("hidden");
+                        $("#btn-offlinedownload").val("切换至导出")
+                    } else {
+                        $(".toggleable").show();
+                        // $(".toggleableother").css("display", "none");
+                        toggleableElement.addClass("hidden");
+                        $("#btn-offlinedownload").val("切换至查询")
+                    }
+                }
+            });
+
+            $("#instance_name").change(function () {
+                var optgroup = $('#instance_name :selected').parent().attr('label');
+                if (optgroup != 'MySQL') {
+                   isHidden = true;
+                }
+            });
+
+        })();
+
+        // 监听sql文本，若sql发生变化则禁用
+        editor.getSession().on('change', function(e) {
+            $("#btn-submitdownload").prop("disabled", true);
+        });
+
+        // 提交导出工单
+        function submitofflinedownload() {
+            let formData = $('#form-sqlquery').serializeArray().reduce(function (obj, item) {
+                obj[item.name] = item.value;
+                return obj;
+            }, {})
+            var sqlContent = editor.getValue();
+            $.ajax({
+                type: "post",
+                url: "/api/v1/workflow/",
+                dataType: "json",
+                contentType: 'application/json;',
+                data: JSON.stringify({
+                        workflow: {
+                            workflow_name: formData.workflow_name,
+                            // demand_url: formData.demand_url,
+                            export_format: formData.export_format,
+                            is_offline_export: 'yes',
+                            group_id: $("#group_name option:selected").attr("group-id"),
+                            instance: $("#instance_name option:selected").attr("instance-id"),
+                            db_name: formData.db_name,
+                            is_backup: 'False',
+                            // run_date_start: formData.run_date_start,
+                            // run_date_end: formData.run_date_end,
+                            run_date_start: '',
+                            run_date_end: '',
+                        },
+                        sql_content: sqlContent
+                    }
+                ),
+                beforeSend: function (xhr) {
+                    $('#btn-submitdownload').button('loading')
+                },
+                complete: function () {
+                    $('#btn-submitdownload').button('reset')
+                },
+                success: function (data) {
+                    window.location.href = "/detail/"+ data.workflow_id
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    if (XMLHttpRequest.responseJSON) {
+                        alert(XMLHttpRequest.responseText)
+                    } else {
+                        alert(errorThrown);
+                    }
+                }
+            });
+
+        }
+
+        // 获取审批流程
+        $("#group_name").change(function () {
+            $.ajax({
+                type: "post",
+                url: "/group/auditors/",
+                dataType: "json",
+                data: {
+                    group_name: $("#group_name").val(),
+                    workflow_type: 2
+                },
+                complete: function () {
+                },
+                success: function (data) {
+                    if (data.status === 0) {
+                        var result = data.data;
+                        $("#workflow_auditors").val(result['auditors']);
+                        $("#workflow_auditors_display").text(result['auditors_display']);
+                        // $("#div-workflow_auditors").show();
+                    } else {
+                        alert(data.msg);
+                    }
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    alert(errorThrown);
+                }
+            });
+        });
+        //离线导出表单验证
+        function sqlofflinedownload_validate() {
+            var result = true;
+            var workflow_name = $("#workflow_name").val();
+            var export_format = $("#export_format").val();
+            var group_name = $("#group_name").val();
+            var workflow_auditors = $("#workflow_auditors").val();
+            var instance_name = $("#instance_name").val();
+            var db_name = $("#db_name").val();
+            var sqlContent = editor.getValue();
+            // 假设 sqlContent 包含多条 SQL 语句，使用分号分隔
+            var sqlStatements = sqlContent.split(';');
+            // 用于存储筛选后的语句
+            var errorStatements = [];
+            // 遍历每一条语句
+            for (var i = 0; i < sqlStatements.length; i++) {
+                // 去除首尾空白字符
+                var trimmedStatement = sqlStatements[i].trim();
+
+                // 只保留以 "SELECT" 开头的语句
+                if (trimmedStatement.toUpperCase().startsWith('SELECT') && trimmedStatement.length > 0) {
+                } else {
+                    // 如果不以 SELECT 开头，输出报错提示
+                    errorStatements.push(trimmedStatement.replace(/\s+/g, ' '));
+                }
+            }
+            // 将筛选后的语句重新组合成一个字符串，使用分号分隔
+            var filteredErrorSql = errorStatements.join(';\n');
+            // 输出非select的SQL语句，并禁用按钮
+            if (filteredErrorSql) {
+                $("#btn-submitdownload").prop("disabled", true);
+                alert("非法SQL\n" + filteredErrorSql)
+                return result = false;
+            } else if (!instance_name) {
+                alert("请选择实例！");
+                return result = false;
+            } else if (!db_name) {
+                alert("请选择数据库！");
+                return result = false;
+            } else if (!sqlContent) {
+                alert("SQL内容不能为空！");
+                return result = false;
+            } else if (!workflow_name) {
+                alert("请输入离线数据导出单名称！");
+                return result = false;
+            } else if (!export_format) {
+                alert("请选择导出格式！");
+                return result = false;
+            } else if (!group_name) {
+                alert("请选择组！");
+                return result = false;
+            } else if (!workflow_auditors) {
+                alert("请配置审批流程！");
+                return result = false;
+            }
+            return result;
+        }
+        $("#btn-submitdownload").click(function () {
+            if (sqlofflinedownload_validate()) {
+                submitofflinedownload();
+            }
+        });
+    </script>
 
     <!-- 查询历史  -->
     <script>
@@ -489,6 +735,7 @@
             if (instance_name && db_name && sql) {
                 $('input[type=button]').addClass('disabled');
                 $('input[type=button]').prop('disabled', true);
+                $("#btn-submitdownload").prop("disabled", true);
                 sqlquery()
             } else {
                 alert("信息不完整，无法一键查询！")
@@ -636,6 +883,7 @@
                     const inputButton = $('input[type=button]')
                     inputButton.addClass('disabled');
                     inputButton.prop("disabled", true)
+                    $("#btn-submitdownload").prop("disabled", true);
                     sqlquery('explain')
                 }
             }
@@ -808,6 +1056,29 @@
                         }
                         var showExport = {{can_download}}===1
                         var query_result_id=(`query_result${n}`);
+                        if ($("#btn-submitdownload").is(':hidden')) {
+                            var isOfflineExport = "no"
+                        } else {
+                            var isOfflineExport = "yes"
+                        }
+                        if (result['full_sql'].trim().toLowerCase().startsWith('explain')) {
+                            if (optgroup === "MySQL" && isOfflineExport === "yes") {
+                                var totalExplainScanRows = 0;
+                                var maxExportRows = "{{ config.max_export_rows }}";
+                                for (var i = 0; i < result['rows'].length; i++) {
+                                    var explainScanRows = parseFloat(result['rows'][i][9]);
+                                    totalExplainScanRows += explainScanRows;
+                                }
+                                if (totalExplainScanRows > maxExportRows) {
+                                    alert('警告信息:\n总扫描行数：' + totalExplainScanRows
+                                        + '\n阈值：' + maxExportRows
+                                        + '\n禁止提交导出!');
+                                    $("#btn-submitdownload").prop("disabled", true);
+                                } else {
+                                    $("#btn-submitdownload").prop("disabled", false);
+                                }
+                            }
+                        }
                         $(`#${query_result_id}`).bootstrapTable('destroy').bootstrapTable({
                             escape: true,
                             data: result['rows'],
@@ -1027,6 +1298,7 @@
             if (sqlquery_validate()) {
                 $('input[type=button]').addClass('disabled');
                 $('input[type=button]').prop('disabled', true);
+                $("#btn-submitdownload").prop("disabled", true);
                 sqlquery();
             }
         }
@@ -1040,6 +1312,7 @@
             showFormat: true,
             showExplain: true,
             showRedisHelp: false,
+            showOfflineDownload: false,
         }
         const createDisplayConfig = function(extraArgs = null) {
             if (extraArgs === null) {
@@ -1048,6 +1321,7 @@
             return Object.assign({}, defaultDisplayConfig, extraArgs)
         }
         const engineDisplayConfig = {
+            "MySQL": createDisplayConfig({showOfflineDownload: true}),
             "MsSQL": createDisplayConfig({showExplain: false}),
             "Redis": createDisplayConfig({showTableName: false, showSchemaName: false,
                 showRedisHelp: true,
@@ -1063,6 +1337,14 @@
         function optgroup_control(change) {
             let optgroup = $('#instance_name :selected').parent().attr('label');
             let displayConfig = engineDisplayConfig[optgroup] || defaultDisplayConfig
+            if (displayConfig.showOfflineDownload) {
+                $("#btn-offlinedownload").show();
+            } else {
+                $(".toggleable").hide();
+                $(".toggleableother").removeClass("hidden");
+                $("#btn-offlinedownload").val("切换至导出")
+                $("#btn-offlinedownload").hide();
+            }
             if (displayConfig.showExplain) {
                 $("#btn-explain").attr('disabled', false);
             } else {

--- a/sql/templates/sqlsubmit.html
+++ b/sql/templates/sqlsubmit.html
@@ -585,6 +585,7 @@
                             is_backup: formData.is_backup === 'True',
                             run_date_start: formData.run_date_start,
                             run_date_end: formData.run_date_end,
+                            is_offline_export: 'no',
                         },
                         sql_content: formData.sql_content
                     }

--- a/sql/templates/sqlworkflow.html
+++ b/sql/templates/sqlworkflow.html
@@ -212,6 +212,19 @@
                             return 'DDL'
                         } else if (String(value) === '2') {
                             return 'DML'
+                        } else if (String(value) === '3') {
+                            if (String(row.export_format) === 'csv') {
+                                row.export_format = 'CSV'
+                            } else if (String(row.export_format) === 'xlsx') {
+                                row.export_format = 'Excel'
+                            } else if (String(row.export_format) === 'sql') {
+                                row.export_format = 'SQL'
+                            } else if (String(row.export_format) === 'json') {
+                                row.export_format = 'JSON'
+                            } else if (String(row.export_format) === 'xml') {
+                                row.export_format = 'XML'
+                            }
+                            return '数据导出: ' + row.export_format
                         }
                     }
                 }, {

--- a/sql/test_notify.py
+++ b/sql/test_notify.py
@@ -84,6 +84,7 @@ class TestNotify(TestCase):
             instance=self.ins,
             db_name="some_db",
             syntax_type=1,
+            is_offline_export="no",
         )
         SqlWorkflowContent.objects.create(
             workflow=self.wf, sql_content="some_sql", execute_result=""

--- a/sql/urls.py
+++ b/sql/urls.py
@@ -26,6 +26,7 @@ from sql import (
 )
 from sql.utils import tasks
 from common.utils import ding_api
+from sql.engines import offlinedownload
 
 urlpatterns = [
     path("", views.index),
@@ -40,6 +41,7 @@ urlpatterns = [
     path("editsql/", views.submit_sql),
     path("submitotherinstance/", views.submit_sql),
     path("detail/<int:workflow_id>/", views.detail, name="detail"),
+    path("downloadfile/", offlinedownload.offline_file_download),
     path("passed/", sql_workflow.passed),
     path("execute/", sql_workflow.execute),
     path("timingtask/", sql_workflow.timing_task),
@@ -93,6 +95,7 @@ urlpatterns = [
     path("check/go_inception/", check.go_inception),
     path("check/email/", check.email),
     path("check/instance/", check.instance),
+    path("check/file_storage_connect/", check.file_storage_connect),
     path("group/group/", resource_group.group),
     path("group/addrelation/", resource_group.addrelation),
     path("group/relations/", resource_group.associated_objects),

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -134,6 +134,7 @@ class AuditV2:
     # 归档表中没有下面两个参数, 所以对归档表来说一下两参数必传
     resource_group: str = ""
     resource_group_id: int = 0
+    offline_data: Optional[dict] = field(default_factory=dict)
 
     def __post_init__(self):
         if not self.workflow:
@@ -233,6 +234,8 @@ class AuditV2:
             self.sys_config.get("auto_review_max_update_rows", 50)
         ):
             # 影响行数超规模, 需要人工审核
+            return False
+        if self.offline_data["is_offline_export"] == "yes":
             return False
         return True
 
@@ -752,6 +755,7 @@ def get_auditor(
     # 归档表中没有下面两个参数, 所以对归档表来说一下两参数必传
     resource_group: str = "",
     resource_group_id: int = 0,
+    offline_data: dict = None,
 ) -> AuditV2:
     current_auditor = settings.CURRENT_AUDITOR
     module, o = current_auditor.split(":")
@@ -763,4 +767,5 @@ def get_auditor(
         audit=audit,
         resource_group=resource_group,
         resource_group_id=resource_group_id,
+        offline_data=offline_data,
     )

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -134,7 +134,7 @@ class AuditV2:
     # 归档表中没有下面两个参数, 所以对归档表来说一下两参数必传
     resource_group: str = ""
     resource_group_id: int = 0
-    offline_data: Optional[dict] = field(default_factory=dict)
+    # offline_data: Optional[dict] = field(default_factory=dict)
 
     def __post_init__(self):
         if not self.workflow:
@@ -235,7 +235,8 @@ class AuditV2:
         ):
             # 影响行数超规模, 需要人工审核
             return False
-        if self.offline_data["is_offline_export"] == "yes":
+        # if self.offline_data["is_offline_export"] == "yes":
+        if self.workflow.is_offline_export == "yes":
             return False
         return True
 
@@ -755,7 +756,7 @@ def get_auditor(
     # 归档表中没有下面两个参数, 所以对归档表来说一下两参数必传
     resource_group: str = "",
     resource_group_id: int = 0,
-    offline_data: dict = None,
+    # offline_data: dict = None,
 ) -> AuditV2:
     current_auditor = settings.CURRENT_AUDITOR
     module, o = current_auditor.split(":")
@@ -767,5 +768,5 @@ def get_auditor(
         audit=audit,
         resource_group=resource_group,
         resource_group_id=resource_group_id,
-        offline_data=offline_data,
+        # offline_data=offline_data,
     )

--- a/sql/views.py
+++ b/sql/views.py
@@ -326,14 +326,18 @@ def sqlquery(request):
     for items in all_config:
         sys_config[items["item"]] = items["value"]
     # 前端需要对 max_export_rows 进行判断,先进行变量的判断是否存在以及是否为空,默认值10000
-    max_export_rows_str = sys_config.get('max_export_rows', '10000')
-    sys_config['max_export_rows'] = int(max_export_rows_str) if max_export_rows_str else 10000
+    max_export_rows_str = sys_config.get("max_export_rows", "10000")
+    sys_config["max_export_rows"] = (
+        int(max_export_rows_str) if max_export_rows_str else 10000
+    )
 
     favorites = QueryLog.objects.filter(username=user.username, favorite=True).values(
         "id", "alias"
     )
     can_download = 1 if user.has_perm("sql.query_download") or user.is_superuser else 0
-    can_offline_download = 1 if user.has_perm("sql.offline_download") or user.is_superuser else 0
+    can_offline_download = (
+        1 if user.has_perm("sql.offline_download") or user.is_superuser else 0
+    )
     context = {
         "favorites": favorites,
         "can_download": can_download,

--- a/sql/views.py
+++ b/sql/views.py
@@ -236,7 +236,13 @@ def detail(request, workflow_id):
     # 获取是否开启手工执行确认
     manual = SysConfig().get("manual")
 
+    all_config = Config.objects.all().values("item", "value")
+    sys_config = {}
+    for items in all_config:
+        sys_config[items["item"]] = items["value"]
+
     context = {
+        "sys_config": sys_config,
         "workflow_detail": workflow_detail,
         "last_operation_info": last_operation_info,
         "is_can_review": is_can_review,
@@ -313,15 +319,30 @@ def sqlquery(request):
     )
     # 收藏语句
     user = request.user
+    group_list = user_groups(user)
+    # 获取所有配置项
+    all_config = Config.objects.all().values("item", "value")
+    sys_config = {}
+    for items in all_config:
+        sys_config[items["item"]] = items["value"]
+    # 前端需要对 max_export_rows 进行判断,先进行变量的判断是否存在以及是否为空,默认值10000
+    max_export_rows_str = sys_config.get('max_export_rows', '10000')
+    sys_config['max_export_rows'] = int(max_export_rows_str) if max_export_rows_str else 10000
+
     favorites = QueryLog.objects.filter(username=user.username, favorite=True).values(
         "id", "alias"
     )
     can_download = 1 if user.has_perm("sql.query_download") or user.is_superuser else 0
-    return render(
-        request,
-        "sqlquery.html",
-        {"favorites": favorites, "can_download": can_download, "engines": engine_map},
-    )
+    can_offline_download = 1 if user.has_perm("sql.offline_download") or user.is_superuser else 0
+    context = {
+        "favorites": favorites,
+        "can_download": can_download,
+        "engines": engine_map,
+        "group_list": group_list,
+        "config": sys_config,
+        "can_offline_download": can_offline_download,
+    }
+    return render(request, "sqlquery.html", context)
 
 
 @permission_required("sql.menu_queryapplylist", raise_exception=True)

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -439,7 +439,8 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
                     workflow=workflow, **validated_data
                 )
                 # 自动创建工作流
-                auditor = get_auditor(workflow=workflow, offline_data=workflow_data)
+                # auditor = get_auditor(workflow=workflow, offline_data=workflow_data)
+                auditor = get_auditor(workflow=workflow)
                 auditor.create_audit()
         except Exception as e:
             logger.error(f"提交工单报错，错误信息：{traceback.format_exc()}")

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -378,14 +378,22 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
         try:
             user_instances(user, tag_codes=["can_write"]).get(id=instance.id)
         except instance.DoesNotExist:
-            raise serializers.ValidationError({"errors": "你所在组未关联该实例！"})
+            if workflow_data["is_offline_export"] == "yes":
+                pass
+            else:
+                raise serializers.ValidationError({"errors": "你所在组未关联该实例！"})
 
         # 再次交给engine进行检测，防止绕过
         try:
             check_engine = get_engine(instance=instance)
-            check_result = check_engine.execute_check(
-                db_name=workflow_data["db_name"], sql=sql_content
-            )
+            if instance.db_type == 'mysql':
+                check_result = check_engine.execute_check(
+                    db_name=workflow_data["db_name"], sql=sql_content, offline_data=workflow_data
+                )
+            else:
+                check_result = check_engine.execute_check(
+                    db_name=workflow_data["db_name"], sql=sql_content
+                )
         except Exception as e:
             raise serializers.ValidationError({"errors": str(e)})
 
@@ -395,7 +403,10 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
         )
         sys_config = SysConfig()
         if not sys_config.get("enable_backup_switch") and check_engine.auto_backup:
-            is_backup = True
+            if workflow_data["is_offline_export"] == "yes":
+                pass
+            else:
+                is_backup = True
 
         # 按照系统配置确定是自动驳回还是放行
         auto_review_wrong = sys_config.get(
@@ -426,7 +437,7 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
                     workflow=workflow, **validated_data
                 )
                 # 自动创建工作流
-                auditor = get_auditor(workflow=workflow)
+                auditor = get_auditor(workflow=workflow, offline_data=workflow_data)
                 auditor.create_audit()
         except Exception as e:
             logger.error(f"提交工单报错，错误信息：{traceback.format_exc()}")

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -386,9 +386,11 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
         # 再次交给engine进行检测，防止绕过
         try:
             check_engine = get_engine(instance=instance)
-            if instance.db_type == 'mysql':
+            if instance.db_type == "mysql":
                 check_result = check_engine.execute_check(
-                    db_name=workflow_data["db_name"], sql=sql_content, offline_data=workflow_data
+                    db_name=workflow_data["db_name"],
+                    sql=sql_content,
+                    offline_data=workflow_data,
                 )
             else:
                 check_result = check_engine.execute_check(

--- a/src/init_sql/v1.11.1_offlinedownload.sql
+++ b/src/init_sql/v1.11.1_offlinedownload.sql
@@ -1,0 +1,9 @@
+  alter table sql_workflow
+  add column export_format varchar(10) DEFAULT NULL,
+  add column is_offline_export varchar(3) NOT NULL,
+  add column file_name varchar(255) DEFAULT NULL;
+
+
+  set @content_type_id=(select id from django_content_type where app_label='sql' and model='permission');
+  insert IGNORE INTO auth_permission (name, content_type_id, codename) VALUES
+('离线下载权限', @content_type_id, 'offline_download');


### PR DESCRIPTION
1、sql/templates/sqlsubmit.html
	添加导出工单参数，默认为非导出工单

2、sql/templates/sqlquery.html
	增加导出工单表单信息，并增加扫描行数检查

3、common/templates/config.html
	增加导出工单相关配置表单

4、sql/views.py
	传递相关页面所需值

5、sql/templates/sqlworkflow.html
	增加工单页面，导出格式的显示

6、sql/templates/detail.html
	增加下载按钮，与 offlinedownload.py 交互

7、common/check.py
	增加config内oss、sftp及本地存储的检查

8、sql_api/serializers.py
	传递相关参数

9、sql/utils/workflow_audit.py
	取消导出工单的自动审核，正常情况下导出工单不应自动审核

10、sql/engines/offlinedownload.py
	导出工单主要代码

11、sql/engines/goinception.py
	增加导出工单类型

12、sql/engines/mysql.py
	传递相关参数

13、sql/models.py
	(1)syntax_type新增(3,导出工单)
	(2)新增字段is_offline_export、export_format、file_name
	(3)permissions新增("offline_download", "离线下载权限")
	涉及 sql:
	alter table sql_workflow
		add column export_format varchar(10) DEFAULT NULL,
		add column is_offline_export varchar(3) NOT NULL,
 		add column file_name varchar(255) DEFAULT NULL;

  	set @content_type_id=(select id from django_content_type where app_label='sql' and model='permission');
  	insert IGNORE INTO auth_permission (name, content_type_id, codename) VALUES('离线下载权限', @content_type_id, 'offline_download');

14、sql/sql_workflow.py
	增加导出格式参数
15、sql/urls.py
	增加 offlinedownload 的路由

新增 sql 脚本： src/init_sql/v1.11.1_offlinedownload.sql 与上方 sql 内容一致，无需反复执行 新增依赖：
	sqlparse==0.4.4
	paramiko==3.4.0
	oss2==2.18.3
	openpyxl==3.1.2
![image](https://github.com/hhyo/Archery/assets/133197875/e55413dc-e506-4e9f-a97f-8f24ab17bc3b)
![image](https://github.com/hhyo/Archery/assets/133197875/97981f41-4a85-4d33-a564-cd378736ecc5)
![image](https://github.com/hhyo/Archery/assets/133197875/a36c9e30-f299-4c4b-bf91-b34f9af7fa48)
![image](https://github.com/hhyo/Archery/assets/133197875/041cfe46-4508-4452-96e2-fbb296eca69c)
![image](https://github.com/hhyo/Archery/assets/133197875/c8554587-5b7f-463f-8d2d-4fc9d8db9fcf)
![image](https://github.com/hhyo/Archery/assets/133197875/f9d6146f-c85e-432a-afe4-47435221c05f)

