### PR TITLE
修复mongodb+srv://addr 工单执行失败

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -385,14 +385,27 @@ class MongoEngine(EngineBase):
 
     def get_master(self):
         """获得主节点的port和host"""
-
         sql = "rs.isMaster().primary"
-        master = self.exec_cmd(sql)
-        if master != "undefined":
-            sp_host = master.replace('"', "").split(":")
-            self.host = sp_host[0]
-            self.port = int(sp_host[1])
-        # return master
+        master = (self.exec_cmd(sql) or "").strip()
+        # 空、undefined 直接返回，不更新 host/port
+        if not master or master == "undefined":
+            return
+        # 明显是错误/异常信息的情况，直接忽略，避免炸 worker
+        lower = master.lower()
+        if any(x in lower for x in ["error", "exception", "typeerror", "failed"]):
+            logger.warning(f"Mongo get_master 返回异常内容: {master}")
+            return
+        # 正常 host:port 场景
+        parts = master.replace('"', "").split(":")
+        if len(parts) >= 2 and parts[0] and parts[1]:
+            self.host = parts[0]
+            try:
+                self.port = int(parts[1])
+            except ValueError:
+                logger.warning(f"Mongo get_master 端口解析失败: {master}")
+        else:
+            # 没有冒号或格式不对，也不要抛异常
+            logger.warning(f"Mongo get_master 返回非 host:port 格式: {master}")
 
     def get_slave(self):
         """获得从节点的port和host"""


### PR DESCRIPTION
当 mongodb host 为 mongodb+srv://host，sql 查询正常，sql 上线时工单执行失败，错误信息为：
list index out of range : Traceback (most recent call last):
File "/opt/venv4archery/lib/python3.11/site-packages/django_q/cluster.py", line 432, in worker
res = f(*task["args"], **task["kwargs"])
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/archery/sql/utils/execute_sql.py", line 48, in execute
return execute_engine.execute_workflow(workflow=workflow_detail)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/archery/sql/engines/mongo.py", line 431, in execute_workflow
return self.execute(
^^^^^^^^^^^^^
File "/opt/archery/sql/engines/mongo.py", line 437, in execute
self.get_master()
File "/opt/archery/sql/engines/mongo.py", line 394, in get_master
self.port = int(sp_host[1])
~~~~~~~^^^
IndexError: list index out of range