### PR TITLE
feat: allow customizable OIDC user attribute mapping via environment …

### DIFF
--- a/archery/settings.py
+++ b/archery/settings.py
@@ -38,6 +38,10 @@ env = environ.Env(
         dict,
         {"username": "cn", "display": "displayname", "email": "mail"},
     ),
+    OIDC_USER_ATTR_MAP=(
+        dict,
+        {"username": "preferred_username", "display": "name", "email": "email"},
+    ),
     Q_CLUISTER_SYNC=(bool, False),  # qcluster 同步模式, debug 时可以调整为 True
     # CSRF_TRUSTED_ORIGINS=subdomain.example.com,subdomain.example2.com subdomain.example.com
     CSRF_TRUSTED_ORIGINS=(list, []),
@@ -309,6 +313,7 @@ SIMPLE_JWT = {
 ENABLE_OIDC = env("ENABLE_OIDC", False)
 if ENABLE_OIDC:
     INSTALLED_APPS += ("mozilla_django_oidc",)
+    OIDC_USER_ATTR_MAP = env("OIDC_USER_ATTR_MAP")
     AUTHENTICATION_BACKENDS = (
         "common.authenticate.oidc_auth.OIDCAuthenticationBackend",
         "django.contrib.auth.backends.ModelBackend",

--- a/common/authenticate/oidc_auth.py
+++ b/common/authenticate/oidc_auth.py
@@ -5,35 +5,76 @@ from django.conf import settings
 
 
 class OIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
+    def _get_oidc_attr_map(self):
+        """
+        Safely retrieve OIDC_USER_ATTR_MAP, handling both dict (normal) and str (misconfiguration/env issue).
+        Format for str: "username=preferred_username,display=name,email=email"
+        """
+        attr_map = getattr(settings, "OIDC_USER_ATTR_MAP", {})
+        if isinstance(attr_map, dict):
+            return attr_map
+
+        # Fallback for string configuration
+        parsed_map = {}
+        if isinstance(attr_map, str):
+            pairs = attr_map.split(",")
+            for pair in pairs:
+                if "=" in pair:
+                    key, value = pair.split("=", 1)
+                    parsed_map[key.strip()] = value.strip()
+
+        return parsed_map
+
     def create_user(self, claims):
         """Return object for a newly created user account."""
-        email = claims.get(settings.OIDC_USER_ATTR_MAP.get("email", "email"))
-        username = claims.get(
-            settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username")
-        )
-        display = claims.get(settings.OIDC_USER_ATTR_MAP.get("display", "name"))
+        attr_map = self._get_oidc_attr_map()
+        username_key = attr_map.get("username", "preferred_username")
+        display_key = attr_map.get("display", "name")
+        email_key = attr_map.get("email", "email")
 
-        if not email or not username or not display:
+        username = claims.get(username_key)
+        display = claims.get(display_key)
+        email = claims.get(email_key)
+
+        if not username or not display or not email:
+            missing_fields = []
+            if not username:
+                missing_fields.append(username_key)
+            if not display:
+                missing_fields.append(display_key)
+            if not email:
+                missing_fields.append(email_key)
+
             raise SuspiciousOperation(
-                "email and name and preferred_username should not be empty"
+                (
+                    "OIDC configuration error.\n"
+                    "Missing OIDC fields: {missing}\n"
+                    "Received claims: {claims}\n"
+                    "Please ensure your .env file contains a correct OIDC_USER_ATTR_MAP.\n"
+                    "Example:\n"
+                    "    OIDC_USER_ATTR_MAP=username=preferred_username,display=name,email=email\n"
+                    "Or refer to https://github.com/hhyo/archery/wiki for more details."
+                ).format(
+                    missing=", ".join(missing_fields),
+                    claims=claims,
+                )
             )
+
         user = self.UserModel.objects.create_user(
-            username, email=email, display=display
+            username, display=display, email=email
         )
         init_user(user)
         return user
 
     def describe_user_by_claims(self, claims):
-        username = claims.get(
-            settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username")
-        )
+        attr_map = self._get_oidc_attr_map()
+        username = claims.get(attr_map.get("username", "preferred_username"))
         return "username {}".format(username)
 
     def filter_users_by_claims(self, claims):
         """Return all users matching the username."""
-        username = claims.get(
-            settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username")
-        )
+        attr_map = self._get_oidc_attr_map()
+        username = claims.get(attr_map.get("username", "preferred_username"))
         if not username or username == "admin":
             return self.UserModel.objects.none()
         return self.UserModel.objects.filter(username__iexact=username)

--- a/common/authenticate/oidc_auth.py
+++ b/common/authenticate/oidc_auth.py
@@ -8,9 +8,11 @@ class OIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
     def create_user(self, claims):
         """Return object for a newly created user account."""
         email = claims.get(settings.OIDC_USER_ATTR_MAP.get("email", "email"))
-        username = claims.get(settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username"))
+        username = claims.get(
+            settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username")
+        )
         display = claims.get(settings.OIDC_USER_ATTR_MAP.get("display", "name"))
-        
+
         if not email or not username or not display:
             raise SuspiciousOperation(
                 "email and name and preferred_username should not be empty"
@@ -22,12 +24,16 @@ class OIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
         return user
 
     def describe_user_by_claims(self, claims):
-        username = claims.get(settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username"))
+        username = claims.get(
+            settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username")
+        )
         return "username {}".format(username)
 
     def filter_users_by_claims(self, claims):
         """Return all users matching the username."""
-        username = claims.get(settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username"))
+        username = claims.get(
+            settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username")
+        )
         if not username or username == "admin":
             return self.UserModel.objects.none()
         return self.UserModel.objects.filter(username__iexact=username)

--- a/common/authenticate/oidc_auth.py
+++ b/common/authenticate/oidc_auth.py
@@ -1,14 +1,16 @@
 from mozilla_django_oidc import auth
 from django.core.exceptions import SuspiciousOperation
 from common.auth import init_user
+from django.conf import settings
 
 
 class OIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
     def create_user(self, claims):
         """Return object for a newly created user account."""
-        email = claims.get("email")
-        username = claims.get("preferred_username")
-        display = claims.get("name")
+        email = claims.get(settings.OIDC_USER_ATTR_MAP.get("email", "email"))
+        username = claims.get(settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username"))
+        display = claims.get(settings.OIDC_USER_ATTR_MAP.get("display", "name"))
+        
         if not email or not username or not display:
             raise SuspiciousOperation(
                 "email and name and preferred_username should not be empty"
@@ -20,12 +22,12 @@ class OIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
         return user
 
     def describe_user_by_claims(self, claims):
-        username = claims.get("preferred_username")
+        username = claims.get(settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username"))
         return "username {}".format(username)
 
     def filter_users_by_claims(self, claims):
         """Return all users matching the username."""
-        username = claims.get("preferred_username")
+        username = claims.get(settings.OIDC_USER_ATTR_MAP.get("username", "preferred_username"))
         if not username or username == "admin":
             return self.UserModel.objects.none()
         return self.UserModel.objects.filter(username__iexact=username)

--- a/common/authenticate/test_oidc_auth.py
+++ b/common/authenticate/test_oidc_auth.py
@@ -1,0 +1,117 @@
+from django.test import TestCase, override_settings
+from django.core.exceptions import SuspiciousOperation
+from django.contrib.auth import get_user_model
+from common.authenticate.oidc_auth import OIDCAuthenticationBackend
+from unittest.mock import MagicMock
+
+User = get_user_model()
+
+from django.conf import settings
+
+
+class TestDefaultOIDCSettings(TestCase):
+    def test_default_attribute_mapping(self):
+        """Test that the default attribute mapping is loaded from settings."""
+        backend = OIDCAuthenticationBackend()
+        attr_map = backend._get_oidc_attr_map()
+        expected_map = getattr(settings, "OIDC_USER_ATTR_MAP", {})
+        self.assertEqual(attr_map, expected_map)
+
+
+@override_settings(
+    OIDC_USER_ATTR_MAP={
+        "username": "preferred_username",
+        "email": "email",
+        "display": "name",
+    }
+)
+class OIDCAuthTest(TestCase):
+    def setUp(self):
+        self.backend = OIDCAuthenticationBackend()
+        self.claims = {
+            "email": "test@example.com",
+            "preferred_username": "testuser",
+            "name": "Test User",
+        }
+
+    def test_create_user_success(self):
+        """Test creating a user with standard claims."""
+        user = self.backend.create_user(self.claims)
+        self.assertEqual(user.username, "testuser")
+        self.assertEqual(user.email, "test@example.com")
+        self.assertEqual(user.display, "Test User")
+        self.assertTrue(User.objects.filter(username="testuser").exists())
+
+    @override_settings(
+        OIDC_USER_ATTR_MAP={"username": "sub", "email": "mail", "display": "nickname"}
+    )
+    def test_create_user_custom_mapping(self):
+        """Test creating a user with custom attribute mapping."""
+        custom_claims = {
+            "mail": "custom@example.com",
+            "sub": "customuser",
+            "nickname": "Custom User",
+        }
+        user = self.backend.create_user(custom_claims)
+        self.assertEqual(user.username, "customuser")
+        self.assertEqual(user.email, "custom@example.com")
+        self.assertEqual(user.display, "Custom User")
+
+    @override_settings(
+        OIDC_USER_ATTR_MAP="username=preferred_username,display=name,email=email"
+    )
+    def test_create_user_string_config(self):
+        """Test creating a user with string configuration for attribute mapping."""
+        user = self.backend.create_user(self.claims)
+        self.assertEqual(user.username, "testuser")
+        self.assertEqual(user.email, "test@example.com")
+        self.assertEqual(user.display, "Test User")
+
+    def test_create_user_missing_email(self):
+        """Test that SuspiciousOperation is raised when email is missing."""
+        claims = self.claims.copy()
+        del claims["email"]
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.create_user(claims)
+        self.assertIn("Missing OIDC fields: email", str(cm.exception))
+
+    def test_create_user_missing_username(self):
+        """Test that SuspiciousOperation is raised when username is missing."""
+        claims = self.claims.copy()
+        del claims["preferred_username"]
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.create_user(claims)
+        self.assertIn("Missing OIDC fields: preferred_username", str(cm.exception))
+
+    def test_create_user_missing_display(self):
+        """Test that SuspiciousOperation is raised when display name is missing."""
+        claims = self.claims.copy()
+        del claims["name"]
+        with self.assertRaises(SuspiciousOperation) as cm:
+            self.backend.create_user(claims)
+        self.assertIn("Missing OIDC fields: name", str(cm.exception))
+
+    def test_describe_user_by_claims(self):
+        """Test describing user by claims."""
+        description = self.backend.describe_user_by_claims(self.claims)
+        self.assertEqual(description, "username testuser")
+
+    def test_filter_users_by_claims_success(self):
+        """Test filtering users finds an existing user."""
+        User.objects.create_user(username="testuser", email="test@example.com")
+        users = self.backend.filter_users_by_claims(self.claims)
+        self.assertEqual(users.count(), 1)
+        self.assertEqual(users.first().username, "testuser")
+
+    def test_filter_users_by_claims_not_found(self):
+        """Test filtering users returns empty if user doesn't exist."""
+        users = self.backend.filter_users_by_claims(self.claims)
+        self.assertEqual(users.count(), 0)
+
+    def test_filter_users_by_claims_admin_block(self):
+        """Test that the 'admin' username is blocked."""
+        claims = {"preferred_username": "admin"}
+        # Ensure 'admin' user exists so we know we aren't just getting empty because of no user
+        User.objects.create_user(username="admin", email="admin@example.com")
+        users = self.backend.filter_users_by_claims(claims)
+        self.assertEqual(users.count(), 0)

--- a/common/authenticate/test_oidc_auth.py
+++ b/common/authenticate/test_oidc_auth.py
@@ -1,31 +1,70 @@
+from unittest.mock import patch, MagicMock
+
+# ========================================================
+# 第一步：準備攔截器但不立即 start，或者將其引用保留以便清理
+# ========================================================
+requests_patcher = patch("requests.get")
+
+mock_response = MagicMock()
+mock_response.status_code = 200
+mock_response.json.return_value = {
+    "authorization_endpoint": "https://example.com/auth",
+    "token_endpoint": "https://example.com/token",
+    "userinfo_endpoint": "https://example.com/userinfo",
+    "jwks_uri": "https://example.com/jwks",
+    "end_session_endpoint": "https://example.com/logout",
+}
+
+# 立即啟動以保護接下來的 Django 導入
+mock_get = requests_patcher.start()
+mock_get.return_value = mock_response
+
+# ========================================================
+# 第二步：現在才開始導入 Django 相關組件
+# ========================================================
 from django.test import TestCase, override_settings
 from django.core.exceptions import SuspiciousOperation
 from django.contrib.auth import get_user_model
-from common.authenticate.oidc_auth import OIDCAuthenticationBackend
-from unittest.mock import MagicMock
-
-User = get_user_model()
-
 from django.conf import settings
 
+# common 內部的導入也放在這之後，因為它們內部通常也會 import settings
+from common.authenticate.oidc_auth import OIDCAuthenticationBackend
 
-class TestDefaultOIDCSettings(TestCase):
-    def test_default_attribute_mapping(self):
-        """Test that the default attribute mapping is loaded from settings."""
-        backend = OIDCAuthenticationBackend()
-        attr_map = backend._get_oidc_attr_map()
-        expected_map = getattr(settings, "OIDC_USER_ATTR_MAP", {})
-        self.assertEqual(attr_map, expected_map)
+# 取得 User 模型
+User = get_user_model()
+
+# ========================================================
+# 第三步：定義測試內容
+# ========================================================
+OIDC_MOCK_ENDPOINTS = {
+    "OIDC_OP_AUTHORIZATION_ENDPOINT": "https://example.com/auth",
+    "OIDC_OP_TOKEN_ENDPOINT": "https://example.com/token",
+    "OIDC_OP_USER_ENDPOINT": "https://example.com/userinfo",
+    "OIDC_OP_JWKS_ENDPOINT": "https://example.com/jwks",
+    "OIDC_OP_LOGOUT_ENDPOINT": "https://example.com/logout",
+    "OIDC_RP_CLIENT_ID": "exampleoidcrpclientid",
+    "OIDC_RP_CLIENT_SECRET": "exampleoidcrpclientsecret",
+}
 
 
-@override_settings(
-    OIDC_USER_ATTR_MAP={
-        "username": "preferred_username",
-        "email": "email",
-        "display": "name",
-    }
-)
+@override_settings(**OIDC_MOCK_ENDPOINTS)
 class OIDCAuthTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # 這裡不再調用 patch().start()，因為全域已經啟動了。
+        # 我們直接引用全域啟動的 patcher 和 mock 對象。
+        cls.requests_patcher = requests_patcher
+        cls.mock_get = mock_get
+
+        # 呼叫原本的 setUpClass (這會觸發 Django settings 的相關處理)
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        # 測試結束後，停止全域啟動的 patch，防止污染其他測試檔案
+        super().tearDownClass()
+        cls.requests_patcher.stop()
+
     def setUp(self):
         self.backend = OIDCAuthenticationBackend()
         self.claims = {
@@ -33,6 +72,12 @@ class OIDCAuthTest(TestCase):
             "preferred_username": "testuser",
             "name": "Test User",
         }
+
+    def test_default_attribute_mapping(self):
+        """Test that the default attribute mapping is loaded from settings."""
+        attr_map = self.backend._get_oidc_attr_map()
+        expected_map = getattr(settings, "OIDC_USER_ATTR_MAP", {})
+        self.assertEqual(attr_map, expected_map)
 
     def test_create_user_success(self):
         """Test creating a user with standard claims."""


### PR DESCRIPTION
## Summary
新增 OIDC 透过 .env file 自订使用者属性（attribute） mapping 的功能。

## Why
目前我们有两间不同的子公司共用同一套 Archery，因员工可能出现相同的 preferred_username，导致账号冲突。  
为避免此问题，我们希望能透过 `.env` 自订 mapping，例如使用 `username=email` 作为唯一识别值。

## Changes
- `settings.py` 新增 `OIDC_USER_ATTR_MAP`，用于读取 .env 中的自订属性映射。
- `oidc_auth.py` 保留默认值 `username=preferred_username,display=name,email=email`，让未自订的管理员仍可维持既有行为，不需额外修改 .env。

## How to Test

### 1. 验证未设定 `.env` 时维持默认行为
执行：
```bash
python3 manage.py shell -c "from django.conf import settings; import os; print('--- DEBUG INFO ---'); print('ENV_VAR:', os.environ.get('OIDC_USER_ATTR_MAP', 'NOT_FOUND')); print('SETTINGS_VAL:', getattr(settings, 'OIDC_USER_ATTR_MAP', 'NOT_FOUND')); print('------------------')"
```
--- DEBUG INFO ---
ENV_VAR: NOT_FOUND
SETTINGS_VAL: {'email': 'email', 'username': 'preferred_username', 'display': 'name'}
------>8----------
### 2. 在 `.env` file 中加入自订 mapping 后应能被读取。
--- DEBUG INFO ---
ENV_VAR: {'email': 'email', 'username': 'email', 'display': 'name'}
SETTINGS_VAL: NOT_FOUND
------>8----------

## Related Issues
N/A

## Notes
此变更为向下相容，不会影响现有使用者。