### PR TITLE
refactor(mongo):重构mongo engine

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -22,6 +22,7 @@ from common.config import SysConfig
 
 logger = logging.getLogger("default")
 
+
 # 自定义异常
 class mongo_error(Exception):
     def __init__(self, error_info):
@@ -333,7 +334,9 @@ class MongoEngine(EngineBase):
                     if len(sp_host) > 1:
                         self.port = int(sp_host[1])
         except Exception:
-            logger.warning(f"mongodb获取主节点信息错误，错误信息{traceback.format_exc()}")
+            logger.warning(
+                f"mongodb获取主节点信息错误，错误信息{traceback.format_exc()}"
+            )
 
     def get_slave(self):
         """获得从节点的port和host"""
@@ -358,7 +361,9 @@ class MongoEngine(EngineBase):
             else:
                 return False
         except Exception:
-            logger.warning(f"mongodb获取从节点信息错误，错误信息{traceback.format_exc()}")
+            logger.warning(
+                f"mongodb获取从节点信息错误，错误信息{traceback.format_exc()}"
+            )
             return False
 
     def get_table_conut(self, table_name, db_name):
@@ -552,9 +557,7 @@ class MongoEngine(EngineBase):
                 opts = _normalize_bool_opts(
                     parsed_args[2] if len(parsed_args) > 2 else {}
                 )
-                result = coll.update_one(
-                    parsed_args[0], parsed_args[1], **(opts or {})
-                )
+                result = coll.update_one(parsed_args[0], parsed_args[1], **(opts or {}))
                 affected_rows = result.modified_count
                 result_doc = {
                     "acknowledged": result.acknowledged,
@@ -579,17 +582,11 @@ class MongoEngine(EngineBase):
                     parsed_args[2] if len(parsed_args) > 2 else {}
                 )
                 opts = opts or {}
-                use_many = (
-                    opts.get("multi", False) if isinstance(opts, dict) else False
-                )
+                use_many = opts.get("multi", False) if isinstance(opts, dict) else False
                 if use_many:
-                    result = coll.update_many(
-                        parsed_args[0], parsed_args[1], **opts
-                    )
+                    result = coll.update_many(parsed_args[0], parsed_args[1], **opts)
                 else:
