### PR TITLE
修复修复fix redis cluster异常问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ mysql-replication==0.22
 django-q==1.3.9
 django-redis==5.2.0
 redis==3.5.3
+redis-py-cluster==2.1.3
 pyodbc==4.*
 gunicorn==22.0.0
 pyecharts==2.0.4

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -11,13 +11,13 @@ import re
 import shlex
 
 import redis
+import rediscluster
 import logging
 import traceback
 
 from common.utils.timer import FuncTimer
 from . import EngineBase
 from .models import ResultSet, ReviewSet, ReviewResult
-from rediscluster import RedisCluster
 
 __author__ = "hhyo"
 
@@ -28,9 +28,11 @@ class RedisEngine(EngineBase):
     def get_connection(self, db_name=None):
         db_name = db_name or self.db_name
         if self.mode == "cluster":
-            return RedisCluster(
+            return rediscluster.RedisCluster(
                 startup_nodes=[{"host": self.host, "port": self.port}],
                 decode_responses=True,
+                socket_connect_timeout=10,
+                ssl=self.is_ssl,
                 password=self.password,
             )
         else:

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -17,6 +17,7 @@ import traceback
 from common.utils.timer import FuncTimer
 from . import EngineBase
 from .models import ResultSet, ReviewSet, ReviewResult
+from rediscluster import RedisCluster
 
 __author__ = "hhyo"
 
@@ -27,15 +28,10 @@ class RedisEngine(EngineBase):
     def get_connection(self, db_name=None):
         db_name = db_name or self.db_name
         if self.mode == "cluster":
-            return redis.cluster.RedisCluster(
-                host=self.host,
-                port=self.port,
-                username=self.user,
-                password=self.password or None,
-                encoding_errors="ignore",
+            return RedisCluster(
+                startup_nodes=[{"host": self.host, "port": self.port}],
                 decode_responses=True,
-                socket_connect_timeout=10,
-                ssl=self.is_ssl,
+                password=self.password,
             )
         else:
             return redis.Redis(

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
     && apt-get install -yq --no-install-recommends nginx mariadb-client \
     && source venv4archery/bin/activate \
     && pip install -r /opt/archery/requirements.txt \
-    && pip install "redis>=4.1.0" \
+    && pip install redis-py-cluster==2.1.3 \
     && cp -f /opt/archery/src/docker/nginx.conf /etc/nginx/ \
     && cp -f /opt/archery/src/docker/supervisord.conf /etc/ \
     && mv /opt/sqladvisor /opt/archery/src/plugins/ \

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update \
     && apt-get install -yq --no-install-recommends nginx mariadb-client \
     && source venv4archery/bin/activate \
     && pip install -r /opt/archery/requirements.txt \
-    && pip install redis-py-cluster==2.1.3 \
     && cp -f /opt/archery/src/docker/nginx.conf /etc/nginx/ \
     && cp -f /opt/archery/src/docker/supervisord.conf /etc/ \
     && mv /opt/sqladvisor /opt/archery/src/plugins/ \


### PR DESCRIPTION
redis资源添加集群模式访问，之前的修复存在问题。
1. 在dockerfile安装redis  >= 4.1.0 需要考虑兼容问题，并需卸载原版本
2. 我是用兼容redis==3.5.3的 redis-py-cluster==2.1.3完成集群访问问题，亲测有效