### PR TITLE
Add support for _delete_by_query API endpoint

### DIFF
--- a/sql/archiver.py
+++ b/sql/archiver.py
@@ -349,6 +349,7 @@ def archive(archive_id):
     )
     args = {
         "no-version-check": True,
+        "no-check-charset": True,
         "source": source,
         "where": condition,
         "progress": 5000,
@@ -356,6 +357,8 @@ def archive(archive_id):
         "charset": "utf8",
         "limit": 10000,
         "txn-size": 1000,
+        "bulk-delete": True,
+        "bulk-insert": True,
         "sleep": sleep,
     }
 

--- a/sql/archiver.py
+++ b/sql/archiver.py
@@ -349,7 +349,6 @@ def archive(archive_id):
     )
     args = {
         "no-version-check": True,
-        "no-check-charset": True,
         "source": source,
         "where": condition,
         "progress": 5000,
@@ -357,8 +356,6 @@ def archive(archive_id):
         "charset": "utf8",
         "limit": 10000,
         "txn-size": 1000,
-        "bulk-delete": True,
-        "bulk-insert": True,
         "sleep": sleep,
     }
 


### PR DESCRIPTION
新增支持es的delete_by_query方法
默认参数 'scroll_size': '3000', 'slices': '2'，每批3000行，并发2
该方法与update_by_query基本差不多，直接参考update_by_query的代码实现

<img width="2321" height="289" alt="00114b6a0e919f458c078b5f37d6d4d1" src="https://github.com/user-attachments/assets/92cd721b-41f0-4ac9-8017-994a7786dfca" />


es版本7.2测试没问题，低版本es可能出现参数不支持的情况，未做验证

