### PR TITLE
add(dictionary):数据字典增加clickhouse数据库支持

### DIFF
--- a/sql/data_dictionary.py
+++ b/sql/data_dictionary.py
@@ -3,7 +3,6 @@ import datetime
 import os
 from urllib.parse import quote
 
-import MySQLdb
 import simplejson as json
 from django.template import loader
 from django.conf import settings
@@ -71,8 +70,8 @@ def table_info(request):
                 db_name=db_name, tb_name=tb_name
             )
 
-            # mysql数据库可以获取创建表格的SQL语句，mssql暂无找到生成创建表格的SQL语句
-            if instance.db_type == "mysql":
+            # mysql和clickhouse数据库可以获取创建表格的SQL语句
+            if instance.db_type in ("mysql", "clickhouse"):
                 _create_sql = query_engine.query(
                     db_name, "show create table `%s`;" % tb_name
                 )
@@ -108,7 +107,7 @@ def export(request):
 
     try:
         instance = user_instances(
-            request.user, db_type=["mysql", "mssql", "oracle"]
+            request.user, db_type=["mysql", "mssql", "oracle", "clickhouse"]
         ).get(instance_name=instance_name)
         query_engine = get_engine(instance=instance)
     except Instance.DoesNotExist:

--- a/sql/engines/clickhouse.py
+++ b/sql/engines/clickhouse.py
@@ -593,7 +593,10 @@ class ClickHouseEngine(EngineBase):
                         database = %(db_name)s
                     ORDER BY name"""
         result = self.query(
-            db_name=db_name, sql=sql_tbs, close_conn=False, parameters={"db_name": db_name}
+            db_name=db_name,
+            sql=sql_tbs,
+            close_conn=False,
+            parameters={"db_name": db_name},
         )
         tbs = []
         for row in result.rows:

--- a/sql/engines/clickhouse.py
+++ b/sql/engines/clickhouse.py
@@ -495,6 +495,147 @@ class ClickHouseEngine(EngineBase):
             self.close()
         return result
 
+    def get_group_tables_by_db(self, db_name):
+        """获取首字符分组的table列表，返回一个dict"""
+        data = {}
+        sql = f"""SELECT
+                    name,
+                    comment
+                FROM
+                    system.tables
+                WHERE
+                    database = %(db_name)s"""
+        result = self.query(db_name=db_name, sql=sql, parameters={"db_name": db_name})
+        for row in result.rows:
+            table_name, table_cmt = row[0], row[1]
+            if table_name[0] not in data:
+                data[table_name[0]] = list()
+            data[table_name[0]].append([table_name, table_cmt])
+        return data
+
+    def get_table_meta_data(self, db_name, tb_name, **kwargs):
+        """数据字典页面使用：获取表格的元信息，返回一个dict{column_list: [], rows: []}"""
+        sql = f"""SELECT
+                    name as table_name,
+                    engine,
+                    total_rows as table_rows,
+                    formatReadableSize(total_bytes) as data_length,
+                    partition_key,
+                    sorting_key,
+                    primary_key,
+                    sampling_key,
+                    metadata_modification_time as create_time,
+                    comment as table_comment
+                FROM
+                    system.tables
+                WHERE
+                    database = %(db_name)s
+                    AND name = %(tb_name)s"""
+        _meta_data = self.query(
+            db_name=db_name,
+            sql=sql,
+            parameters={"db_name": db_name, "tb_name": tb_name},
+        )
+        return {"column_list": _meta_data.column_list, "rows": _meta_data.rows[0]}
+
+    def get_table_desc_data(self, db_name, tb_name, **kwargs):
+        """获取表格字段信息"""
+        sql = f"""SELECT
+                    name as `列名`,
+                    type as `列类型`,
+                    default_kind as `默认值类型`,
+                    default_expression as `默认值`,
+                    is_in_partition_key as `分区键`,
+                    is_in_sorting_key as `排序键`,
+                    is_in_primary_key as `主键`,
+                    comment as `列说明`
+                FROM
+                    system.columns
+                WHERE
+                    database = %(db_name)s
+                    AND table = %(tb_name)s
+                ORDER BY position"""
+        _desc_data = self.query(
+            db_name=db_name,
+            sql=sql,
+            parameters={"db_name": db_name, "tb_name": tb_name},
+        )
+        return {"column_list": _desc_data.column_list, "rows": _desc_data.rows}
+
+    def get_table_index_data(self, db_name, tb_name, **kwargs):
+        """获取表格索引信息（ClickHouse的data skipping index）"""
+        sql = f"""SELECT
+                    name as `索引名`,
+                    type_full as `索引类型`,
+                    expr as `索引表达式`,
+                    granularity as `粒度`
+                FROM
+                    system.data_skipping_indices
+                WHERE
+                    database = %(db_name)s
+                    AND table = %(tb_name)s"""
+        _index_data = self.query(
+            db_name=db_name,
+            sql=sql,
+            parameters={"db_name": db_name, "tb_name": tb_name},
+        )
+        return {"column_list": _index_data.column_list, "rows": _index_data.rows}
+
+    def get_tables_metas_data(self, db_name, **kwargs):
+        """获取数据库所有表格信息，用作数据字典导出接口"""
+        sql_tbs = f"""SELECT
+                        name as TABLE_NAME,
+                        comment as TABLE_COMMENT,
+                        engine as ENGINE
+                    FROM
+                        system.tables
+                    WHERE
+                        database = %(db_name)s
+                    ORDER BY name"""
+        result = self.query(
+            db_name=db_name, sql=sql_tbs, close_conn=False, parameters={"db_name": db_name}
+        )
+        tbs = []
+        for row in result.rows:
+            tbs.append(dict(zip(result.column_list, row)))
+
+        table_metas = []
+        for tb in tbs:
+            _meta = dict()
+            engine_keys = [
+                {"key": "COLUMN_NAME", "value": "字段名"},
+                {"key": "COLUMN_TYPE", "value": "数据类型"},
+                {"key": "COLUMN_DEFAULT", "value": "默认值"},
+                {"key": "IS_IN_PRIMARY_KEY", "value": "是否主键"},
+                {"key": "COLUMN_COMMENT", "value": "备注"},
+            ]
+            _meta["ENGINE_KEYS"] = engine_keys
+            _meta["TABLE_INFO"] = tb
+            sql_cols = f"""SELECT
+                            name as COLUMN_NAME,
+                            type as COLUMN_TYPE,
+                            default_expression as COLUMN_DEFAULT,
+                            is_in_primary_key as IS_IN_PRIMARY_KEY,
+                            comment as COLUMN_COMMENT
+                        FROM
+                            system.columns
+                        WHERE
+                            database = %(db_name)s
+                            AND table = %(tb_name)s
+                        ORDER BY position"""
+            query_result = self.query(
+                db_name=db_name,
+                sql=sql_cols,
+                close_conn=False,
+                parameters={"db_name": db_name, "tb_name": tb["TABLE_NAME"]},
+            )
+            columns = []
+            for row in query_result.rows:
+                columns.append(dict(zip(query_result.column_list, row)))
+            _meta["COLUMNS"] = tuple(columns)
+            table_metas.append(_meta)
+        return table_metas
+
     def close(self):
         if self.conn:
             self.conn.close()

--- a/sql/engines/test_clickhouse.py
+++ b/sql/engines/test_clickhouse.py
@@ -1,0 +1,605 @@
+# -*- coding: UTF-8 -*-
+"""
+ClickHouse 引擎单元测试
+对 sql/engines/clickhouse.py 中的 ClickHouseEngine 进行全面的功能覆盖测试
+
+所有测试使用 Mock 对象模拟 Instance，不依赖真实数据库
+"""
+
+from unittest.mock import patch, Mock
+
+import pytest
+
+from sql.engines.clickhouse import ClickHouseEngine
+from sql.engines.models import ResultSet, ReviewSet, ReviewResult
+
+
+@pytest.fixture
+def mock_instance():
+    """模拟 Instance 对象，避免对 Django ORM 和数据库的依赖"""
+    ins = Mock()
+    ins.instance_name = "ch_ins"
+    ins.host = "some_host"
+    ins.port = 9000
+    ins.db_name = "test_db"
+    ins.db_type = "clickhouse"
+    ins.mode = ""
+    ins.tunnel = None
+    ins.get_username_password.return_value = ("ins_user", "some_str")
+    return ins
+
+
+# ----------------- 基本属性 -----------------
+def test_engine_base_info(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    assert engine.name == "ClickHouse"
+    assert engine.info == "ClickHouse engine"
+    assert engine.test_query == "SELECT 1"
+
+
+def test_auto_backup(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    assert engine.auto_backup is False
+
+
+def test_escape_string(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    # 包含特殊字符时应被转义
+    result = engine.escape_string("a'b\\c")
+    assert isinstance(result, str)
+    assert result != "a'b\\c"
+
+
+# ----------------- 连接管理 -----------------
+@patch("sql.engines.clickhouse.connect")
+def test_get_connection_without_db(mock_connect, mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    engine.get_connection()
+    mock_connect.assert_called_once()
+    kwargs = mock_connect.call_args.kwargs
+    assert "database" not in kwargs
+    assert kwargs["host"] == "some_host"
+    assert kwargs["port"] == 9000
+
+
+@patch("sql.engines.clickhouse.connect")
+def test_get_connection_with_db(mock_connect, mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    engine.get_connection(db_name="my_db")
+    mock_connect.assert_called_once()
+    kwargs = mock_connect.call_args.kwargs
+    assert kwargs.get("database") == "my_db"
+
+
+@patch("sql.engines.clickhouse.connect")
+def test_get_connection_reuse(mock_connect, mock_instance):
+    """已存在的连接应被复用"""
+    engine = ClickHouseEngine(instance=mock_instance)
+    engine.conn = Mock()
+    conn = engine.get_connection()
+    assert conn is engine.conn
+    mock_connect.assert_not_called()
+
+
+def test_close(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    mock_conn = Mock()
+    engine.conn = mock_conn
+    engine.close()
+    mock_conn.close.assert_called_once()
+    assert engine.conn is None
+
+
+def test_close_when_no_conn(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    engine.conn = None
+    engine.close()  # 不应抛异常
+    assert engine.conn is None
+
+
+# ----------------- query -----------------
+@patch("sql.engines.clickhouse.connect")
+def test_query_success(mock_connect, mock_instance):
+    mock_cursor = Mock()
+    mock_cursor.fetchmany.return_value = [("v1", "v2")]
+    mock_cursor.description = (("k1", "x"), ("k2", "x"))
+    mock_connect.return_value.cursor.return_value = mock_cursor
+
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.query(sql="select 1", limit_num=10)
+    mock_cursor.execute.assert_called_once()
+    mock_cursor.fetchmany.assert_called_once_with(size=10)
+    assert isinstance(rs, ResultSet)
+    assert rs.column_list == ["k1", "k2"]
+    assert rs.rows == [("v1", "v2")]
+    assert rs.affected_rows == 1
+
+
+@patch("sql.engines.clickhouse.connect")
+def test_query_fetchall(mock_connect, mock_instance):
+    mock_cursor = Mock()
+    mock_cursor.fetchall.return_value = [("a",), ("b",)]
+    mock_cursor.description = (("col", "x"),)
+    mock_connect.return_value.cursor.return_value = mock_cursor
+
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.query(sql="select 1", limit_num=0)
+    mock_cursor.fetchall.assert_called_once()
+    assert rs.affected_rows == 2
+
+
+@patch("sql.engines.clickhouse.connect")
+def test_query_error(mock_connect, mock_instance):
+    mock_cursor = Mock()
+    mock_cursor.execute.side_effect = Exception("boom\nStack trace:xxx")
+    mock_connect.return_value.cursor.return_value = mock_cursor
+
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.query(sql="bad sql")
+    assert "boom" in rs.error
+    assert "Stack trace" not in rs.error
+
+
+# ----------------- server_version -----------------
+@patch.object(ClickHouseEngine, "query")
+def test_server_version(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(rows=[("ClickHouse 21.8.3.44",)])
+    engine = ClickHouseEngine(instance=mock_instance)
+    assert engine.server_version == (21, 8, 3)
+
+
+# ----------------- 结构类查询 -----------------
+@patch.object(ClickHouseEngine, "query")
+def test_get_table_engine_exist(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(rows=[("MergeTree",)])
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.get_table_engine("db.tb")
+    assert ret == {"status": 1, "engine": "MergeTree"}
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_get_table_engine_not_exist(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(rows=[])
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.get_table_engine("db.tb")
+    assert ret == {"status": 0, "engine": "None"}
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_get_all_databases(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        rows=[
+            ("system",),
+            ("INFORMATION_SCHEMA",),
+            ("information_schema",),
+            ("datasets",),
+            ("my_db",),
+            ("another",),
+        ]
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.get_all_databases()
+    assert rs.rows == ["my_db", "another"]
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_get_all_tables(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(rows=[("t1",), ("t2",)])
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.get_all_tables(db_name="my_db")
+    assert rs.rows == ["t1", "t2"]
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_get_all_columns_by_tb(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        rows=[("id", "Int32", ""), ("name", "String", "")]
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.get_all_columns_by_tb(db_name="my_db", tb_name="t1")
+    assert rs.rows == ["id", "name"]
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_describe_table(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        rows=[("CREATE TABLE t1 (id Int32,name String) ENGINE = MergeTree",)]
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.describe_table(db_name="my_db", tb_name="t1")
+    assert rs.rows[0][0] == "t1"
+    assert "\n" in rs.rows[0][1]
+
+
+# ----------------- query_check -----------------
+@patch.object(ClickHouseEngine, "server_version", new=(21, 8, 3))
+@patch.object(ClickHouseEngine, "query")
+def test_query_check_valid_select(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(rows=[("plan",)])
+    engine = ClickHouseEngine(instance=mock_instance)
+    result = engine.query_check(db_name="my_db", sql="select id from t1")
+    assert result["bad_query"] is False
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 8, 3))
+def test_query_check_bad_syntax_type(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    result = engine.query_check(db_name="my_db", sql="delete from t1")
+    assert result["bad_query"] is True
+    assert result["msg"] == "不支持的查询语法类型!"
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 8, 3))
+@patch.object(ClickHouseEngine, "query")
+def test_query_check_has_star(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(rows=[("plan",)])
+    engine = ClickHouseEngine(instance=mock_instance)
+    result = engine.query_check(db_name="my_db", sql="select * from t1")
+    assert result["has_star"] is True
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(20, 1, 0))
+def test_query_check_explain_low_version(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    result = engine.query_check(db_name="my_db", sql="explain select 1")
+    assert result["bad_query"] is True
+    assert "不支持explain" in result["msg"]
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 8, 3))
+@patch.object(ClickHouseEngine, "query")
+def test_query_check_explain_error(mock_query, mock_instance):
+    rs = ResultSet()
+    rs.error = "syntax error"
+    mock_query.return_value = rs
+    engine = ClickHouseEngine(instance=mock_instance)
+    result = engine.query_check(db_name="my_db", sql="select id from t1")
+    assert result["bad_query"] is True
+    assert result["msg"] == "syntax error"
+
+
+def test_query_check_empty(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    result = engine.query_check(db_name="my_db", sql="-- only comment\n")
+    assert result["bad_query"] is True
+
+
+# ----------------- filter_sql -----------------
+def test_filter_sql_no_limit(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    sql = engine.filter_sql(sql="select id from t1", limit_num=100)
+    assert sql == "select id from t1 limit 100;"
+
+
+def test_filter_sql_with_limit_n(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    sql = engine.filter_sql(sql="select id from t1 limit 200", limit_num=100)
+    assert sql == "select id from t1 limit 100;"
+
+
+def test_filter_sql_with_limit_offset(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    sql = engine.filter_sql(sql="select id from t1 limit 200 offset 50", limit_num=100)
+    assert sql == "select id from t1 limit 100 offset 50;"
+
+
+def test_filter_sql_with_offset_comma_limit(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    sql = engine.filter_sql(sql="select id from t1 limit 10,200", limit_num=100)
+    assert sql == "select id from t1 limit 10,100;"
+
+
+def test_filter_sql_not_select(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    sql = engine.filter_sql(sql="show tables", limit_num=100)
+    assert sql == "show tables;"
+
+
+# ----------------- explain_check -----------------
+@patch.object(ClickHouseEngine, "server_version", new=(21, 1, 2))
+@patch.object(ClickHouseEngine, "query")
+def test_explain_check_ok(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(rows=[("ast",)])
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.explain_check(
+        check_result=ReviewSet(),
+        db_name="db",
+        line=1,
+        statement="alter table t1 add column c1 Int32",
+    )
+    assert ret.errlevel == 0
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 1, 2))
+@patch.object(ClickHouseEngine, "query")
+def test_explain_check_error(mock_query, mock_instance):
+    rs = ResultSet()
+    rs.error = "bad ast"
+    mock_query.return_value = rs
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.explain_check(
+        check_result=ReviewSet(), db_name="db", line=1, statement="alter table t1"
+    )
+    assert ret.errlevel == 2
+    assert "bad ast" in ret.errormessage
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(20, 1, 0))
+def test_explain_check_version_too_low(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.explain_check(
+        check_result=ReviewSet(), db_name="db", line=1, statement="alter table t1"
+    )
+    # 低版本直接返回审核通过结果，不会执行 explain
+    assert ret.errlevel == 0
+
+
+# ----------------- execute_check -----------------
+def _mock_config(engine, critical_ddl_regex=""):
+    """辅助：mock 引擎的 config 对象"""
+    mock_cfg = Mock()
+    mock_cfg.get.return_value = critical_ddl_regex
+    engine.config = mock_cfg
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 8, 3))
+def test_execute_check_reject_select(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    _mock_config(engine)
+    ret = engine.execute_check(db_name="db", sql="select 1;")
+    assert isinstance(ret, ReviewSet)
+    assert ret.rows[0].errlevel == 2
+    assert "仅支持DML和DDL语句" in ret.rows[0].errormessage
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 8, 3))
+def test_execute_check_critical_ddl(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    _mock_config(engine, critical_ddl_regex="^drop")
+    ret = engine.execute_check(db_name="db", sql="drop table t1;")
+    assert ret.rows[0].errlevel == 2
+    assert "高危" in ret.rows[0].stagestatus
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 1, 2))
+@patch.object(ClickHouseEngine, "get_table_engine")
+def test_execute_check_alter_table_not_exist(mock_get_engine, mock_instance):
+    mock_get_engine.return_value = {"status": 0, "engine": "None"}
+    engine = ClickHouseEngine(instance=mock_instance)
+    _mock_config(engine)
+    ret = engine.execute_check(db_name="db", sql="alter table t1 add column c Int;")
+    assert ret.rows[0].errlevel == 2
+    assert ret.rows[0].stagestatus == "表不存在"
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 1, 2))
+@patch.object(ClickHouseEngine, "get_table_engine")
+def test_execute_check_alter_table_unsupported_engine(mock_get_engine, mock_instance):
+    mock_get_engine.return_value = {"status": 1, "engine": "Log"}
+    engine = ClickHouseEngine(instance=mock_instance)
+    _mock_config(engine)
+    ret = engine.execute_check(db_name="db", sql="alter table t1 add column c Int;")
+    assert ret.rows[0].errlevel == 2
+    assert "MergeTree" in ret.rows[0].errormessage
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 1, 2))
+@patch.object(ClickHouseEngine, "get_table_engine")
+@patch.object(ClickHouseEngine, "explain_check")
+def test_execute_check_alter_table_mergetree(
+    mock_explain, mock_get_engine, mock_instance
+):
+    mock_get_engine.return_value = {"status": 1, "engine": "MergeTree"}
+    mock_explain.return_value = ReviewResult(
+        id=1,
+        errlevel=0,
+        stagestatus="Audit completed",
+        errormessage="None",
+        sql="alter table t1 add column c Int",
+        affected_rows=0,
+        execute_time=0,
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    _mock_config(engine)
+    ret = engine.execute_check(db_name="db", sql="alter table t1 add column c Int;")
+    assert ret.rows[0].errlevel == 0
+    mock_explain.assert_called_once()
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 1, 2))
+@patch.object(ClickHouseEngine, "get_table_engine")
+def test_execute_check_alter_delete_non_mergetree(mock_get_engine, mock_instance):
+    mock_get_engine.return_value = {"status": 1, "engine": "Distributed"}
+    engine = ClickHouseEngine(instance=mock_instance)
+    _mock_config(engine)
+    ret = engine.execute_check(db_name="db", sql="alter table t1 delete where id=1;")
+    assert ret.rows[0].errlevel == 2
+    assert "DELETE与UPDATE" in ret.rows[0].errormessage
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 1, 2))
+@patch.object(ClickHouseEngine, "get_table_engine")
+def test_execute_check_truncate_unsupported_engine(mock_get_engine, mock_instance):
+    mock_get_engine.return_value = {"status": 1, "engine": "View"}
+    engine = ClickHouseEngine(instance=mock_instance)
+    _mock_config(engine)
+    ret = engine.execute_check(db_name="db", sql="truncate table t1;")
+    assert ret.rows[0].errlevel == 2
+    assert "TRUNCATE" in ret.rows[0].errormessage
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 1, 2))
+@patch.object(ClickHouseEngine, "get_table_engine")
+def test_execute_check_truncate_table_not_exist(mock_get_engine, mock_instance):
+    mock_get_engine.return_value = {"status": 0, "engine": "None"}
+    engine = ClickHouseEngine(instance=mock_instance)
+    _mock_config(engine)
+    ret = engine.execute_check(db_name="db", sql="truncate table t1;")
+    assert ret.rows[0].errlevel == 2
+    assert ret.rows[0].stagestatus == "表不存在"
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 1, 2))
+@patch.object(ClickHouseEngine, "get_table_engine")
+def test_execute_check_insert_table_exist(mock_get_engine, mock_instance):
+    mock_get_engine.return_value = {"status": 1, "engine": "MergeTree"}
+    engine = ClickHouseEngine(instance=mock_instance)
+    _mock_config(engine)
+    ret = engine.execute_check(db_name="db", sql="insert into t1 values (1, 'a');")
+    assert ret.rows[0].errlevel == 0
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 1, 2))
+@patch.object(ClickHouseEngine, "get_table_engine")
+def test_execute_check_insert_table_not_exist(mock_get_engine, mock_instance):
+    mock_get_engine.return_value = {"status": 0, "engine": "None"}
+    engine = ClickHouseEngine(instance=mock_instance)
+    _mock_config(engine)
+    ret = engine.execute_check(db_name="db", sql="insert into t1 values (1, 'a');")
+    assert ret.rows[0].errlevel == 2
+    assert ret.rows[0].stagestatus == "表不存在"
+
+
+@patch.object(ClickHouseEngine, "server_version", new=(21, 1, 2))
+def test_execute_check_insert_bad_syntax(mock_instance):
+    engine = ClickHouseEngine(instance=mock_instance)
+    _mock_config(engine)
+    ret = engine.execute_check(db_name="db", sql="insert into ;")
+    assert ret.rows[0].errlevel == 2
+    assert "INSERT语法不正确" in ret.rows[0].errormessage
+
+
+# ----------------- execute -----------------
+@patch("sql.engines.clickhouse.connect")
+def test_execute_success(mock_connect, mock_instance):
+    mock_cursor = Mock()
+    mock_connect.return_value.cursor.return_value = mock_cursor
+    engine = ClickHouseEngine(instance=mock_instance)
+    result = engine.execute(db_name="db", sql="insert into t1 values(1);")
+    assert isinstance(result, ResultSet)
+    assert result.error is None
+    mock_cursor.execute.assert_called()
+
+
+@patch("sql.engines.clickhouse.connect")
+def test_execute_error(mock_connect, mock_instance):
+    mock_cursor = Mock()
+    mock_cursor.execute.side_effect = Exception("failed\nStack trace:...")
+    mock_connect.return_value.cursor.return_value = mock_cursor
+    engine = ClickHouseEngine(instance=mock_instance)
+    result = engine.execute(db_name="db", sql="bad sql")
+    assert "failed" in result.error
+    assert "Stack trace" not in result.error
+
+
+# ----------------- execute_workflow -----------------
+def _build_workflow_mock(sql_content, db_name="db"):
+    wf = Mock()
+    wf.db_name = db_name
+    wf.sqlworkflowcontent = Mock()
+    wf.sqlworkflowcontent.sql_content = sql_content
+    return wf
+
+
+@patch.object(ClickHouseEngine, "execute")
+def test_execute_workflow_all_success(mock_execute, mock_instance):
+    rs = ResultSet()
+    rs.error = None
+    mock_execute.return_value = rs
+    wf = _build_workflow_mock("insert into t values(1);insert into t values(2);")
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.execute_workflow(wf)
+    assert isinstance(ret, ReviewSet)
+    assert len(ret.rows) == 2
+    for r in ret.rows:
+        assert r.errlevel == 0
+
+
+@patch.object(ClickHouseEngine, "execute")
+def test_execute_workflow_fail_stop(mock_execute, mock_instance):
+    ok = ResultSet()
+    ok.error = None
+    bad = ResultSet()
+    bad.error = "err"
+    mock_execute.side_effect = [ok, bad]
+    wf = _build_workflow_mock(
+        "insert into t values(1);insert into t values(2);insert into t values(3);"
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.execute_workflow(wf)
+    # 第一条成功，第二条失败，第三条标记为未执行
+    assert ret.rows[0].errlevel == 0
+    assert ret.rows[1].errlevel == 2
+    assert ret.error == "err"
+
+
+# ----------------- 数据字典相关 -----------------
+@patch.object(ClickHouseEngine, "query")
+def test_get_group_tables_by_db(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        rows=[("apple", "c1"), ("ant", "c2"), ("banana", "c3")]
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.get_group_tables_by_db(db_name="db")
+    assert "a" in ret
+    assert "b" in ret
+    assert len(ret["a"]) == 2
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_get_table_meta_data(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        column_list=["table_name", "engine"],
+        rows=[("t1", "MergeTree")],
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.get_table_meta_data(db_name="db", tb_name="t1")
+    assert ret["column_list"] == ["table_name", "engine"]
+    assert ret["rows"] == ("t1", "MergeTree")
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_get_table_desc_data(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        column_list=["列名", "列类型"],
+        rows=[("id", "Int32"), ("name", "String")],
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.get_table_desc_data(db_name="db", tb_name="t1")
+    assert len(ret["rows"]) == 2
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_get_table_index_data(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        column_list=["索引名", "索引类型", "索引表达式", "粒度"],
+        rows=[("idx1", "minmax", "id", 8192)],
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.get_table_index_data(db_name="db", tb_name="t1")
+    assert len(ret["rows"]) == 1
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_get_tables_metas_data(mock_query, mock_instance):
+    tbs_rs = ResultSet(
+        column_list=["TABLE_NAME", "TABLE_COMMENT", "ENGINE"],
+        rows=[("t1", "comment", "MergeTree")],
+    )
+    cols_rs = ResultSet(
+        column_list=[
+            "COLUMN_NAME",
+            "COLUMN_TYPE",
+            "COLUMN_DEFAULT",
+            "IS_IN_PRIMARY_KEY",
+            "COLUMN_COMMENT",
+        ],
+        rows=[("id", "Int32", "", 1, "主键"), ("name", "String", "", 0, "名称")],
+    )
+    mock_query.side_effect = [tbs_rs, cols_rs]
+    engine = ClickHouseEngine(instance=mock_instance)
+    ret = engine.get_tables_metas_data(db_name="db")
+    assert len(ret) == 1
+    assert ret[0]["TABLE_INFO"]["TABLE_NAME"] == "t1"
+    assert len(ret[0]["COLUMNS"]) == 2
+    assert ret[0]["COLUMNS"][0]["COLUMN_NAME"] == "id"

--- a/sql/templates/data_dictionary.html
+++ b/sql/templates/data_dictionary.html
@@ -13,6 +13,7 @@
                         <optgroup id="optgroup-mysql" label="MySQL"></optgroup>
                         <optgroup id="optgroup-mssql" label="MsSQL"></optgroup>
                         <optgroup id="optgroup-oracle" label="Oracle"></optgroup>
+                        <optgroup id="optgroup-clickhouse" label="ClickHouse"></optgroup>
                     </select>
                 </div>
                 <div class="form-group">
@@ -196,6 +197,80 @@
                         </div>
                     </div>
                 </div> <!--modal-body-->
+                <div class="modal-body" id="modal-body-clickhouse" >
+                    <div class="panel panel-default">
+                        <div class="panel-heading">表信息</div>
+                        <div class="panel-body">
+                            <div class="table-responsive">
+                                <table id="meta_data" class="table table-striped table-hover"
+                                       style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+                                    <tbody>
+                                    <tr>
+                                        <th>表名</th>
+                                        <td id="table_name"></td>
+                                        <th>引擎</th>
+                                        <td id="engine"></td>
+                                    </tr>
+                                    <tr>
+                                        <th>表行数</th>
+                                        <td id="table_rows"></td>
+                                        <th>数据大小</th>
+                                        <td id="data_length"></td>
+                                    </tr>
+                                    <tr>
+                                        <th>分区键</th>
+                                        <td id="partition_key"></td>
+                                        <th>排序键</th>
+                                        <td id="sorting_key"></td>
+                                    </tr>
+                                    <tr>
+                                        <th>主键</th>
+                                        <td id="primary_key"></td>
+                                        <th>采样键</th>
+                                        <td id="sampling_key"></td>
+                                    </tr>
+                                    <tr>
+                                        <th>创建时间</th>
+                                        <td id="create_time"></td>
+                                        <th>表说明</th>
+                                        <td id="table_comment"></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel panel-default">
+                        <div class="panel-heading">列信息</div>
+                        <div class="panel-body">
+                            <div class="table-responsive">
+                                <table id="field-list-clickhouse" data-toggle="table" class="table table-striped table-hover"
+                                       style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel panel-default">
+                        <div class="panel-heading">索引信息</div>
+                        <div class="panel-body">
+                            <div class="table-responsive">
+                                <table id="index-list-clickhouse" data-toggle="table" class="table table-striped table-hover"
+                                       style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel panel-default">
+                        <div class="panel-heading">建表语句</div>
+                        <div class="panel-body">
+                            <div class="table-responsive">
+                                <table id="create-table-sql-clickhouse" data-toggle="table" class="table table-striped table-hover"
+                                       style="table-layout:inherit;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div> <!--modal-body-->
                 <div class="modal-body" id="modal-body-oracle" >
                     <div class="panel panel-default">
                         <div class="panel-heading">表信息</div>
@@ -290,7 +365,7 @@
                     url: "/group/user_all_instances/",
                     dataType: "json",
                     data: {
-                        db_type: ['mysql', 'mssql', 'oracle']
+                        db_type: ['mysql', 'mssql', 'oracle', 'clickhouse']
                     },
                     complete: function () {
                         if ($('#instance_name').val()) {
@@ -305,6 +380,7 @@
                             $("#optgroup-mysql").empty();
                             $("#optgroup-mssql").empty();
                             $("#optgroup-oracle").empty();
+                            $("#optgroup-clickhouse").empty();
                             console.log(instance_result);
                             for (let i = 0; i < result.length; i++) {
                                 let instance_name = "<option value=\"" + result[i]['instance_name'] + "\">" + result[i]['instance_name'] + "</option>";
@@ -314,6 +390,8 @@
                                     $("#optgroup-mssql").append(instance_name);
                                 } else if (result[i]['db_type'] === 'oracle') {
                                     $("#optgroup-oracle").append(instance_name);
+                                } else if (result[i]['db_type'] === 'clickhouse') {
+                                    $("#optgroup-clickhouse").append(instance_name);
                                 }
                             }
                             $('#instance_name').selectpicker('render');
@@ -459,7 +537,6 @@
                         var result = data.data;
                         if (inst_db_type === 'mysql') {
                             showModalBody('mysql');
-                            //console.log("hide_oracle");
 
                             $("#create-table-sql").bootstrapTable('destroy').bootstrapTable({
                                 data: result['create_sql'],
@@ -467,20 +544,33 @@
                                     field: 1,
                                     formatter: function (value, row, index) {
                                         var sql = window.sqlFormatter.format(value);
-                                        //替换所有的换行符
                                         sql = sql.replace(/\r\n/g, "<br>");
                                         sql = sql.replace(/\n/g, "<br>");
-                                        //替换所有的空格
                                         sql = sql.replace(/\s/g, " ");
                                         return sql;
+                                    }
+                                }],
+                                locale: 'zh-CN'
+                            });
+                        } else if (inst_db_type === 'clickhouse') {
+                            showModalBody('clickhouse');
 
+                            $("#create-table-sql-clickhouse").bootstrapTable('destroy').bootstrapTable({
+                                data: result['create_sql'],
+                                columns: [{
+                                    field: 0,
+                                    formatter: function (value, row, index) {
+                                        var sql = value;
+                                        sql = sql.replace(/\r\n/g, "<br>");
+                                        sql = sql.replace(/\n/g, "<br>");
+                                        sql = sql.replace(/\s/g, " ");
+                                        return sql;
                                     }
                                 }],
                                 locale: 'zh-CN'
                             });
                         } else if (inst_db_type === 'oracle') {
                             showModalBody('oracle');
-                            //console.log("hide_mysql");
                         } else if (inst_db_type === 'mssql') {
                             showModalBody('mssql');
                         }


### PR DESCRIPTION
数据字典当前默认的数据库engine为："mysql", "mssql", "oracle"
增加clickhouse的支持，clickhouse的engine实现相同的方法调用。

测试案例：创建带主键索引和二级索引的表，查看对应的数据字典

```sql
CREATE TABLE my_table (
    event_time DateTime,
    user_id UInt64,
    product_id String,
    price Float64,
    -- 声明二级索引
    INDEX idx_user (user_id) TYPE minmax GRANULARITY 4,
    INDEX idx_product (product_id) TYPE bloom_filter() GRANULARITY 3
)
ENGINE = MergeTree()
ORDER BY (event_time, user_id);  -- 定义主键/排序键索引
```