-                    result = coll.update_one(
-                        parsed_args[0], parsed_args[1], **opts
-                    )
+                    result = coll.update_one(parsed_args[0], parsed_args[1], **opts)
                 affected_rows = result.modified_count
                 result_doc = {
                     "acknowledged": result.acknowledged,
@@ -692,7 +689,11 @@ class MongoEngine(EngineBase):
                 affected_rows = 0
                 result_doc = {"ok": 1}
             elif method == "convertToCapped":
-                size = parsed_args[0].get("size", 0) if isinstance(parsed_args[0], dict) else parsed_args[0]
+                size = (
+                    parsed_args[0].get("size", 0)
+                    if isinstance(parsed_args[0], dict)
+                    else parsed_args[0]
+                )
                 result = db.command("convertToCapped", collection, size=size)
                 affected_rows = 0
                 result_doc = result
@@ -746,9 +747,7 @@ class MongoEngine(EngineBase):
 
                 result = coll.bulk_write(operations, **(opts or {}))
                 affected_rows = (
-                    result.modified_count
-                    + result.deleted_count
-                    + result.inserted_count
+                    result.modified_count + result.deleted_count + result.inserted_count
                 )
                 result_doc = {
                     "acknowledged": result.acknowledged,
@@ -1317,7 +1316,7 @@ class MongoEngine(EngineBase):
                             query_dict["findOne_filter"] = fo_condition or "{}"
                             # dispose_pair 返回的 p_index 指向闭合大括号本身，需跳过
                             fo_projection = (
-                                re_char[p_index + 1:].strip().lstrip(",").strip()
+                                re_char[p_index + 1 :].strip().lstrip(",").strip()
                             )
                             if fo_projection:
                                 query_dict["findOne_projection"] = fo_projection
@@ -1332,13 +1331,9 @@ class MongoEngine(EngineBase):
                             p_index, cd_condition = self.dispose_pair(
                                 re_char, 0, "{", "}"
                             )
-                            query_dict["countDocuments_filter"] = (
-                                cd_condition or "{}"
-                            )
+                            query_dict["countDocuments_filter"] = cd_condition or "{}"
                             # dispose_pair 返回的 p_index 指向闭合大括号本身，需跳过
-                            cd_opts = (
-                                re_char[p_index + 1:].strip().lstrip(",").strip()
-                            )
+                            cd_opts = re_char[p_index + 1 :].strip().lstrip(",").strip()
                             if cd_opts:
                                 query_dict["countDocuments_options"] = cd_opts
                         except Exception:
@@ -1423,7 +1418,11 @@ class MongoEngine(EngineBase):
             if method == "find":
                 condition = de.decode(query_dict["condition"])
             if method == "count":
-                condition = de.decode(query_dict["condition"]) if query_dict.get("condition") else {}
+                condition = (
+                    de.decode(query_dict["condition"])
+                    if query_dict.get("condition")
+                    else {}
+                )
                 condition = condition or {}
             find_cmd += "(condition)"
         if "projection" in query_dict and query_dict["projection"]:
@@ -1457,9 +1456,7 @@ class MongoEngine(EngineBase):
 
         # 覆盖 findOne/countDocuments/distinct/stats 对应的 pymongo 命令
         if method == "findOne":
-            findone_filter = (
-                de.decode(query_dict.get("findOne_filter", "{}")) or {}
-            )
+            findone_filter = de.decode(query_dict.get("findOne_filter", "{}")) or {}
             if "findOne_projection" in query_dict:
                 findone_projection = de.decode(query_dict["findOne_projection"])
                 find_cmd = "collection.find_one(findone_filter, findone_projection)"
@@ -1470,21 +1467,17 @@ class MongoEngine(EngineBase):
                 de.decode(query_dict.get("countDocuments_filter", "{}")) or {}
             )
             if "countDocuments_options" in query_dict:
-                countdoc_options = (
-                    de.decode(query_dict["countDocuments_options"]) or {}
-                )
+                countdoc_options = de.decode(query_dict["countDocuments_options"]) or {}
                 find_cmd = (
                     "collection.count_documents(countdoc_filter, **countdoc_options)"
                 )
             else:
                 find_cmd = "collection.count_documents(countdoc_filter)"
         elif method == "distinct":
-            distinct_parts = self.__split_args(
-                query_dict.get("distinct_args", "")
-            ) or [""]
-            distinct_field = (
-                distinct_parts[0].strip().strip('"').strip("'")
-            )
+            distinct_parts = self.__split_args(query_dict.get("distinct_args", "")) or [
+                ""
+            ]
+            distinct_field = distinct_parts[0].strip().strip('"').strip("'")
             if len(distinct_parts) > 1 and distinct_parts[1].strip():
                 distinct_filter = de.decode(distinct_parts[1]) or {}
                 find_cmd = "collection.distinct(distinct_field, distinct_filter)"

--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -4,16 +4,15 @@ import time
 import pymongo
 import logging
 import traceback
-import subprocess
 import simplejson as json
 import datetime
-import tempfile
 from bson.son import SON
 from bson import json_util
 from pymongo.errors import OperationFailure
 from dateutil.parser import parse
 from bson.objectid import ObjectId
 from bson.int64 import Int64
+from bson.regex import Regex
 
 from sql.utils.data_masking import data_masking
 
@@ -22,10 +21,6 @@ from .models import ResultSet, ReviewSet, ReviewResult
 from common.config import SysConfig
 
 logger = logging.getLogger("default")
-
-# mongo客户端安装在本机的位置
-mongo = "mongo"
-
 
 # 自定义异常
 class mongo_error(Exception):
@@ -189,6 +184,42 @@ class JsonDecoder:
             else:
                 return int(expr)
 
+        def __next_regex(self):
+            """处理 MongoDB 原生正则字面量 /pattern/flags，返回 bson.regex.Regex"""
+            self.__move_i()  # 跳过起始的 /
+            pattern = ""
+            trans_flag = False
+            while self.__cur_char() != "":
+                ch = self.__cur_char()
+                if trans_flag:
+                    # 保留反斜杠与转义字符，交给正则引擎自行解析
+                    pattern += ch
+                    trans_flag = False
+                    self.__move_i()
+                    continue
+                if ch == "\\":
+                    pattern += ch
+                    trans_flag = True
+                    self.__move_i()
+                    continue
+                if ch == "/":
+                    break
+                pattern += ch
+                self.__move_i()
+            if self.__cur_char() != "/":
+                raise Exception('missing closing "/" in regex')
+
+            # 读取 flags: i m s x (MongoDB 支持的正则选项)
+            self.__move_i()  # 跳过闭合的 /
+            flags_str = ""
+            while self.__cur_char() in ("i", "m", "s", "x"):
+                flags_str += self.__cur_char()
+                self.__move_i()
+            # 回退一步，让外层 next() 的 __move_i 推进到下一个字符
+            self.__move_i(-1)
+
+            return Regex(pattern, flags_str)
+
         def __next_const(self):
             """处理没有被''和""包含的字符，如true和ObjectId"""
             outstr = ""
@@ -212,8 +243,9 @@ class JsonDecoder:
 
             self.__move_i(-1)
 
-            if outstr in ("true", "false", "null"):
-                return {"true": True, "false": False, "null": None}[outstr]
+            stripped = outstr.strip()
+            if stripped in ("true", "false", "null"):
+                return {"true": True, "false": False, "null": None}[stripped]
             elif data_type == "ObjectId":
                 ojStr = re.findall(r"ObjectId\(.*?\)", outstr)  # 单独处理ObjectId
                 if len(ojStr) > 0:
@@ -241,8 +273,8 @@ class JsonDecoder:
                     id_str = re.findall(r"\(.*?\)", nuStr[0])
                     nlong = id_str[0].replace(" ", "")[2:-2]
                     return Int64(nlong)
-            elif outstr:
-                return outstr
+            elif stripped:
+                return stripped
             raise Exception('Invalid symbol "%s"' % outstr)
 
         def next(self):
@@ -267,6 +299,8 @@ class JsonDecoder:
                 cur_token = self.__next_const()
             elif ch.isdigit() or ch in (".", "-", "+"):  # 检测字符串是否只由数字组成
                 cur_token = self.__next_number()
+            elif ch == "/":  # MongoDB 原生正则字面量 /pattern/flags
+                cur_token = self.__next_regex()
             else:
                 raise Exception('Invalid symbol "%s"' % ch)
             self.__move_i()
@@ -286,145 +320,453 @@ class MongoEngine(EngineBase):
     def test_connection(self):
         return self.get_all_databases()
 
-    def exec_cmd(self, sql, db_name=None, slave_ok=""):
-        """审核时执行的语句"""
-
-        if self.port and self.host:
-            msg = ""
-            auth_db = self.instance.db_name or "admin"
-            sql_len = len(sql)
-            is_load = False  # 默认不使用load方法执行mongodb sql语句
-            try:
-                if not sql.startswith("var host=") and sql_len > 4000:
-                    # 在master节点执行的情况，如果sql长度大于4000,就采取load js的方法
-                    # 因为用mongo load方法执行js脚本，所以需要重新改写一下sql，以便回显js执行结果
-                    sql = "var result = " + sql + "\nprintjson(result);"
-                    # 因为要知道具体的临时文件位置，所以用了NamedTemporaryFile模块
-                    fp = tempfile.NamedTemporaryFile(
-                        suffix=".js", prefix="mongo_", dir="/tmp/", delete=True
-                    )
-                    fp.write(sql.encode("utf-8"))
-                    fp.seek(0)  # 把文件指针指向开始，这样写的sql内容才能落到磁盘文件上
-                    cmd = self._build_cmd(
-                        db_name, auth_db, slave_ok, fp.name, is_load=True
-                    )
-                    is_load = True  # 标记使用了load方法，用来在finally里面判断是否需要强制删除临时文件
-                elif (
-                    not sql.startswith("var host=") and sql_len < 4000
-                ):  # 在master节点执行的情况， 如果sql长度小于4000,就直接用mongo shell执行，减少磁盘交换，节省性能
-                    cmd = self._build_cmd(db_name, auth_db, slave_ok, sql=sql)
-                else:
-                    cmd = self._build_cmd(
-                        db_name, auth_db, sql=sql, slave_ok="rs.slaveOk();"
-                    )
-                p = subprocess.Popen(
-                    cmd,
-                    shell=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    universal_newlines=True,
-                )
-                re_msg = []
-                for line in iter(p.stdout.read, ""):
-                    re_msg.append(line)
-                # 因为返回的line中也有可能带有换行符，因此需要先全部转换成字符串
-                __msg = "\n".join(re_msg)
-                _re_msg = []
-                for _line in __msg.split("\n"):
-                    if not _re_msg and re.match("WARNING.*", _line):
-                        # 第一行可能是WARNING语句，因此跳过
-                        continue
-                    _re_msg.append(_line)
-
-                msg = "\n".join(_re_msg)
-                msg = msg.replace("true\n", "")
-            except Exception as e:
-                logger.warning(
-                    f"mongo语句执行报错，语句：{sql}，{e}错误信息{traceback.format_exc()}"
-                )
-            finally:
-                if is_load:
-                    fp.close()
-        return msg
-
-    # 用来进行判断是否有用户名与密码以及是否需要临时文件的情况，进而返回要执行的mongo命令
-    def _build_cmd(
-        self, db_name, auth_db, slave_ok="", tempfile_=None, sql=None, is_load=False
-    ):
-        # 提取公共参数
-        common_params = {
-            "mongo": "mongo",
-            "host": self.host,
-            "port": self.port,
-            "db_name": db_name,
-            "auth_db": auth_db,
-            "slave_ok": slave_ok,
-        }
-        if is_load:
-            cmd_template = (
-                "{mongo} --quiet {auth_options} {host}:{port}/{auth_db} <<\\EOF\n"
-                "db=db.getSiblingDB('{db_name}');{slave_ok}load('{tempfile_}')\nEOF"
-            )
-            # 长度超限使用loadjs的方式运行，使用临时文件
-            common_params["tempfile_"] = tempfile_
-        else:
-            cmd_template = (
-                "{mongo} --quiet {auth_options} {host}:{port}/{auth_db} <<\\EOF\n"
-                "db=db.getSiblingDB('{db_name}');{slave_ok}{sql}\nEOF"
-            )
-            # 长度不超限直接mongo shell，无需临时文件
-            common_params["sql"] = sql
-        # 如果有账号密码，则添加选项
-        if self.user and self.password:
-            common_params["auth_options"] = "-u {uname} -p '{password}'".format(
-                uname=self.user, password=self.password
-            )
-        else:
-            common_params["auth_options"] = ""
-        return cmd_template.format(**common_params)
-
     def get_master(self):
         """获得主节点的port和host"""
-
-        sql = "rs.isMaster().primary"
-        master = self.exec_cmd(sql)
-        if master != "undefined":
-            sp_host = master.replace('"', "").split(":")
-            self.host = sp_host[0]
-            self.port = int(sp_host[1])
-        # return master
+        try:
+            conn = self.get_connection()
+            master = conn.admin.command("isMaster").get("primary")
+            if master:
+                master = master.strip().replace('"', "").replace("'", "")
+                if master != "undefined" and ":" in master:
+                    sp_host = master.split(":")
+                    self.host = sp_host[0]
+                    if len(sp_host) > 1:
+                        self.port = int(sp_host[1])
+        except Exception:
+            logger.warning(f"mongodb获取主节点信息错误，错误信息{traceback.format_exc()}")
 
     def get_slave(self):
         """获得从节点的port和host"""
-
-        sql = """var host=""; rs.status().members.forEach(function(item) {i=1; if (item.stateStr =="SECONDARY") \
-        {host=item.name } }); print(host);"""
-        slave_msg = self.exec_cmd(sql, db_name=self.db_name)
-        # 如果是阿里云的云mongodb，会获取不到备节点真实的ip和端口，那就干脆不获取，直接用主节点来执行sql
-        # 如果是自建mongodb，获取到备节点的ip是192.168.1.33:27019这样的值；但如果是阿里云mongodb，获取到的备节点ip是SECONDARY、hiddenNode这样的值
-        # 所以，为了使代码更加通用，通过有无冒号来判断自建Mongod还是阿里云mongdb；没有冒号就判定为阿里云mongodb，直接返回false；
-        if ":" not in slave_msg:
-            return False
-        if slave_msg.lower().find("undefined") < 0:
-            sp_host = slave_msg.replace('"', "").split(":")
-            self.host = sp_host[0]
-            self.port = int(sp_host[1])
-            return True
-        else:
+        try:
+            conn = self.get_connection()
+            rs_status = conn.admin.command("replSetGetStatus")
+            slave_msg = ""
+            for member in rs_status.get("members", []):
+                if member.get("stateStr") == "SECONDARY":
+                    slave_msg = member.get("name", "")
+                    break
+            # 如果是阿里云的云mongodb，会获取不到备节点真实的ip和端口，那就干脆不获取，直接用主节点来执行sql
+            # 如果是自建mongodb，获取到备节点的ip是192.168.1.33:27019这样的值；但如果是阿里云mongodb，获取到的备节点ip是SECONDARY、hiddenNode这样的值
+            # 所以，为了使代码更加通用，通过有无冒号来判断自建Mongod还是阿里云mongdb；没有冒号就判定为阿里云mongodb，直接返回false；
+            if ":" not in slave_msg:
+                return False
+            if slave_msg.lower().find("undefined") < 0:
+                sp_host = slave_msg.replace('"', "").split(":")
+                self.host = sp_host[0]
+                self.port = int(sp_host[1])
+                return True
+            else:
+                return False
+        except Exception:
+            logger.warning(f"mongodb获取从节点信息错误，错误信息{traceback.format_exc()}")
             return False
 
     def get_table_conut(self, table_name, db_name):
         try:
-            count_sql = f"db.{table_name}.count()"
-            status = self.get_slave()  # 查询总数据要求在slave节点执行
-            if self.host and self.port and status:
-                count = int(self.exec_cmd(count_sql, db_name, slave_ok="rs.slaveOk();"))
-            else:
-                count = int(self.exec_cmd(count_sql, db_name))
+            self.get_slave()  # 查询总数据要求在slave节点执行，会更新 self.host/port
+            conn = self.get_connection(db_name)
+            db = conn[db_name]
+            count = db[table_name].count_documents({})
             return count
         except Exception as e:
             logger.debug("get_table_conut:" + str(e))
             return 0
+
+    def __split_args(self, args_str):
+        """安全地按逗号分割参数，忽略 {}[]() 和字符串内部的逗号"""
+        args = []
+        current = []
+        depth = 0
+        in_string = False
+        string_char = None
+
+        for i, ch in enumerate(args_str):
+            if ch in ('"', "'") and (i == 0 or args_str[i - 1] != "\\"):
+                if not in_string:
+                    in_string = True
+                    string_char = ch
+                elif ch == string_char:
+                    in_string = False
+                    string_char = None
+                current.append(ch)
+            elif in_string:
+                current.append(ch)
+            elif ch in ("{", "[", "("):
+                depth += 1
+                current.append(ch)
+            elif ch in ("}", "]", ")"):
+                depth -= 1
+                current.append(ch)
+            elif ch == "," and depth == 0:
+                args.append("".join(current).strip())
+                current = []
+            else:
+                current.append(ch)
+
+        if current:
+            args.append("".join(current).strip())
+
+        return args
+
+    def _execute_shell_sql(self, sql, db_name):
+        """
+        解析 MongoDB shell 语句并通过 pymongo 执行
+        返回 (success: bool, result_json: str, affected_rows: int)
+        """
+        sql = sql.strip().rstrip(";")
+
+        # 找到最后一个 ".method(" 的位置
+        last_dot_pos = -1
+        in_string = False
+        string_char = None
+        paren_depth = 0
+
+        for i, ch in enumerate(sql):
+            if ch in ('"', "'") and (i == 0 or sql[i - 1] != "\\"):
+                if not in_string:
+                    in_string = True
+                    string_char = ch
+                elif ch == string_char:
+                    in_string = False
+                    string_char = None
+            elif not in_string:
+                if ch == "(":
+                    paren_depth += 1
+                elif ch == ")":
+                    paren_depth -= 1
+                elif ch == "." and paren_depth == 0:
+                    last_dot_pos = i
+
+        if last_dot_pos < 0:
+            return False, f"无法解析语句: {sql}", 0
+
+        method_part = sql[last_dot_pos + 1 :]
+        paren_pos = method_part.find("(")
+        if paren_pos < 0:
+            return False, f"无法解析方法参数: {sql}", 0
+
+        method = method_part[:paren_pos].strip()
+
+        # 提取参数
+        _, args_with_parens = self.dispose_pair(
+            sql, last_dot_pos + 1 + paren_pos, "(", ")"
+        )
+        args_str = args_with_parens.strip("()")
+        args = self.__split_args(args_str)
+
+        # 解析参数为 Python 对象
+        de = JsonDecoder()
+        parsed_args = []
+        for arg in args:
+            arg = arg.strip()
+            if not arg:
+                continue
+            if arg.startswith("{") or arg.startswith("["):
+                parsed_args.append(de.decode(arg))
+            elif arg.startswith('"') or arg.startswith("'"):
+                parsed_args.append(arg[1:-1])
+            elif arg.isdigit():
+                parsed_args.append(int(arg))
+            elif arg == "true":
+                parsed_args.append(True)
+            elif arg == "false":
+                parsed_args.append(False)
+            else:
+                parsed_args.append(arg)
+
+        # 提取 collection
+        head = sql[:last_dot_pos].strip()
+
+        conn = self.get_connection(db_name)
+        db = conn[db_name]
+
+        if method == "createCollection":
+            coll = None
+            coll_name = parsed_args[0] if parsed_args else None
+        else:
+            if "getCollection" in head:
+                gc_start = head.find("getCollection")
+                _, gc_args = self.dispose_pair(
+                    head, gc_start + len("getCollection"), "(", ")"
+                )
+                collection = gc_args.strip("()").strip().strip('"').strip("'")
+            else:
+                collection = head.replace("db.", "").strip()
+            coll = db[collection]
+
+        affected_rows = 0
+
+        def _to_bool(v):
+            """将整数 1/0、字符串 '1'/'0'/'true'/'false' 归一化为布尔值"""
+            if isinstance(v, bool):
+                return v
+            if isinstance(v, (int, float)):
+                return bool(v)
+            if isinstance(v, str):
+                s = v.strip().lower()
+                if s in ("true", "1"):
+                    return True
+                if s in ("false", "0"):
+                    return False
+            return v
+
+        def _normalize_bool_opts(opts, keys=("upsert", "multi", "justOne")):
+            """对 opts 中已知布尔选项做类型归一化，避免 pymongo 校验报错"""
+            if isinstance(opts, dict):
+                for k in keys:
+                    if k in opts:
+                        opts[k] = _to_bool(opts[k])
+            return opts
+
+        try:
+            if method == "insertOne":
+                result = coll.insert_one(parsed_args[0])
+                affected_rows = 1
+                result_doc = {
+                    "acknowledged": result.acknowledged,
+                    "insertedId": str(result.inserted_id),
+                }
+            elif method == "insertMany":
+                result = coll.insert_many(parsed_args[0])
+                affected_rows = len(result.inserted_ids)
+                result_doc = {
+                    "acknowledged": result.acknowledged,
+                    "insertedIds": [str(i) for i in result.inserted_ids],
+                }
+            elif method == "insert":
+                if isinstance(parsed_args[0], list):
+                    result = coll.insert_many(parsed_args[0])
+                    affected_rows = len(result.inserted_ids)
+                    result_doc = {
+                        "acknowledged": result.acknowledged,
+                        "insertedIds": [str(i) for i in result.inserted_ids],
+                    }
+                else:
+                    result = coll.insert_one(parsed_args[0])
+                    affected_rows = 1
+                    result_doc = {
+                        "acknowledged": result.acknowledged,
+                        "insertedId": str(result.inserted_id),
+                    }
+            elif method == "updateOne":
+                opts = _normalize_bool_opts(
+                    parsed_args[2] if len(parsed_args) > 2 else {}
+                )
+                result = coll.update_one(
+                    parsed_args[0], parsed_args[1], **(opts or {})
+                )
+                affected_rows = result.modified_count
+                result_doc = {
+                    "acknowledged": result.acknowledged,
+                    "matchedCount": result.matched_count,
+                    "modifiedCount": result.modified_count,
+                }
+            elif method == "updateMany":
+                opts = _normalize_bool_opts(
+                    parsed_args[2] if len(parsed_args) > 2 else {}
+                )
+                result = coll.update_many(
+                    parsed_args[0], parsed_args[1], **(opts or {})
+                )
+                affected_rows = result.modified_count
+                result_doc = {
+                    "acknowledged": result.acknowledged,
+                    "matchedCount": result.matched_count,
+                    "modifiedCount": result.modified_count,
+                }
+            elif method == "update":
+                opts = _normalize_bool_opts(
+                    parsed_args[2] if len(parsed_args) > 2 else {}
+                )
+                opts = opts or {}
+                use_many = (
+                    opts.get("multi", False) if isinstance(opts, dict) else False
+                )
+                if use_many:
+                    result = coll.update_many(
+                        parsed_args[0], parsed_args[1], **opts
+                    )
+                else:
+                    result = coll.update_one(
+                        parsed_args[0], parsed_args[1], **opts
+                    )
+                affected_rows = result.modified_count
+                result_doc = {
+                    "acknowledged": result.acknowledged,
+                    "matchedCount": result.matched_count,
+                    "modifiedCount": result.modified_count,
+                }
+            elif method == "replaceOne":
+                opts = _normalize_bool_opts(
+                    parsed_args[2] if len(parsed_args) > 2 else {}
+                )
+                result = coll.replace_one(
+                    parsed_args[0], parsed_args[1], **(opts or {})
+                )
+                affected_rows = result.modified_count
+                result_doc = {
+                    "acknowledged": result.acknowledged,
+                    "matchedCount": result.matched_count,
+                    "modifiedCount": result.modified_count,
+                }
+            elif method == "deleteOne":
+                opts = _normalize_bool_opts(
+                    parsed_args[1] if len(parsed_args) > 1 else {}
+                )
+                result = coll.delete_one(parsed_args[0], **(opts or {}))
+                affected_rows = result.deleted_count
+                result_doc = {
+                    "acknowledged": result.acknowledged,
+                    "deletedCount": result.deleted_count,
+                }
+            elif method == "deleteMany":
+                opts = _normalize_bool_opts(
+                    parsed_args[1] if len(parsed_args) > 1 else {}
+                )
+                result = coll.delete_many(parsed_args[0], **(opts or {}))
+                affected_rows = result.deleted_count
+                result_doc = {
+                    "acknowledged": result.acknowledged,
+                    "deletedCount": result.deleted_count,
+                }
+            elif method == "remove":
+                opts = _normalize_bool_opts(
+                    parsed_args[1] if len(parsed_args) > 1 else {}
+                )
+                opts = opts or {}
+                just_one = (
+                    opts.get("justOne", False) if isinstance(opts, dict) else False
+                )
+                if just_one:
+                    result = coll.delete_one(parsed_args[0])
+                else:
+                    result = coll.delete_many(parsed_args[0])
+                affected_rows = result.deleted_count
+                result_doc = {
+                    "acknowledged": result.acknowledged,
+                    "deletedCount": result.deleted_count,
+                }
+            elif method == "drop":
+                coll.drop()
+                affected_rows = 0
+                result_doc = {"ok": 1}
+            elif method == "createCollection":
+                coll_name = parsed_args[0] if parsed_args else None
+                opts = parsed_args[1] if len(parsed_args) > 1 else {}
+                db.create_collection(coll_name, **(opts or {}))
+                affected_rows = 0
+                result_doc = {"ok": 1}
+            elif method in ("createIndex", "ensureIndex"):
+                keys = parsed_args[0]
+                if isinstance(keys, dict):
+                    keys = list(keys.items())
+                opts = parsed_args[1] if len(parsed_args) > 1 else {}
+                idx_name = coll.create_index(keys, **(opts or {}))
+                affected_rows = 0
+                result_doc = {"ok": 1, "indexName": idx_name}
+            elif method == "createIndexes":
+                from pymongo.operations import IndexModel
+
+                indexes = []
+                for idx_def in parsed_args[0]:
+                    keys = idx_def.get("key", {})
+                    if isinstance(keys, dict):
+                        keys = list(keys.items())
+                    opts = {k: v for k, v in idx_def.items() if k != "key"}
+                    indexes.append(IndexModel(keys, **opts))
+                idx_names = coll.create_indexes(indexes)
+                affected_rows = 0
+                result_doc = {"ok": 1, "indexNames": idx_names}
+            elif method == "dropIndex":
+                coll.drop_index(parsed_args[0])
+                affected_rows = 0
+                result_doc = {"ok": 1}
+            elif method == "dropIndexes":
+                coll.drop_indexes()
+                affected_rows = 0
+                result_doc = {"ok": 1}
+            elif method == "renameCollection":
+                new_name = parsed_args[0] if parsed_args else None
+                opts = parsed_args[1] if len(parsed_args) > 1 else {}
+                coll.rename(new_name, **(opts or {}))
+                affected_rows = 0
+                result_doc = {"ok": 1}
+            elif method == "convertToCapped":
+                size = parsed_args[0].get("size", 0) if isinstance(parsed_args[0], dict) else parsed_args[0]
+                result = db.command("convertToCapped", collection, size=size)
+                affected_rows = 0
+                result_doc = result
+            elif method == "bulkWrite":
+                from pymongo.operations import (
+                    InsertOne,
+                    UpdateOne,
+                    UpdateMany,
+                    DeleteOne,
+                    DeleteMany,
+                    ReplaceOne,
+                )
+
+                operations = []
+                ops_list = parsed_args[0]
+                opts = parsed_args[1] if len(parsed_args) > 1 else {}
+
+                for op in ops_list:
+                    op_type = list(op.keys())[0]
+                    op_detail = op[op_type]
+                    if op_type == "insertOne":
+                        operations.append(InsertOne(op_detail["document"]))
+                    elif op_type == "updateOne":
+                        operations.append(
+                            UpdateOne(
+                                op_detail["filter"],
+                                op_detail["update"],
+                                upsert=_to_bool(op_detail.get("upsert", False)),
+                            )
+                        )
+                    elif op_type == "updateMany":
+                        operations.append(
+                            UpdateMany(
+                                op_detail["filter"],
+                                op_detail["update"],
+                                upsert=_to_bool(op_detail.get("upsert", False)),
+                            )
+                        )
+                    elif op_type == "deleteOne":
+                        operations.append(DeleteOne(op_detail["filter"]))
+                    elif op_type == "deleteMany":
+                        operations.append(DeleteMany(op_detail["filter"]))
+                    elif op_type == "replaceOne":
+                        operations.append(
+                            ReplaceOne(
+                                op_detail["filter"],
+                                op_detail["replacement"],
+                                upsert=_to_bool(op_detail.get("upsert", False)),
+                            )
+                        )
+
+                result = coll.bulk_write(operations, **(opts or {}))
+                affected_rows = (
+                    result.modified_count
+                    + result.deleted_count
+                    + result.inserted_count
+                )
+                result_doc = {
+                    "acknowledged": result.acknowledged,
+                    "insertedCount": result.inserted_count,
+                    "matchedCount": result.matched_count,
+                    "modifiedCount": result.modified_count,
+                    "deletedCount": result.deleted_count,
+                    "upsertedCount": result.upserted_count,
+                }
+            else:
+                return False, f"暂不支持的语句: {sql}", 0
+
+            return True, json.dumps(result_doc, ensure_ascii=False), affected_rows
+        except Exception:
+            logger.warning(
+                f"mongo pymongo执行报错，语句：{sql}，错误信息{traceback.format_exc()}"
+            )
+            return False, str(traceback.format_exc()), 0
 
     def execute_workflow(self, workflow):
         """执行上线单，返回Review set"""
@@ -444,28 +786,14 @@ class MongoEngine(EngineBase):
             if not exec_sql == "":
                 exec_sql = exec_sql.strip()
                 try:
-                    # DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
                     start = time.perf_counter()
-                    r = self.exec_cmd(exec_sql, db_name)
+
+                    success, r, actual_affected_rows = self._execute_shell_sql(
+                        exec_sql, db_name
+                    )
                     end = time.perf_counter()
                     line += 1
-                    logger.debug("执行结果：" + r)
-                    # 如果执行中有错误
-                    rz = r.replace(" ", "").replace('"', "")
-                    tr = 1
-                    if (
-                        r.lower().find("syntaxerror") >= 0
-                        or rz.find("ok:0") >= 0
-                        or rz.find("error:invalid") >= 0
-                        or rz.find("ReferenceError") >= 0
-                        or rz.find("getErrorWithCode") >= 0
-                        or rz.find("failedtoconnect") >= 0
-                        or rz.find("Error:") >= 0
-                    ):
-                        tr = 0
-                    if (rz.find("errmsg") >= 0 or tr == 0) and (
-                        r.lower().find("already exist") < 0
-                    ):
+                    if not success:
                         execute_result.error = r
                         result = ReviewResult(
                             id=line,
@@ -476,70 +804,11 @@ class MongoEngine(EngineBase):
                             sql=exec_sql,
                         )
                     else:
-                        try:
-                            r = json.loads(r)
-                        except Exception as e:
-                            logger.info(str(e))
-                        finally:
-                            methodStr = exec_sql.split(").")[-1].split("(")[0].strip()
-                            if "." in methodStr:
-                                methodStr = methodStr.split(".")[-1]
-                            if methodStr == "insert":
-                                m = re.search(r'"nInserted"\s*:\s*(\d+)', r)
-                                actual_affected_rows = int(m.group(1))
-                            elif methodStr in ("insertOne", "insertMany"):
-                                if isinstance(r, dict):
-                                    # mongosh / driver JSON formats
-                                    if "nInserted" in r:  # BulkWriteResult style
-                                        actual_affected_rows = r["nInserted"]
-                                    elif (
-                                        "insertedIds" in r
-                                    ):  # CLI acknowledged + insertedIds
-                                        actual_affected_rows = len(r["insertedIds"])
-                                    elif "insertedId" in r:  # insertOne single id
-                                        actual_affected_rows = 1
-                                    else:
-                                        actual_affected_rows = 0
-                                elif isinstance(r, str):
-                                    # mongo 4.x CLI string outputs
-                                    m = re.search(r'"nInserted"\s*:\s*(\d+)', r)
-                                    actual_affected_rows = (
-                                        int(m.group(1)) if m else r.count("ObjectId")
-                                    )
-                                    actual_affected_rows = r.count("ObjectId")
-                                else:
-                                    actual_affected_rows = 0
-                            elif methodStr == "update":
-                                m = re.search(
-                                    r'(?:"modifiedCount"|"nModified")\s*:\s*(\d+)',
-                                    r,
-                                )
-                                actual_affected_rows = int(m.group(1))
-                            elif methodStr in ("updateOne", "updateMany"):
-                                if isinstance(r, dict):
-                                    actual_affected_rows = r.get(
-                                        "modifiedCount", r.get("nModified", 0)
-                                    )
-                                elif isinstance(r, str):
-                                    m = re.search(
-                                        r'(?:"modifiedCount"|"nModified")\s*:\s*(\d+)',
-                                        r,
-                                    )
-                                    actual_affected_rows = int(m.group(1)) if m else 0
-                                else:
-                                    actual_affected_rows = 0
-                            elif methodStr in ("deleteOne", "deleteMany"):
-                                actual_affected_rows = r.get("deletedCount", 0)
-                            elif methodStr == "remove":
-                                actual_affected_rows = r.get("nRemoved", 0)
-                            else:
-                                actual_affected_rows = 0
-                        # 把结果转换为ReviewSet
                         result = ReviewResult(
                             id=line,
                             errlevel=0,
                             stagestatus="执行结束",
-                            errormessage=str(r),
+                            errormessage=r,
                             execute_time=round(end - start, 6),
                             affected_rows=actual_affected_rows,
                             sql=exec_sql,
@@ -1033,6 +1302,54 @@ class MongoEngine(EngineBase):
                     query_dict["collection"] = collection
                 elif method.lower() == "getindexes":
                     query_dict["method"] = "index_information"
+                elif method == "count":
+                    query_dict["method"] = "count"
+                    if "condition" not in query_dict:
+                        query_dict["condition"] = re_char
+                    query_dict["count"] = re_char
+                elif method == "findOne":
+                    query_dict["method"] = method
+                    if re_char.strip():
+                        try:
+                            p_index, fo_condition = self.dispose_pair(
+                                re_char, 0, "{", "}"
+                            )
+                            query_dict["findOne_filter"] = fo_condition or "{}"
+                            # dispose_pair 返回的 p_index 指向闭合大括号本身，需跳过
+                            fo_projection = (
+                                re_char[p_index + 1:].strip().lstrip(",").strip()
+                            )
+                            if fo_projection:
+                                query_dict["findOne_projection"] = fo_projection
+                        except Exception:
+                            query_dict["findOne_filter"] = "{}"
+                    else:
+                        query_dict["findOne_filter"] = "{}"
+                elif method == "countDocuments":
+                    query_dict["method"] = method
+                    if re_char.strip():
+                        try:
+                            p_index, cd_condition = self.dispose_pair(
+                                re_char, 0, "{", "}"
+                            )
+                            query_dict["countDocuments_filter"] = (
+                                cd_condition or "{}"
+                            )
+                            # dispose_pair 返回的 p_index 指向闭合大括号本身，需跳过
+                            cd_opts = (
+                                re_char[p_index + 1:].strip().lstrip(",").strip()
+                            )
+                            if cd_opts:
+                                query_dict["countDocuments_options"] = cd_opts
+                        except Exception:
+                            query_dict["countDocuments_filter"] = "{}"
+                    else:
+                        query_dict["countDocuments_filter"] = "{}"
+                elif method == "distinct":
+                    query_dict["method"] = method
+                    query_dict["distinct_args"] = re_char
+                elif method == "stats":
+                    query_dict["method"] = method
                 else:
                     query_dict[method] = re_char
             index += 1
@@ -1105,6 +1422,9 @@ class MongoEngine(EngineBase):
                 condition.append({"$limit": limit_num})
             if method == "find":
                 condition = de.decode(query_dict["condition"])
+            if method == "count":
+                condition = de.decode(query_dict["condition"]) if query_dict.get("condition") else {}
+                condition = condition or {}
             find_cmd += "(condition)"
         if "projection" in query_dict and query_dict["projection"]:
             projection = de.decode(query_dict["projection"])
@@ -1135,6 +1455,44 @@ class MongoEngine(EngineBase):
         if "explain" in query_dict:
             find_cmd += ".explain()"
 
+        # 覆盖 findOne/countDocuments/distinct/stats 对应的 pymongo 命令
+        if method == "findOne":
+            findone_filter = (
+                de.decode(query_dict.get("findOne_filter", "{}")) or {}
+            )
+            if "findOne_projection" in query_dict:
+                findone_projection = de.decode(query_dict["findOne_projection"])
+                find_cmd = "collection.find_one(findone_filter, findone_projection)"
+            else:
+                find_cmd = "collection.find_one(findone_filter)"
+        elif method == "countDocuments":
+            countdoc_filter = (
+                de.decode(query_dict.get("countDocuments_filter", "{}")) or {}
+            )
+            if "countDocuments_options" in query_dict:
+                countdoc_options = (
+                    de.decode(query_dict["countDocuments_options"]) or {}
+                )
+                find_cmd = (
+                    "collection.count_documents(countdoc_filter, **countdoc_options)"
+                )
+            else:
+                find_cmd = "collection.count_documents(countdoc_filter)"
+        elif method == "distinct":
+            distinct_parts = self.__split_args(
+                query_dict.get("distinct_args", "")
+            ) or [""]
+            distinct_field = (
+                distinct_parts[0].strip().strip('"').strip("'")
+            )
+            if len(distinct_parts) > 1 and distinct_parts[1].strip():
+                distinct_filter = de.decode(distinct_parts[1]) or {}
+                find_cmd = "collection.distinct(distinct_field, distinct_filter)"
+            else:
+                find_cmd = "collection.distinct(distinct_field)"
+        elif method == "stats":
+            find_cmd = 'db.command("collStats", collection_name)'
+
         try:
             conn = self.get_connection()
             db = conn[db_name]
@@ -1159,6 +1517,27 @@ class MongoEngine(EngineBase):
                 columns.append("index_list")
                 for k, v in cursor.items():
                     rows.append({k: v})
+            elif method == "findOne":
+                columns.append("findOne")
+                if cursor is None:
+                    rows = []
+                else:
+                    doc = json.loads(json_util.dumps(cursor))
+                    rows = [doc]
+            elif method == "countDocuments":
+                columns.append("count")
+                rows.append({"count": cursor})
+            elif method == "distinct":
+                columns.append("distinct")
+                distinct_values = json.loads(json_util.dumps(cursor))
+                for v in distinct_values:
+                    rows.append({"value": v})
+            elif method == "stats":
+                columns.append("stats")
+                stats_result = json.loads(json_util.dumps(cursor))
+                for k, v in stats_result.items():
+                    if k != "ok":
+                        rows.append({k: v})
             elif method == "aggregate" and sql.find("$group") >= 0:  # 生成聚合数据
                 row = []
                 columns.insert(0, "mongodballdata")

--- a/sql/engines/test_mongo.py
+++ b/sql/engines/test_mongo.py
@@ -1,9 +1,16 @@
 import pytest
+import json
+import datetime
 from unittest.mock import patch, MagicMock
-from sql.engines.mongo import MongoEngine
+from bson.objectid import ObjectId
+from bson.int64 import Int64
+
+from sql.engines.mongo import MongoEngine, JsonDecoder, mongo_error
+from sql.engines.models import ResultSet
 
 
-# 创建MongoEngine测试实例的fixture
+# ====================== Fixtures ======================
+
 @pytest.fixture
 def mongo_engine():
     engine = MongoEngine()
@@ -13,348 +20,1270 @@ def mongo_engine():
     engine.password = "test_password"
     engine.instance = MagicMock()
     engine.instance.db_name = "test_db"
+    engine.instance.is_ssl = False
+    engine.instance.verify_ssl = True
     return engine
 
 
-# 测试带load参数的命令生成
-def test_build_cmd_with_load(mongo_engine):
-    # Call the method with is_load=True
-    cmd = mongo_engine._build_cmd(
-        db_name="test_db",
-        auth_db="admin",
-        slave_ok="rs.slaveOk();",
-        tempfile_="/tmp/test.js",
-        is_load=True,
-    )
-
-    # Expected command template
-    expected_cmd = (
-        "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-        "db=db.getSiblingDB('test_db');rs.slaveOk();load('/tmp/test.js')\nEOF"
-    )
-
-    # Assertions
-    assert cmd == expected_cmd
+def _mock_collection(mongo_engine):
+    """创建一个通用的 conn/db/collection mock 并挂载到 engine 上"""
+    mock_conn = MagicMock()
+    mock_db = MagicMock()
+    mock_coll = MagicMock()
+    mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+    mock_db.__getitem__ = MagicMock(return_value=mock_coll)
+    mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+    return mock_conn, mock_db, mock_coll
 
 
-# 测试不带load参数的命令生成
-def test_build_cmd_without_load(mongo_engine):
-    # Call the method with is_load=False
-    cmd = mongo_engine._build_cmd(
-        db_name="test_db",
-        auth_db="admin",
-        slave_ok="rs.slaveOk();",
-        sql="db.test_collection.find()",
-        is_load=False,
-    )
+# ====================== mongo_error ======================
 
-    # Expected command template
-    expected_cmd = (
-        "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-        "db=db.getSiblingDB('test_db');rs.slaveOk();db.test_collection.find()\nEOF"
-    )
-
-    # Assertions
-    assert cmd == expected_cmd
+class TestMongoError:
+    def test_mongo_error_str(self):
+        err = mongo_error("failed")
+        assert str(err) == "failed"
 
 
-# 测试无认证信息时命令生成
-def test_build_cmd_without_auth(mongo_engine):
-    # Set user and password to None
-    mongo_engine.user = None
-    mongo_engine.password = None
+# ====================== JsonDecoder ======================
 
-    # Call the method with is_load=False
-    cmd = mongo_engine._build_cmd(
-        db_name="test_db",
-        auth_db="admin",
-        slave_ok="rs.slaveOk();",
-        sql="db.test_collection.find()",
-        is_load=False,
-    )
+class TestJsonDecoder:
+    def setup_method(self):
+        self.de = JsonDecoder()
 
-    # Expected command template
-    expected_cmd = (
-        "mongo --quiet  localhost:27017/admin <<\\EOF\n"
-        "db=db.getSiblingDB('test_db');rs.slaveOk();db.test_collection.find()\nEOF"
-    )
+    def test_decode_simple_object(self):
+        assert self.de.decode("{'a':1}") == {"a": 1}
 
-    # Assertions
-    assert cmd == expected_cmd
+    def test_decode_nested_object(self):
+        assert self.de.decode("{'a':{'b':2}}") == {"a": {"b": 2}}
+
+    def test_decode_array(self):
+        assert self.de.decode("[1,2,3]") == [1, 2, 3]
+
+    def test_decode_array_of_objects(self):
+        assert self.de.decode("[{'a':1},{'b':2}]") == [{"a": 1}, {"b": 2}]
+
+    def test_decode_bool_and_null(self):
+        assert self.de.decode("{'a':true,'b':false,'c':null}") == {
+            "a": True,
+            "b": False,
+            "c": None,
+        }
+
+    def test_decode_empty_object(self):
+        assert self.de.decode("{}") == {}
+
+    def test_decode_empty_array(self):
+        assert self.de.decode("[]") == []
+
+    def test_decode_none_when_empty_string(self):
+        assert self.de.decode("") is None
+
+    def test_decode_invalid_start(self):
+        with pytest.raises(Exception, match='Json must start with'):
+            self.de.decode("123")
+
+    def test_decode_objectid(self):
+        val = self.de.decode("{'_id':ObjectId('507f1f77bcf86cd799439011')}")
+        assert isinstance(val["_id"], ObjectId)
+
+    def test_decode_number_long(self):
+        val = self.de.decode("{'n':NumberLong('123456789')}")
+        assert isinstance(val["n"], Int64)
+        assert int(val["n"]) == 123456789
+
+    def test_decode_isodate(self):
+        val = self.de.decode('{"t":ISODate("2024-01-01")}')
+        assert isinstance(val["t"], datetime.datetime)
+
+    def test_decode_float(self):
+        val = self.de.decode("{'a':1.5}")
+        assert val["a"] == 1.5
+
+    def test_decode_negative_number(self):
+        val = self.de.decode("{'a':-10}")
+        assert val["a"] == -10
 
 
-# 测试无认证信息且带load参数的命令生成
-def test_build_cmd_with_load_without_auth(mongo_engine):
-    # Set user and password to None
-    mongo_engine.user = None
-    mongo_engine.password = None
+# ====================== __split_args ======================
 
-    # Call the method with is_load=True
-    cmd = mongo_engine._build_cmd(
-        db_name="test_db",
-        auth_db="admin",
-        slave_ok="rs.slaveOk();",
-        tempfile_="/tmp/test.js",
-        is_load=True,
-    )
+class TestSplitArgs:
+    def test_basic_args(self, mongo_engine):
+        result = mongo_engine._MongoEngine__split_args("1, 2, 3")
+        assert result == ["1", "2", "3"]
 
-    # Expected command template
-    expected_cmd = (
-        "mongo --quiet  localhost:27017/admin <<\\EOF\n"
-        "db=db.getSiblingDB('test_db');rs.slaveOk();load('/tmp/test.js')\nEOF"
-    )
+    def test_nested_json(self, mongo_engine):
+        args_str = "{'a':1}, {'b': {'c': 2}}, [1, 2, 3]"
+        result = mongo_engine._MongoEngine__split_args(args_str)
+        assert len(result) == 3
+        assert result[0] == "{'a':1}"
+        assert result[1] == "{'b': {'c': 2}}"
+        assert result[2] == "[1, 2, 3]"
 
-    # Assertions
-    assert cmd == expected_cmd
+    def test_string_with_comma(self, mongo_engine):
+        args_str = "{'name': 'a,b'}, {'age': 20}"
+        result = mongo_engine._MongoEngine__split_args(args_str)
+        assert len(result) == 2
+        assert result[0] == "{'name': 'a,b'}"
+
+    def test_parentheses_nested(self, mongo_engine):
+        args_str = "({'a':1}, {'$set':{'b':2}}, {upsert:true})"
+        result = mongo_engine._MongoEngine__split_args(args_str[1:-1])
+        assert len(result) == 3
+
+    def test_empty_string(self, mongo_engine):
+        assert mongo_engine._MongoEngine__split_args("") == []
+
+    def test_single_arg(self, mongo_engine):
+        assert mongo_engine._MongoEngine__split_args("abc") == ["abc"]
 
 
-# 参数化测试多种Mongo命令的生成
-@pytest.mark.parametrize(
-    "params,expected_cmd",
-    [
-        # 基础 find 查询
-        (
-            dict(
+# ====================== _execute_shell_sql ======================
+
+class TestExecuteShellSql:
+    def _mock_collection(self, mongo_engine):
+        _, _, mock_coll = _mock_collection(mongo_engine)
+        return mock_coll
+
+    def test_insertOne(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.acknowledged = True
+        mock_result.inserted_id = "abc123"
+        mock_coll.insert_one.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.insertOne({'name':'archery'})", "test_db"
+        )
+        assert success is True
+        assert affected == 1
+        result_doc = json.loads(result)
+        assert result_doc["insertedId"] == "abc123"
+
+    def test_insertMany(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.acknowledged = True
+        mock_result.inserted_ids = ["id1", "id2"]
+        mock_coll.insert_many.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.insertMany([{'a':1},{'b':2}])", "test_db"
+        )
+        assert success is True
+        assert affected == 2
+
+    def test_insert_list(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.acknowledged = True
+        mock_result.inserted_ids = ["id1"]
+        mock_coll.insert_many.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.insert([{'a':1}])", "test_db"
+        )
+        assert success is True
+        assert affected == 1
+
+    def test_insert_single_doc(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.acknowledged = True
+        mock_result.inserted_id = "id1"
+        mock_coll.insert_one.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.insert({'a':1})", "test_db"
+        )
+        assert success is True
+        assert affected == 1
+        mock_coll.insert_one.assert_called_once()
+
+    def test_updateOne(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.acknowledged = True
+        mock_result.matched_count = 1
+        mock_result.modified_count = 1
+        mock_coll.update_one.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.updateOne({'a':1},{'$set':{'b':2}})", "test_db"
+        )
+        assert success is True
+        assert affected == 1
+        result_doc = json.loads(result)
+        assert result_doc["modifiedCount"] == 1
+
+    def test_updateOne_with_upsert(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.modified_count = 1
+        mock_coll.update_one.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.updateOne({'a':1},{'$set':{'b':2}},{'upsert':true})",
+            "test_db",
+        )
+        assert success is True
+        _, kwargs = mock_coll.update_one.call_args
+        assert kwargs.get("upsert") is True
+
+    def test_updateMany(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.modified_count = 5
+        mock_coll.update_many.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.updateMany({'a':1},{'$set':{'b':2}})", "test_db"
+        )
+        assert success is True
+        assert affected == 5
+
+    def test_update_with_multi(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.modified_count = 3
+        mock_coll.update_many.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.update({'a':1},{'$set':{'b':2}},{'multi':true})", "test_db"
+        )
+        assert success is True
+        assert affected == 3
+        mock_coll.update_many.assert_called_once()
+
+    def test_update_without_multi(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.modified_count = 1
+        mock_coll.update_one.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.update({'a':1},{'$set':{'b':2}})", "test_db"
+        )
+        assert success is True
+        assert affected == 1
+        mock_coll.update_one.assert_called_once()
+
+    def test_replaceOne(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.modified_count = 1
+        mock_coll.replace_one.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.replaceOne({'a':1},{'b':2})", "test_db"
+        )
+        assert success is True
+        assert affected == 1
+
+    def test_deleteOne(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.deleted_count = 1
+        mock_coll.delete_one.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.deleteOne({'a':1})", "test_db"
+        )
+        assert success is True
+        assert affected == 1
+
+    def test_deleteMany(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.deleted_count = 5
+        mock_coll.delete_many.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.deleteMany({'a':1})", "test_db"
+        )
+        assert success is True
+        assert affected == 5
+
+    def test_remove_justOne(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.deleted_count = 1
+        mock_coll.delete_one.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.remove({'a':1},{'justOne':true})", "test_db"
+        )
+        assert success is True
+        assert affected == 1
+        mock_coll.delete_one.assert_called_once()
+
+    def test_remove_many(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.deleted_count = 3
+        mock_coll.delete_many.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.remove({'a':1})", "test_db"
+        )
+        assert success is True
+        assert affected == 3
+        mock_coll.delete_many.assert_called_once()
+
+    def test_drop(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.drop()", "test_db"
+        )
+        assert success is True
+        assert affected == 0
+        mock_coll.drop.assert_called_once()
+
+    def test_createCollection(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_db = MagicMock()
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.createCollection('new_coll',{'capped':true})", "test_db"
+        )
+        assert success is True
+        assert affected == 0
+        mock_db.create_collection.assert_called_once_with("new_coll", capped=True)
+
+    def test_createIndex(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_coll.create_index.return_value = "name_1"
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.createIndex({'name':1},{'background':true})", "test_db"
+        )
+        assert success is True
+        assert affected == 0
+        result_doc = json.loads(result)
+        assert result_doc["indexName"] == "name_1"
+
+    def test_ensureIndex(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_coll.create_index.return_value = "age_1"
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.ensureIndex({'age':1})", "test_db"
+        )
+        assert success is True
+        result_doc = json.loads(result)
+        assert result_doc["indexName"] == "age_1"
+
+    def test_dropIndex(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.dropIndex('name_1')", "test_db"
+        )
+        assert success is True
+        mock_coll.drop_index.assert_called_once_with("name_1")
+
+    def test_dropIndexes(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.dropIndexes()", "test_db"
+        )
+        assert success is True
+        mock_coll.drop_indexes.assert_called_once()
+
+    def test_renameCollection(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.renameCollection('new_name')", "test_db"
+        )
+        assert success is True
+        mock_coll.rename.assert_called_once_with("new_name")
+
+    def test_bulkWrite(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.modified_count = 1
+        mock_result.deleted_count = 1
+        mock_result.inserted_count = 1
+        mock_result.upserted_count = 0
+        mock_result.matched_count = 1
+        mock_result.acknowledged = True
+        mock_coll.bulk_write.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.bulkWrite([{'insertOne':{'document':{'a':1}}},{'updateOne':{'filter':{'a':1},'update':{'$set':{'b':2}}}}])",
+            "test_db",
+        )
+        assert success is True
+        assert affected == 3
+        mock_coll.bulk_write.assert_called_once()
+
+    def test_unsupported_statement(self, mongo_engine):
+        self._mock_collection(mongo_engine)
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.unknownMethod()", "test_db"
+        )
+        assert success is False
+        assert "暂不支持的语句" in result
+
+    def test_getCollection_syntax(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_result = MagicMock()
+        mock_result.deleted_count = 2
+        mock_coll.delete_many.return_value = mock_result
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            'db.getCollection("test").deleteMany({"a":1})', "test_db"
+        )
+        assert success is True
+        assert affected == 2
+
+    def test_exception_handling(self, mongo_engine):
+        mock_coll = self._mock_collection(mongo_engine)
+        mock_coll.insert_one.side_effect = Exception("insert failed")
+
+        success, result, affected = mongo_engine._execute_shell_sql(
+            "db.test.insertOne({'a':1})", "test_db"
+        )
+        assert success is False
+        assert affected == 0
+
+
+# ====================== get_master ======================
+
+class TestGetMaster:
+    def test_get_master_success(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.admin.command.return_value = {"primary": "192.168.1.10:27017"}
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        mongo_engine.get_master()
+        assert mongo_engine.host == "192.168.1.10"
+        assert mongo_engine.port == 27017
+
+    def test_get_master_undefined(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.admin.command.return_value = {"primary": "undefined"}
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        mongo_engine.get_master()
+        assert mongo_engine.host == "localhost"
+
+    def test_get_master_no_primary(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.admin.command.return_value = {}
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        mongo_engine.get_master()
+        assert mongo_engine.host == "localhost"
+
+    def test_get_master_exception(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.admin.command.side_effect = Exception("conn failed")
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        mongo_engine.get_master()
+        assert mongo_engine.host == "localhost"
+
+
+# ====================== get_slave ======================
+
+class TestGetSlave:
+    def test_get_slave_success(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.admin.command.return_value = {
+            "members": [
+                {"stateStr": "PRIMARY", "name": "host1:27017"},
+                {"stateStr": "SECONDARY", "name": "host2:27018"},
+            ]
+        }
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.get_slave()
+        assert result is True
+        assert mongo_engine.host == "host2"
+        assert mongo_engine.port == 27018
+
+    def test_get_slave_aliyun(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.admin.command.return_value = {
+            "members": [
+                {"stateStr": "SECONDARY", "name": "SECONDARY"},
+            ]
+        }
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.get_slave()
+        assert result is False
+
+    def test_get_slave_no_secondary(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.admin.command.return_value = {"members": []}
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.get_slave()
+        assert result is False
+
+    def test_get_slave_exception(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.admin.command.side_effect = Exception("conn failed")
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.get_slave()
+        assert result is False
+
+
+# ====================== execute ======================
+
+class TestExecute:
+    @patch.object(MongoEngine, "get_master")
+    def test_execute_success(self, mock_get_master, mongo_engine):
+        with patch.object(mongo_engine, "_execute_shell_sql") as mock_exec:
+            mock_exec.return_value = (True, '{"ok":1}', 1)
+            result = mongo_engine.execute(
+                db_name="test_db", sql="db.test.insertOne({'a':1})"
+            )
+            assert result.error is None
+            assert len(result.rows) == 1
+            assert result.rows[0].affected_rows == 1
+            assert result.rows[0].stagestatus == "执行结束"
+
+    @patch.object(MongoEngine, "get_master")
+    def test_execute_failure(self, mock_get_master, mongo_engine):
+        with patch.object(mongo_engine, "_execute_shell_sql") as mock_exec:
+            mock_exec.return_value = (False, "some error", 0)
+            result = mongo_engine.execute(
+                db_name="test_db", sql="db.test.insertOne({'a':1})"
+            )
+            assert result.error == "some error"
+            assert result.rows[0].errlevel == 2
+
+    @patch.object(MongoEngine, "get_master")
+    def test_execute_multi_statement(self, mock_get_master, mongo_engine):
+        with patch.object(mongo_engine, "_execute_shell_sql") as mock_exec:
+            mock_exec.side_effect = [
+                (True, '{"ok":1}', 1),
+                (True, '{"ok":1}', 5),
+            ]
+            result = mongo_engine.execute(
                 db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.find({})",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.find({})\nEOF",
-        ),
-        # find 带条件
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.find({'name':'archery'})",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.find({'name':'archery'})\nEOF",
-        ),
-        # aggregate 查询
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.aggregate([{'$match':{'age':{'$gt':18}}}])",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.aggregate([{'$match':{'age':{'$gt':18}}}])\nEOF",
-        ),
-        # count 查询
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.count({'status':'active'})",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.count({'status':'active'})\nEOF",
-        ),
-        # explain 查询
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.find({'score':{'$gte':90}}).explain()",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.find({'score':{'$gte':90}}).explain()\nEOF",
-        ),
-        # find 带 sort/limit/skip
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.find({}).sort({'age':-1}).limit(10).skip(5)",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.find({}).sort({'age':-1}).limit(10).skip(5)\nEOF",
-        ),
-        # findOne 查询
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.findOne({'_id':ObjectId('507f1f77bcf86cd799439011')})",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.findOne({'_id':ObjectId('507f1f77bcf86cd799439011')})\nEOF",
-        ),
-        # insertOne
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.insertOne({'name':'archery','age':20})",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.insertOne({'name':'archery','age':20})\nEOF",
-        ),
-        # updateMany
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.updateMany({'status':'active'},{'$set':{'score':100}})",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.updateMany({'status':'active'},{'$set':{'score':100}})\nEOF",
-        ),
-        # deleteMany
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.deleteMany({'expired':true})",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.deleteMany({'expired':true})\nEOF",
-        ),
-        # createIndex
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.createIndex({'name':1},{'background':true})",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.createIndex({'name':1},{'background':true})\nEOF",
-        ),
-        # dropIndex
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.test_collection.dropIndex('name_1')",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.test_collection.dropIndex('name_1')\nEOF",
-        ),
-        # createCollection
-        (
-            dict(
-                db_name="test_db",
-                auth_db="admin",
-                slave_ok="",
-                sql="db.createCollection('new_collection')",
-                is_load=False,
-            ),
-            "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-            "db=db.getSiblingDB('test_db');db.createCollection('new_collection')\nEOF",
-        ),
-    ],
-)
-def test_build_cmd_various_queries(mongo_engine, params, expected_cmd):
-    # 测试多种Mongo命令的生成
-    cmd = mongo_engine._build_cmd(**params)
-    assert cmd == expected_cmd
+                sql="db.test.insertOne({'a':1});db.test.updateMany({'a':1},{'$set':{'b':2}})",
+            )
+            assert len(result.rows) == 2
+            assert result.rows[0].affected_rows == 1
+            assert result.rows[1].affected_rows == 5
+
+    @patch.object(MongoEngine, "get_master")
+    def test_execute_empty_sql(self, mock_get_master, mongo_engine):
+        result = mongo_engine.execute(db_name="test_db", sql="")
+        assert len(result.rows) == 0
+
+    @patch.object(MongoEngine, "get_master")
+    def test_execute_workflow(self, mock_get_master, mongo_engine):
+        workflow = MagicMock()
+        workflow.db_name = "test_db"
+        workflow.sqlworkflowcontent.sql_content = "db.test.insertOne({'a':1})"
+        with patch.object(mongo_engine, "_execute_shell_sql") as mock_exec:
+            mock_exec.return_value = (True, '{"ok":1}', 1)
+            result = mongo_engine.execute_workflow(workflow)
+            assert len(result.rows) == 1
 
 
-# 测试带slave_ok参数的命令生成
-def test_build_cmd_with_slave_ok(mongo_engine):
-    cmd = mongo_engine._build_cmd(
-        db_name="test_db",
-        auth_db="admin",
-        slave_ok="rs.slaveOk();",
-        sql="db.test_collection.find()",
-        is_load=False,
-    )
-    expected_cmd = (
-        "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-        "db=db.getSiblingDB('test_db');rs.slaveOk();db.test_collection.find()\nEOF"
-    )
-    assert cmd == expected_cmd
+# ====================== execute_check ======================
+
+class TestExecuteCheck:
+    @patch("sql.engines.mongo.SysConfig")
+    @patch.object(MongoEngine, "get_all_tables")
+    def test_execute_check_insertOne(self, mock_get_tables, mock_sys_config, mongo_engine):
+        mock_get_tables.return_value = MagicMock(rows=["test"])
+        mock_sys_config.return_value.get.return_value = False
+        result = mongo_engine.execute_check(
+            db_name="test_db", sql="db.test.insertOne({'a':1});"
+        )
+        assert result.error_count == 0
+        assert result.rows[0].stagestatus == "Audit completed"
+
+    @patch("sql.engines.mongo.SysConfig")
+    @patch.object(MongoEngine, "get_all_tables")
+    def test_execute_check_unsupported(self, mock_get_tables, mock_sys_config, mongo_engine):
+        mock_get_tables.return_value = MagicMock(rows=["test"])
+        mock_sys_config.return_value.get.return_value = False
+        result = mongo_engine.execute_check(
+            db_name="test_db", sql="db.test.unknownMethod();"
+        )
+        assert result.error_count == 1
+        assert result.rows[0].stagestatus == "驳回不支持语句"
+
+    @patch("sql.engines.mongo.SysConfig")
+    @patch.object(MongoEngine, "get_all_tables")
+    def test_execute_check_no_semicolon(self, mock_get_tables, mock_sys_config, mongo_engine):
+        mock_get_tables.return_value = MagicMock(rows=["test"])
+        mock_sys_config.return_value.get.return_value = False
+        with pytest.raises(Exception, match="请以分号结尾"):
+            mongo_engine.execute_check(
+                db_name="test_db", sql="db.test.insertOne({'a':1})"
+            )
+
+    @patch("sql.engines.mongo.SysConfig")
+    @patch.object(MongoEngine, "get_all_tables")
+    def test_execute_check_table_not_exists(self, mock_get_tables, mock_sys_config, mongo_engine):
+        mock_get_tables.return_value = MagicMock(rows=["other"])
+        mock_sys_config.return_value.get.return_value = False
+        result = mongo_engine.execute_check(
+            db_name="test_db", sql="db.test.drop();"
+        )
+        assert result.error_count == 1
+        assert result.rows[0].stagestatus == "文档不存在"
+
+    @patch("sql.engines.mongo.SysConfig")
+    @patch.object(MongoEngine, "get_all_tables")
+    def test_execute_check_createCollection_exists(
+        self, mock_get_tables, mock_sys_config, mongo_engine
+    ):
+        mock_get_tables.return_value = MagicMock(rows=["test"])
+        mock_sys_config.return_value.get.return_value = False
+        result = mongo_engine.execute_check(
+            db_name="test_db", sql="db.createCollection('test');"
+        )
+        assert result.error_count == 1
+        assert result.rows[0].stagestatus == "文档已经存在"
+
+    @patch("sql.engines.mongo.SysConfig")
+    @patch.object(MongoEngine, "get_all_tables")
+    def test_execute_check_createIndex_no_background(
+        self, mock_get_tables, mock_sys_config, mongo_engine
+    ):
+        mock_get_tables.return_value = MagicMock(rows=["test"])
+        mock_sys_config.return_value.get.return_value = False
+        result = mongo_engine.execute_check(
+            db_name="test_db", sql="db.test.createIndex({'name':1});"
+        )
+        assert result.error_count == 1
+        assert result.rows[0].stagestatus == "后台创建索引"
+
+    @patch("sql.engines.mongo.SysConfig")
+    @patch.object(MongoEngine, "get_all_tables")
+    def test_execute_check_syntax_error(
+        self, mock_get_tables, mock_sys_config, mongo_engine
+    ):
+        mock_get_tables.return_value = MagicMock(rows=["test"])
+        mock_sys_config.return_value.get.return_value = False
+        result = mongo_engine.execute_check(
+            db_name="test_db", sql="SELECT * FROM test;"
+        )
+        assert result.error_count == 1
+        assert result.rows[0].stagestatus == "语法错误"
 
 
-# 测试db_name为空时命令生成
-def test_build_cmd_with_empty_db_name(mongo_engine):
-    cmd = mongo_engine._build_cmd(
-        db_name="",
-        auth_db="admin",
-        slave_ok="",
-        sql="db.test_collection.find()",
-        is_load=False,
-    )
-    expected_cmd = (
-        "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-        "db=db.getSiblingDB('');db.test_collection.find()\nEOF"
-    )
-    assert cmd == expected_cmd
+# ====================== get_connection / close ======================
+
+class TestGetConnection:
+    @patch("sql.engines.mongo.pymongo.MongoClient")
+    def test_get_connection(self, mock_client, mongo_engine):
+        mock_instance = MagicMock()
+        mock_client.return_value = mock_instance
+        conn = mongo_engine.get_connection("test_db")
+        assert conn is mock_instance
+        assert mongo_engine.db_name == "test_db"
+        mock_client.assert_called_once()
+
+    @patch("sql.engines.mongo.pymongo.MongoClient")
+    def test_get_connection_default_db(self, mock_client, mongo_engine):
+        mongo_engine.instance.db_name = ""
+        mock_client.return_value = MagicMock()
+        mongo_engine.get_connection()
+        assert mongo_engine.db_name == "admin"
+
+    @patch("sql.engines.mongo.pymongo.MongoClient")
+    def test_get_connection_with_tls(self, mock_client, mongo_engine):
+        mongo_engine.instance.is_ssl = True
+        mongo_engine.instance.verify_ssl = False
+        mock_client.return_value = MagicMock()
+        mongo_engine.get_connection("test_db")
+        _, kwargs = mock_client.call_args
+        assert kwargs.get("tls") is True
+        assert kwargs.get("tlsInsecure") is True
+
+    @patch("sql.engines.mongo.pymongo.MongoClient")
+    def test_get_connection_without_auth(self, mock_client, mongo_engine):
+        mongo_engine.user = ""
+        mongo_engine.password = ""
+        mock_client.return_value = MagicMock()
+        mongo_engine.get_connection("test_db")
+        mock_client.assert_called_once()
 
 
-# 测试user和password为None时命令生成
-def test_build_cmd_with_none_user_password(mongo_engine):
-    mongo_engine.user = None
-    mongo_engine.password = None
-    cmd = mongo_engine._build_cmd(
-        db_name="test_db",
-        auth_db="admin",
-        slave_ok="",
-        sql="db.test_collection.find()",
-        is_load=False,
-    )
-    expected_cmd = (
-        "mongo --quiet  localhost:27017/admin <<\\EOF\n"
-        "db=db.getSiblingDB('test_db');db.test_collection.find()\nEOF"
-    )
-    assert cmd == expected_cmd
+class TestClose:
+    def test_close(self, mongo_engine):
+        mock_conn = MagicMock()
+        mongo_engine.conn = mock_conn
+        mongo_engine.close()
+        mock_conn.close.assert_called_once()
+        assert mongo_engine.conn is None
 
 
-# 测试带load和slave_ok参数的命令生成
-def test_build_cmd_with_load_and_slave_ok(mongo_engine):
-    cmd = mongo_engine._build_cmd(
-        db_name="test_db",
-        auth_db="admin",
-        slave_ok="rs.slaveOk();",
-        tempfile_="/tmp/test.js",
-        is_load=True,
-    )
-    expected_cmd = (
-        "mongo --quiet -u test_user -p 'test_password' localhost:27017/admin <<\\EOF\n"
-        "db=db.getSiblingDB('test_db');rs.slaveOk();load('/tmp/test.js')\nEOF"
-    )
-    assert cmd == expected_cmd
+# ====================== get_all_databases / tables ======================
+
+class TestGetAllDatabases:
+    def test_get_all_databases(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.list_database_names.return_value = ["db1", "db2"]
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.get_all_databases()
+        assert isinstance(result, ResultSet)
+        assert result.rows == ["db1", "db2"]
+
+    def test_get_all_databases_operation_failure(self, mongo_engine):
+        from pymongo.errors import OperationFailure
+
+        mock_conn = MagicMock()
+        mock_conn.list_database_names.side_effect = OperationFailure("auth failed")
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+        mongo_engine.db_name = "test_db"
+
+        result = mongo_engine.get_all_databases()
+        assert result.rows == ["test_db"]
+
+    def test_test_connection(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.list_database_names.return_value = ["db1"]
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+        result = mongo_engine.test_connection()
+        assert result.rows == ["db1"]
 
 
-# 测试无认证信息且带load和slave_ok参数的命令生成
-def test_build_cmd_with_load_without_auth_and_slave_ok(mongo_engine):
-    mongo_engine.user = None
-    mongo_engine.password = None
-    cmd = mongo_engine._build_cmd(
-        db_name="test_db",
-        auth_db="admin",
-        slave_ok="rs.slaveOk();",
-        tempfile_="/tmp/test.js",
-        is_load=True,
-    )
-    expected_cmd = (
-        "mongo --quiet  localhost:27017/admin <<\\EOF\n"
-        "db=db.getSiblingDB('test_db');rs.slaveOk();load('/tmp/test.js')\nEOF"
-    )
-    assert cmd == expected_cmd
+class TestGetAllTables:
+    def test_get_all_tables(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["coll1", "coll2"]
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.get_all_tables("test_db")
+        assert result.rows == ["coll1", "coll2"]
+
+
+class TestGetTableCount:
+    def test_get_table_count(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_db = MagicMock()
+        mock_coll = MagicMock()
+        mock_coll.count_documents.return_value = 100
+        mock_db.__getitem__ = MagicMock(return_value=mock_coll)
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+        mongo_engine.get_slave = MagicMock(return_value=True)
+
+        count = mongo_engine.get_table_conut("test", "test_db")
+        assert count == 100
+
+    def test_get_table_count_exception(self, mongo_engine):
+        mongo_engine.get_slave = MagicMock(return_value=True)
+        mongo_engine.get_connection = MagicMock(side_effect=Exception("fail"))
+        count = mongo_engine.get_table_conut("test", "test_db")
+        assert count == 0
+
+
+class TestGetAllColumnsByTb:
+    def test_get_all_columns(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_db = MagicMock()
+        mock_coll = MagicMock()
+        # options 中不带 viewOn
+        mock_coll.options.return_value = {}
+        # sort().limit() 两次调用，一次 _id 升序、一次 _id 降序
+        mock_coll.find.return_value.sort.return_value.limit.side_effect = [
+            [{"_id": "1", "name": "a"}],
+            [{"_id": "2", "age": 10}],
+        ]
+        mock_db.__getitem__ = MagicMock(return_value=mock_coll)
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.get_all_columns_by_tb("test_db", "test")
+        assert "_id" in result.rows
+        assert "name" in result.rows
+        assert "age" in result.rows
+
+    def test_get_all_columns_view(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_db = MagicMock()
+        mock_coll = MagicMock()
+        mock_coll.options.return_value = {"viewOn": "base_table"}
+        mock_coll.find.return_value.limit.return_value = [
+            {"_id": "1", "x": 1},
+            {"_id": "2", "y": 2},
+        ]
+        mock_db.__getitem__ = MagicMock(return_value=mock_coll)
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.get_all_columns_by_tb("test_db", "v")
+        assert "x" in result.rows
+        assert "y" in result.rows
+
+
+class TestDescribeTable:
+    def test_describe_table(self, mongo_engine):
+        mongo_engine.get_all_columns_by_tb = MagicMock(
+            return_value=MagicMock(rows=["_id", "name"])
+        )
+        result = mongo_engine.describe_table("test_db", "test")
+        assert result.rows == [[["_id"]], [["name"]]]
+
+
+# ====================== get_roles ======================
+
+class TestGetRoles:
+    def test_get_roles(self, mongo_engine):
+        mock_result = MagicMock()
+        mock_result.rows = [
+            ["admin.custom_role1", "custom_role1"],
+            ["admin.custom_role2", "custom_role2"],
+        ]
+        mongo_engine.query = MagicMock(return_value=mock_result)
+        result = mongo_engine.get_roles()
+        assert "read" in result.rows
+        assert "readWrite" in result.rows
+        assert "userAdminAnyDatabase" in result.rows
+        assert "custom_role1" in result.rows
+        assert "custom_role2" in result.rows
+
+
+# ====================== dispose_pair / dispose_str ======================
+
+class TestDisposePair:
+    def test_dispose_pair_simple(self, mongo_engine):
+        _, re_char = mongo_engine.dispose_pair("(abc)", 0, "(", ")")
+        assert re_char == "(abc)"
+
+    def test_dispose_pair_nested(self, mongo_engine):
+        _, re_char = mongo_engine.dispose_pair("({'a':1})", 0, "(", ")")
+        assert re_char == "({'a':1})"
+
+    def test_dispose_pair_with_string_containing_brace(self, mongo_engine):
+        _, re_char = mongo_engine.dispose_pair('({"a":"{b"})', 0, "(", ")")
+        assert re_char == '({"a":"{b"})'
+
+    def test_dispose_pair_unclosed(self, mongo_engine):
+        with pytest.raises(Exception, match="has no closed"):
+            mongo_engine.dispose_pair("(abc", 0, "(", ")")
+
+    def test_dispose_str_unclosed(self, mongo_engine):
+        with pytest.raises(Exception, match="has no close"):
+            MongoEngine.dispose_str('"abc', '"', 0)
+
+
+# ====================== parse_query_sentence ======================
+
+class TestParseQuerySentence:
+    def test_find(self, mongo_engine):
+        qd = mongo_engine.parse_query_sentence("db.test.find({'a':1})")
+        assert qd["collection"] == "test"
+        assert qd["method"] == "find"
+        assert qd["condition"] == "{'a':1}"
+
+    def test_find_with_projection(self, mongo_engine):
+        qd = mongo_engine.parse_query_sentence("db.test.find({'a':1},{'name':1})")
+        assert qd["method"] == "find"
+        assert qd["projection"] == "{'name':1}"
+
+    def test_getCollection(self, mongo_engine):
+        qd = mongo_engine.parse_query_sentence(
+            'db.getCollection("my_coll").find({})'
+        )
+        assert qd["collection"] == "my_coll"
+
+    def test_count(self, mongo_engine):
+        qd = mongo_engine.parse_query_sentence("db.test.count({'a':1})")
+        assert qd["method"] == "count"
+        assert qd["count"] == "{'a':1}"
+
+    def test_findOne(self, mongo_engine):
+        qd = mongo_engine.parse_query_sentence("db.test.findOne({'a':1})")
+        assert qd["method"] == "findOne"
+        assert qd["findOne_filter"] == "{'a':1}"
+
+    def test_findOne_no_args(self, mongo_engine):
+        qd = mongo_engine.parse_query_sentence("db.test.findOne()")
+        assert qd["method"] == "findOne"
+        assert qd["findOne_filter"] == "{}"
+
+    def test_countDocuments(self, mongo_engine):
+        qd = mongo_engine.parse_query_sentence("db.test.countDocuments({'a':1})")
+        assert qd["method"] == "countDocuments"
+        assert qd["countDocuments_filter"] == "{'a':1}"
+
+    def test_distinct(self, mongo_engine):
+        qd = mongo_engine.parse_query_sentence("db.test.distinct('name')")
+        assert qd["method"] == "distinct"
+        assert "'name'" in qd["distinct_args"]
+
+    def test_stats(self, mongo_engine):
+        qd = mongo_engine.parse_query_sentence("db.test.stats()")
+        assert qd["method"] == "stats"
+
+    def test_getIndexes(self, mongo_engine):
+        qd = mongo_engine.parse_query_sentence("db.test.getIndexes()")
+        assert qd["method"] == "index_information"
+
+    def test_aggregate(self, mongo_engine):
+        qd = mongo_engine.parse_query_sentence(
+            "db.test.aggregate([{'$match':{'a':1}},{'$group':{'_id':'$a'}}])"
+        )
+        assert qd["method"] == "aggregate"
+        assert isinstance(qd["condition"], list)
+        assert len(qd["condition"]) == 2
+
+
+# ====================== filter_sql ======================
+
+class TestFilterSql:
+    def test_filter_sql_plain(self, mongo_engine):
+        assert mongo_engine.filter_sql("db.test.find({})") == "db.test.find({})"
+
+    def test_filter_sql_explain(self, mongo_engine):
+        result = mongo_engine.filter_sql("explain db.test.find({})")
+        assert result.endswith(".explain()")
+
+    def test_filter_sql_strip_semicolon(self, mongo_engine):
+        assert mongo_engine.filter_sql("db.test.find({});extra") == "db.test.find({})"
+
+
+# ====================== query_check ======================
+
+class TestQueryCheck:
+    def test_query_check_valid(self, mongo_engine):
+        mongo_engine.get_all_tables = MagicMock(return_value=MagicMock(rows=["test"]))
+        result = mongo_engine.query_check(
+            db_name="test_db", sql="db.test.find({});"
+        )
+        assert result["bad_query"] is False
+
+    def test_query_check_invalid_syntax(self, mongo_engine):
+        result = mongo_engine.query_check(
+            db_name="test_db", sql="SELECT * FROM test"
+        )
+        assert result["bad_query"] is True
+
+    def test_query_check_table_not_exist(self, mongo_engine):
+        mongo_engine.get_all_tables = MagicMock(return_value=MagicMock(rows=["other"]))
+        result = mongo_engine.query_check(
+            db_name="test_db", sql="db.test.find({});"
+        )
+        assert result["bad_query"] is True
+        assert "不存在" in result["msg"]
+
+    def test_query_check_explain(self, mongo_engine):
+        mongo_engine.get_all_tables = MagicMock(return_value=MagicMock(rows=["test"]))
+        result = mongo_engine.query_check(
+            db_name="test_db", sql="explain db.test.find({})"
+        )
+        assert result["filtered_sql"].endswith(".explain()")
+
+
+# ====================== query ======================
+
+class TestQuery:
+    def test_query_count(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_db = MagicMock()
+        mock_coll = MagicMock()
+        mock_coll.count_documents.return_value = 42
+        mock_db.__getitem__ = MagicMock(return_value=mock_coll)
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.query(
+            db_name="test_db", sql="db.test.count({'a':1})", limit_num=10
+        )
+        assert result.error is None
+        assert result.affected_rows == 1
+        assert result.column_list == ["count"]
+
+    def test_query_findOne(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_db = MagicMock()
+        mock_coll = MagicMock()
+        mock_coll.find_one.return_value = {"_id": "1", "name": "archery"}
+        mock_db.__getitem__ = MagicMock(return_value=mock_coll)
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.query(
+            db_name="test_db", sql="db.test.findOne({'a':1})", limit_num=10
+        )
+        assert result.error is None
+        assert result.column_list == ["findOne"]
+
+    def test_query_findOne_none(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_db = MagicMock()
+        mock_coll = MagicMock()
+        mock_coll.find_one.return_value = None
+        mock_db.__getitem__ = MagicMock(return_value=mock_coll)
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.query(
+            db_name="test_db", sql="db.test.findOne({'a':1})", limit_num=10
+        )
+        assert result.error is None
+        assert result.affected_rows == 0
+
+    def test_query_countDocuments(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_db = MagicMock()
+        mock_coll = MagicMock()
+        mock_coll.count_documents.return_value = 5
+        mock_db.__getitem__ = MagicMock(return_value=mock_coll)
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.query(
+            db_name="test_db",
+            sql="db.test.countDocuments({'a':1})",
+            limit_num=10,
+        )
+        assert result.error is None
+        assert result.column_list == ["count"]
+
+    def test_query_distinct(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_db = MagicMock()
+        mock_coll = MagicMock()
+        mock_coll.distinct.return_value = ["a", "b", "c"]
+        mock_db.__getitem__ = MagicMock(return_value=mock_coll)
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.query(
+            db_name="test_db",
+            sql="db.test.distinct('name')",
+            limit_num=10,
+        )
+        assert result.error is None
+        assert result.column_list == ["distinct"]
+
+    def test_query_error(self, mongo_engine):
+        mongo_engine.get_connection = MagicMock(side_effect=Exception("conn failed"))
+
+        result = mongo_engine.query(
+            db_name="test_db", sql="db.test.count({'a':1})", limit_num=10
+        )
+        assert result.error is not None
+
+
+# ====================== processlist / kill_op ======================
+
+class TestProcesslist:
+    def test_processlist_active(self, mongo_engine):
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.__enter__ = MagicMock(
+            return_value=iter(
+                [
+                    {
+                        "opid": 1,
+                        "clientMetadata": {},
+                        "client": "1.2.3.4",
+                        "effectiveUsers": [{"user": "root"}],
+                    }
+                ]
+            )
+        )
+        cursor_mock.__exit__ = MagicMock(return_value=False)
+        mock_conn.admin.aggregate.return_value = cursor_mock
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.processlist("Active")
+        assert len(result.rows) == 1
+        assert result.rows[0]["effectiveUsers_user"] == "root"
+
+    def test_processlist_exception(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.admin.aggregate.side_effect = Exception("fail")
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.processlist("Active")
+        assert result.error is not None
+
+
+class TestKillOp:
+    def test_get_kill_command(self, mongo_engine):
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.__enter__ = MagicMock(
+            return_value=iter([{"opid": 1}, {"opid": "str_opid"}])
+        )
+        cursor_mock.__exit__ = MagicMock(return_value=False)
+        mock_conn.admin.aggregate.return_value = cursor_mock
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        cmd = mongo_engine.get_kill_command([1, "str_opid"])
+        assert "db.killOp(1);" in cmd
+        assert 'db.killOp("str_opid");' in cmd
+
+    def test_kill_op_success(self, mongo_engine):
+        mock_conn = MagicMock()
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+        result = mongo_engine.kill_op([1, 2])
+        assert result.error is None
+        assert mock_conn.admin.command.call_count == 2
+
+    def test_kill_op_connection_error(self, mongo_engine):
+        mongo_engine.get_connection = MagicMock(side_effect=Exception("fail"))
+        result = mongo_engine.kill_op([1])
+        assert result.error is not None
+
+    def test_kill_op_command_error(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.admin.command.side_effect = Exception("op error")
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+        result = mongo_engine.kill_op([1])
+        assert result.error is not None
+
+
+# ====================== instance users ======================
+
+class TestInstanceUsers:
+    def test_get_all_databases_summary(self, mongo_engine):
+        mongo_engine.get_all_databases = MagicMock(
+            return_value=MagicMock(error=None, rows=["db1"])
+        )
+        mock_conn = MagicMock()
+        mock_conn.__getitem__.return_value.command.return_value = {
+            "users": [{"user": "u1", "roles": [{"role": "read", "db": "db1"}]}]
+        }
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.get_all_databases_summary()
+        assert len(result.rows) == 1
+        assert result.rows[0]["db_name"] == "db1"
+
+    def test_get_instance_users_summary(self, mongo_engine):
+        mongo_engine.get_all_databases = MagicMock(
+            return_value=MagicMock(error=None, rows=["db1"])
+        )
+        mock_conn = MagicMock()
+        mock_conn.__getitem__.return_value.command.return_value = {
+            "users": [{"user": "u1", "roles": [{"role": "read", "db": "db1"}]}]
+        }
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.get_instance_users_summary()
+        assert len(result.rows) == 1
+        assert result.rows[0]["db_name_user"] == "db1.u1"
+        assert result.rows[0]["user"] == "u1"
+
+    def test_create_instance_user(self, mongo_engine):
+        mock_conn = MagicMock()
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.create_instance_user(
+            db_name="db1", user="u1", password1="pwd", remark="note"
+        )
+        assert result.error is None
+        assert result.rows[0]["user"] == "u1"
+
+    def test_create_instance_user_error(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.__getitem__.return_value.command.side_effect = Exception("err")
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.create_instance_user(
+            db_name="db1", user="u1", password1="pwd"
+        )
+        assert result.error is not None
+
+    def test_drop_instance_user(self, mongo_engine):
+        mock_conn = MagicMock()
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.drop_instance_user("db1.u1")
+        assert result.error is None
+
+    def test_drop_instance_user_error(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.__getitem__.return_value.command.side_effect = Exception("err")
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.drop_instance_user("db1.u1")
+        assert result.error is not None
+
+    def test_reset_instance_user_pwd(self, mongo_engine):
+        mock_conn = MagicMock()
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.reset_instance_user_pwd("db1.u1", "new_pwd")
+        assert result.error is None
+
+    def test_reset_instance_user_pwd_error(self, mongo_engine):
+        mock_conn = MagicMock()
+        mock_conn.__getitem__.return_value.command.side_effect = Exception("err")
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.reset_instance_user_pwd("db1.u1", "new_pwd")
+        assert result.error is not None
+
+
+# ====================== query_masking ======================
+
+class TestQueryMasking:
+    @patch("sql.engines.mongo.data_masking")
+    def test_query_masking(self, mock_masking, mongo_engine):
+        mock_masking.return_value = "masked"
+        result = mongo_engine.query_masking(
+            db_name="test_db", sql="db.test.find({})", resultset=MagicMock()
+        )
+        assert result == "masked"
+        mock_masking.assert_called_once()
+
+
+# ====================== parse_tuple / fill_query_columns ======================
+
+class TestParseTuple:
+    def test_fill_query_columns(self):
+        cursor = [{"a": 1, "b": 2}, {"c": 3}]
+        columns = ["mongodballdata"]
+        result = MongoEngine.fill_query_columns(cursor, columns)
+        assert "a" in result
+        assert "b" in result
+        assert "c" in result
+
+    def test_parse_tuple_with_projection(self, mongo_engine):
+        cursor = [{"_id": "1", "name": "archery", "age": 10}]
+        rows, columns = mongo_engine.parse_tuple(
+            cursor, "test_db", "test", projection={"name": 1}
+        )
+        assert "mongodballdata" in columns
+        assert "name" in columns
+        assert len(rows) == 1
+
+    def test_parse_tuple_without_projection(self, mongo_engine):
+        mongo_engine.get_all_columns_by_tb = MagicMock(
+            return_value=MagicMock(rows=["_id", "name"])
+        )
+        cursor = [{"_id": "1", "name": "archery"}]
+        rows, columns = mongo_engine.parse_tuple(
+            cursor, "test_db", "test"
+        )
+        assert "mongodballdata" in columns
+        assert len(rows) == 1
+
+    def test_parse_tuple_array_value(self, mongo_engine):
+        cursor = [{"_id": "1", "arr": [1, 2, 3]}]
+        rows, _ = mongo_engine.parse_tuple(
+            cursor, "test_db", "test", projection={"arr": 1}
+        )
+        # 数组被转换为 "(array) N Elements"
+        assert any("Elements" in str(item) for row in rows for item in row)
+
+    def test_parse_tuple_missing_field(self, mongo_engine):
+        cursor = [{"_id": "1"}]
+        rows, _ = mongo_engine.parse_tuple(
+            cursor, "test_db", "test", projection={"missing_field": 1}
+        )
+        # 缺失的字段被填充为 "(N/A)"
+        assert any("(N/A)" in str(item) for row in rows for item in row)

--- a/sql/engines/test_mongo.py
+++ b/sql/engines/test_mongo.py
@@ -8,8 +8,8 @@ from bson.int64 import Int64
 from sql.engines.mongo import MongoEngine, JsonDecoder, mongo_error
 from sql.engines.models import ResultSet
 
-
 # ====================== Fixtures ======================
+
 
 @pytest.fixture
 def mongo_engine():
@@ -38,6 +38,7 @@ def _mock_collection(mongo_engine):
 
 # ====================== mongo_error ======================
 
+
 class TestMongoError:
     def test_mongo_error_str(self):
         err = mongo_error("failed")
@@ -45,6 +46,7 @@ class TestMongoError:
 
 
 # ====================== JsonDecoder ======================
+
 
 class TestJsonDecoder:
     def setup_method(self):
@@ -79,7 +81,7 @@ class TestJsonDecoder:
         assert self.de.decode("") is None
 
     def test_decode_invalid_start(self):
-        with pytest.raises(Exception, match='Json must start with'):
+        with pytest.raises(Exception, match="Json must start with"):
             self.de.decode("123")
 
     def test_decode_objectid(self):
@@ -105,6 +107,7 @@ class TestJsonDecoder:
 
 
 # ====================== __split_args ======================
+
 
 class TestSplitArgs:
     def test_basic_args(self, mongo_engine):
@@ -138,6 +141,7 @@ class TestSplitArgs:
 
 
 # ====================== _execute_shell_sql ======================
+
 
 class TestExecuteShellSql:
     def _mock_collection(self, mongo_engine):
@@ -450,6 +454,7 @@ class TestExecuteShellSql:
 
 # ====================== get_master ======================
 
+
 class TestGetMaster:
     def test_get_master_success(self, mongo_engine):
         mock_conn = MagicMock()
@@ -486,6 +491,7 @@ class TestGetMaster:
 
 
 # ====================== get_slave ======================
+
 
 class TestGetSlave:
     def test_get_slave_success(self, mongo_engine):
@@ -533,6 +539,7 @@ class TestGetSlave:
 
 
 # ====================== execute ======================
+
 
 class TestExecute:
     @patch.object(MongoEngine, "get_master")
@@ -590,10 +597,13 @@ class TestExecute:
 
 # ====================== execute_check ======================
 
+
 class TestExecuteCheck:
     @patch("sql.engines.mongo.SysConfig")
     @patch.object(MongoEngine, "get_all_tables")
-    def test_execute_check_insertOne(self, mock_get_tables, mock_sys_config, mongo_engine):
+    def test_execute_check_insertOne(
+        self, mock_get_tables, mock_sys_config, mongo_engine
+    ):
         mock_get_tables.return_value = MagicMock(rows=["test"])
         mock_sys_config.return_value.get.return_value = False
         result = mongo_engine.execute_check(
@@ -604,7 +614,9 @@ class TestExecuteCheck:
 
     @patch("sql.engines.mongo.SysConfig")
     @patch.object(MongoEngine, "get_all_tables")
-    def test_execute_check_unsupported(self, mock_get_tables, mock_sys_config, mongo_engine):
+    def test_execute_check_unsupported(
+        self, mock_get_tables, mock_sys_config, mongo_engine
+    ):
         mock_get_tables.return_value = MagicMock(rows=["test"])
         mock_sys_config.return_value.get.return_value = False
         result = mongo_engine.execute_check(
@@ -615,7 +627,9 @@ class TestExecuteCheck:
 
     @patch("sql.engines.mongo.SysConfig")
     @patch.object(MongoEngine, "get_all_tables")
-    def test_execute_check_no_semicolon(self, mock_get_tables, mock_sys_config, mongo_engine):
+    def test_execute_check_no_semicolon(
+        self, mock_get_tables, mock_sys_config, mongo_engine
+    ):
         mock_get_tables.return_value = MagicMock(rows=["test"])
         mock_sys_config.return_value.get.return_value = False
         with pytest.raises(Exception, match="请以分号结尾"):
@@ -625,12 +639,12 @@ class TestExecuteCheck:
 
     @patch("sql.engines.mongo.SysConfig")
     @patch.object(MongoEngine, "get_all_tables")
-    def test_execute_check_table_not_exists(self, mock_get_tables, mock_sys_config, mongo_engine):
+    def test_execute_check_table_not_exists(
+        self, mock_get_tables, mock_sys_config, mongo_engine
+    ):
         mock_get_tables.return_value = MagicMock(rows=["other"])
         mock_sys_config.return_value.get.return_value = False
-        result = mongo_engine.execute_check(
-            db_name="test_db", sql="db.test.drop();"
-        )
+        result = mongo_engine.execute_check(db_name="test_db", sql="db.test.drop();")
         assert result.error_count == 1
         assert result.rows[0].stagestatus == "文档不存在"
 
@@ -675,6 +689,7 @@ class TestExecuteCheck:
 
 
 # ====================== get_connection / close ======================
+
 
 class TestGetConnection:
     @patch("sql.engines.mongo.pymongo.MongoClient")
@@ -722,6 +737,7 @@ class TestClose:
 
 
 # ====================== get_all_databases / tables ======================
+
 
 class TestGetAllDatabases:
     def test_get_all_databases(self, mongo_engine):
@@ -835,6 +851,7 @@ class TestDescribeTable:
 
 # ====================== get_roles ======================
 
+
 class TestGetRoles:
     def test_get_roles(self, mongo_engine):
         mock_result = MagicMock()
@@ -852,6 +869,7 @@ class TestGetRoles:
 
 
 # ====================== dispose_pair / dispose_str ======================
+
 
 class TestDisposePair:
     def test_dispose_pair_simple(self, mongo_engine):
@@ -877,6 +895,7 @@ class TestDisposePair:
 
 # ====================== parse_query_sentence ======================
 
+
 class TestParseQuerySentence:
     def test_find(self, mongo_engine):
         qd = mongo_engine.parse_query_sentence("db.test.find({'a':1})")
@@ -890,9 +909,7 @@ class TestParseQuerySentence:
         assert qd["projection"] == "{'name':1}"
 
     def test_getCollection(self, mongo_engine):
-        qd = mongo_engine.parse_query_sentence(
-            'db.getCollection("my_coll").find({})'
-        )
+        qd = mongo_engine.parse_query_sentence('db.getCollection("my_coll").find({})')
         assert qd["collection"] == "my_coll"
 
     def test_count(self, mongo_engine):
@@ -939,6 +956,7 @@ class TestParseQuerySentence:
 
 # ====================== filter_sql ======================
 
+
 class TestFilterSql:
     def test_filter_sql_plain(self, mongo_engine):
         assert mongo_engine.filter_sql("db.test.find({})") == "db.test.find({})"
@@ -953,25 +971,20 @@ class TestFilterSql:
 
 # ====================== query_check ======================
 
+
 class TestQueryCheck:
     def test_query_check_valid(self, mongo_engine):
         mongo_engine.get_all_tables = MagicMock(return_value=MagicMock(rows=["test"]))
-        result = mongo_engine.query_check(
-            db_name="test_db", sql="db.test.find({});"
-        )
+        result = mongo_engine.query_check(db_name="test_db", sql="db.test.find({});")
         assert result["bad_query"] is False
 
     def test_query_check_invalid_syntax(self, mongo_engine):
-        result = mongo_engine.query_check(
-            db_name="test_db", sql="SELECT * FROM test"
-        )
+        result = mongo_engine.query_check(db_name="test_db", sql="SELECT * FROM test")
         assert result["bad_query"] is True
 
     def test_query_check_table_not_exist(self, mongo_engine):
         mongo_engine.get_all_tables = MagicMock(return_value=MagicMock(rows=["other"]))
-        result = mongo_engine.query_check(
-            db_name="test_db", sql="db.test.find({});"
-        )
+        result = mongo_engine.query_check(db_name="test_db", sql="db.test.find({});")
         assert result["bad_query"] is True
         assert "不存在" in result["msg"]
 
@@ -984,6 +997,7 @@ class TestQueryCheck:
 
 
 # ====================== query ======================
+
 
 class TestQuery:
     def test_query_count(self, mongo_engine):
@@ -1077,6 +1091,7 @@ class TestQuery:
 
 # ====================== processlist / kill_op ======================
 
+
 class TestProcesslist:
     def test_processlist_active(self, mongo_engine):
         mock_conn = MagicMock()
@@ -1146,6 +1161,7 @@ class TestKillOp:
 
 
 # ====================== instance users ======================
+
 
 class TestInstanceUsers:
     def test_get_all_databases_summary(self, mongo_engine):
@@ -1230,6 +1246,7 @@ class TestInstanceUsers:
 
 # ====================== query_masking ======================
 
+
 class TestQueryMasking:
     @patch("sql.engines.mongo.data_masking")
     def test_query_masking(self, mock_masking, mongo_engine):
@@ -1242,6 +1259,7 @@ class TestQueryMasking:
 
 
 # ====================== parse_tuple / fill_query_columns ======================
+
 
 class TestParseTuple:
     def test_fill_query_columns(self):
@@ -1266,9 +1284,7 @@ class TestParseTuple:
             return_value=MagicMock(rows=["_id", "name"])
         )
         cursor = [{"_id": "1", "name": "archery"}]
-        rows, columns = mongo_engine.parse_tuple(
-            cursor, "test_db", "test"
-        )
+        rows, columns = mongo_engine.parse_tuple(cursor, "test_db", "test")
         assert "mongodballdata" in columns
         assert len(rows) == 1
 

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1655,9 +1655,13 @@ class MongoTest(TestCase):
         check_result = self.engine.filter_sql(sql, 0)
         self.assertEqual(check_result, "db.job.find().count().explain()")
 
-    @patch("sql.engines.mongo.MongoEngine.exec_cmd")
-    def test_get_slave(self, mock_exec_cmd):
-        mock_exec_cmd.return_value = "172.30.2.123:27017"
+    @patch("sql.engines.mongo.MongoEngine.get_connection")
+    def test_get_slave(self, mock_get_connection):
+        mock_conn = Mock()
+        mock_conn.admin.command.return_value = {
+            "members": [{"stateStr": "SECONDARY", "name": "172.30.2.123:27017"}]
+        }
+        mock_get_connection.return_value = mock_conn
         flag = self.engine.get_slave()
         self.assertEqual(True, flag)
 
@@ -1790,44 +1794,32 @@ class MongoTest(TestCase):
         check_result = self.engine.execute_check("some_db", sql)
         self.assertEqual(check_result.rows[0].__dict__["stagestatus"], "语法错误")
 
-    @patch("sql.engines.mongo.MongoEngine.exec_cmd")
+    @patch("sql.engines.mongo.MongoEngine._execute_shell_sql")
     @patch("sql.engines.mongo.MongoEngine.get_master")
-    def test_execute(self, mock_get_master, mock_exec_cmd):
+    def test_execute(self, mock_get_master, mock_execute_shell_sql):
         sql = """db.job.find().createIndex({"skuId":1},{background:true})"""
-        mock_exec_cmd.return_value = """{
-                                        "createdCollectionAutomatically" : false,
-                                        "numIndexesBefore" : 2,
-                                        "numIndexesAfter" : 3,
-                                        "ok" : 1
-                                      }"""
+        mock_execute_shell_sql.return_value = (True, '{"ok": 1}', 0)
 
         check_result = self.engine.execute("some_db", sql)
         mock_get_master.assert_called_once()
         self.assertEqual(check_result.rows[0].__dict__["errlevel"], 0)
 
-    @patch("sql.engines.mongo.MongoEngine.exec_cmd")
+    @patch("sql.engines.mongo.MongoEngine._execute_shell_sql")
     @patch("sql.engines.mongo.MongoEngine.get_master")
-    def test_execute_on_dml(self, mock_get_master, mock_exec_cmd):
+    def test_execute_on_dml(self, mock_get_master, mock_execute_shell_sql):
         sql = """db.job.insertMany([{"title":"test1"},{"title":test2"},{"title":test3"}]);"""
-        mock_exec_cmd.return_value = """{
-                                            "acknowledged" : true,
-                                            "insertedIds" : [
-                                                ObjectId("63b77b53afab4917dfd48a20"),
-                                                ObjectId("63b77b53afab4917dfd48a21"),
-                                                ObjectId("63b77b53afab4917dfd48a22")
-                                            ]
-                                        }"""
+        mock_execute_shell_sql.return_value = (True, '{"acknowledged": true}', 3)
 
         check_result = self.engine.execute("some_db", sql)
         mock_get_master.assert_called_once()
         self.assertEqual(check_result.rows[0].__dict__["affected_rows"], 3)
 
-    @patch("sql.engines.mongo.MongoEngine.exec_cmd")
+    @patch("sql.engines.mongo.MongoEngine._execute_shell_sql")
     @patch("sql.engines.mongo.MongoEngine.get_master")
-    def test_execute_return_error(self, mock_get_master, mock_exec_cmd):
+    def test_execute_return_error(self, mock_get_master, mock_execute_shell_sql):
         sql = """db.job.insertMany({"title":"test1"},{"title":test2"},{"title":test3"});"""
-        mock_exec_cmd.return_value = (
-            """uncaught exception: TypeError: documents.map is not a function"""
+        mock_execute_shell_sql.return_value = (
+            False, "uncaught exception: TypeError: documents.map is not a function", 0
         )
         check_result = self.engine.execute("some_db", sql)
         mock_get_master.assert_called_once()

--- a/sql/engines/tests.py
+++ b/sql/engines/tests.py
@@ -1819,7 +1819,9 @@ class MongoTest(TestCase):
     def test_execute_return_error(self, mock_get_master, mock_execute_shell_sql):
         sql = """db.job.insertMany({"title":"test1"},{"title":test2"},{"title":test3"});"""
         mock_execute_shell_sql.return_value = (
-            False, "uncaught exception: TypeError: documents.map is not a function", 0
+            False,
+            "uncaught exception: TypeError: documents.map is not a function",
+            0,
         )
         check_result = self.engine.execute("some_db", sql)
         mock_get_master.assert_called_once()

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -136,6 +136,7 @@
                         <div class="text-info">
                             <li>支持注释行，可选择指定语句执行，默认执行第一条;</li>
                             <li>查询结果行数限制见权限管理，会选择查询涉及表的最小limit值</li>
+                            <li id="mongo-hint-info" style="display:none">支持mongo原生查询语句，例如：<code>db.users.find({ age: { $eq: 25 } });</code></li>
                         </div>
                     </form>
                 </div>
@@ -1157,6 +1158,7 @@
             showFormat: true,
             showExplain: true,
             showRedisHelp: false,
+            showMongoHint: false,
         }
         const createDisplayConfig = function(extraArgs = null) {
             if (extraArgs === null) {
@@ -1169,7 +1171,7 @@
                 showRedisHelp: true,
                 showFormat: false, showExplain: false}),
             "PgSQL": createDisplayConfig({showSchemaName: true}),
-            "Mongo": createDisplayConfig({showFormat: false}),
+            "Mongo": createDisplayConfig({showFormat: false, showMongoHint: true}),
             "Phoenix": createDisplayConfig({showExplain: false}),
             "Cassandra": createDisplayConfig({showExplain: false}),
             // 如有特殊的显示需求, 在此处添加配置, 并在下方的optgroup_control中添加对应的控制逻辑
@@ -1204,6 +1206,11 @@
                     redis_help_tab_add();
                 } else {
                     redis_help_tab_remove();
+                }
+                if (displayConfig.showMongoHint) {
+                    $("#mongo-hint-info").show();
+                } else {
+                    $("#mongo-hint-info").hide();
                 }
             }
         }

--- a/sql/templates/sqlsubmit.html
+++ b/sql/templates/sqlsubmit.html
@@ -112,6 +112,10 @@
                                     SQL提交
                                 </button>
                             </div>
+                            <!--描述信息-->
+                            <div class="text-info">
+                                <li id="mongo-hint-info" style="display:none">支持mongo原生命令，例如：<code>db.users.updateOne({ name: "Charlie" }, { $set: { phone: "123456789", status: "active" } });</code></li>
+                            </div>
                         </div>
                     </form>
                 </div>
@@ -257,6 +261,12 @@
             if (optgroup != "MySQL" && optgroup != "Oracle") {
                 $("#div-backup").hide();
                 $("#is_backup").val("False");
+            }
+            // MongoDB提示信息
+            if (optgroup === "Mongo") {
+                $("#mongo-hint-info").show();
+            } else {
+                $("#mongo-hint-info").hide();
             }
             //将数据通过ajax提交给获取db_name
             $.ajax({


### PR DESCRIPTION
背景：原mongo引擎的执行方法，单独使用mongo cmd二进制可执行文件，通过拼接命令的方式进行执行的操作，而查询方法使用pymongo链接的方式进行查询。
重构：查询和执行都改为使用pymongo api的方式操作，不再拼接命令行。

原命令行方式的缺点：
1、操作系统依赖：基于/usr/local/bin/mongo本地文件，以Archery-1.14.0的docker部署为例，由于底层系统升级，导致mongo失效，还要手动更改适应对应操作系统的mongo版本。
ldd /usr/local/bin/mongo
	libcrypto.so.10 => not found
	libssl.so.10 => not found
错误提示：[#3070](https://github.com/hhyo/Archery/issues/3070)
2、一致性较差：其他sql引擎都没有引入外部依赖，只有mongo的执行方法引入外部依赖。查询和执行的调用不一致。
原命令行方式的优点：
1、命令支持全：由于使用命令行的方式，执行的命令理论上来说是最全的。实际上工单流程会有一个前置【SQL检测】功能，调用execute_check方法，需要枚举命令，依赖于枚举的命令集。


更改的功能：
1、重构：execute方法完全使用pymongo api的方式操作，放弃拼接命令行，减少操作系统依赖。
2、bool值转义：对upsert/multi/justOne相关的值做bool值转义。
3、查询命令增加：支持findOne/count/countDocuments/distinct/stats的查询语句。
4、正则表达式：支持mongo原生正则表达式查询。
5、bug更改：修复get_master函数在部分mongo版本可能根本没值的情况。


解决的问题：

执行语法问题：
[#3070](https://github.com/hhyo/Archery/issues/3070)

查询语法问题：
[#3145](https://github.com/hhyo/Archery/issues/3145)
[#1456](https://github.com/hhyo/Archery/issues/1456)
[#2355](https://github.com/hhyo/Archery/issues/2355)
[#2049](https://github.com/hhyo/Archery/issues/2049)
[#2163](https://github.com/hhyo/Archery/issues/2163)