### PR TITLE
add(redis-slowlog):增加redis的慢查询日志采集和展示

### DIFF
--- a/common/utils/chart_dao.py
+++ b/common/utils/chart_dao.py
@@ -141,7 +141,7 @@ group by date(date_add(ts_min, interval 8 HOUR));"""
 
     # 慢日志历史趋势图(按时长)
     def slow_query_review_history_by_pct_95_time(self, checksum):
-        sql = f"""select truncate(Query_time_pct_95,6),date(date_add(ts_min, interval 8 HOUR))
+        sql = f"""select truncate(MAX(Query_time_pct_95),6),date(date_add(ts_min, interval 8 HOUR))
 from mysql_slow_query_review_history
 where checksum = '{checksum}'
 group by date(date_add(ts_min, interval 8 HOUR));"""
@@ -160,7 +160,7 @@ group by date(ts_min);"""
     # Redis慢日志历史趋势图(按时长)
     def redis_slow_query_review_history_by_pct_95_time(self, checksum, hostnames):
         hostname_list = "','".join(hostnames)
-        sql = f"""select truncate(duration_pct_95,6),date(ts_min)
+        sql = f"""select truncate(MAX(duration_pct_95),6),date(ts_min)
 from redis_slow_query_review_history
 where checksum = '{checksum}'
 and hostname in ('{hostname_list}')

--- a/common/utils/chart_dao.py
+++ b/common/utils/chart_dao.py
@@ -147,6 +147,26 @@ where checksum = '{checksum}'
 group by date(date_add(ts_min, interval 8 HOUR));"""
         return self.__query(sql)
 
+    # Redis慢日志历史趋势图(按次数)
+    def redis_slow_query_review_history_by_cnt(self, checksum, hostnames):
+        hostname_list = "','".join(hostnames)
+        sql = f"""select sum(cnt),date(ts_min)
+from redis_slow_query_review_history
+where checksum = '{checksum}'
+and hostname in ('{hostname_list}')
+group by date(ts_min);"""
+        return self.__query(sql)
+
+    # Redis慢日志历史趋势图(按时长)
+    def redis_slow_query_review_history_by_pct_95_time(self, checksum, hostnames):
+        hostname_list = "','".join(hostnames)
+        sql = f"""select truncate(duration_pct_95,6),date(ts_min)
+from redis_slow_query_review_history
+where checksum = '{checksum}'
+and hostname in ('{hostname_list}')
+group by date(ts_min);"""
+        return self.__query(sql)
+
     # 慢日志db/user维度统计
     def slow_query_count_by_db_by_user(self):
         sql = """

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ mysql-replication==0.22
 django-q==1.3.9
 django-redis==5.2.0
 redis==3.5.3
+redis-py-cluster==2.1.3
 pyodbc==4.*
 gunicorn==22.0.0
 pyecharts==2.0.4

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -70,11 +70,10 @@ class RedisEngine(EngineBase):
                     continue
                 parts = line.split()
                 if len(parts) >= 8 and "master" in parts[2] and "fail" not in parts[2]:
-                    host_port = parts[1]
-                    # 处理格式: 127.0.0.1:7001@17001
-                    host = host_port.split(":")[0]
-                    port = host_port.split(":")[1].split("@")[0]
-                    masters.append(f"{host}:{port}")
+                    # 处理格式: 127.0.0.1:7001@17001、[2001:db8::10]:6379@16379、2001:db8::10:6379@16379
+                    # 截取@之前的字符串，去掉[]即为 host:port
+                    host_port = parts[1].split("@")[0].replace("[", "").replace("]", "")
+                    masters.append(host_port)
             return masters if masters else [f"{self.host}:{self.port}"]
         except Exception as e:
             logger.warning(f"获取Redis集群节点失败: {e}")

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -61,8 +61,8 @@ class RedisEngine(EngineBase):
         """
         if self.mode != "cluster":
             return [f"{self.host}:{self.port}"]
-        conn = self.get_connection()
         try:
+            conn = self.get_connection()
             nodes_info = conn.execute_command("CLUSTER", "NODES")
             masters = []
             for line in nodes_info.split("\n"):
@@ -89,8 +89,8 @@ class RedisEngine(EngineBase):
         :return:
         """
         result = ResultSet(full_sql="CONFIG GET databases")
-        conn = self.get_connection()
         try:
+            conn = self.get_connection()
             rows = conn.config_get("databases")["databases"]
         except Exception as e:
             """

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -72,7 +72,8 @@ class RedisEngine(EngineBase):
                 if len(parts) >= 8 and "master" in parts[2] and "fail" not in parts[2]:
                     # 处理格式: 127.0.0.1:7001@17001、[2001:db8::10]:6379@16379、2001:db8::10:6379@16379
                     # 截取@之前的字符串，去掉[]即为 host:port
-                    host_port = parts[1].split("@")[0].replace("[", "").replace("]", "")
+                    # 兼容redis7.2,hostname有可能在@之前，例如：ip:port,hostname@cport
+                    host_port = parts[1].split("@")[0].split(",")[0].replace("[", "").replace("]", "")
                     masters.append(host_port)
             return masters if masters else [f"{self.host}:{self.port}"]
         except Exception as e:

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -11,6 +11,7 @@ import re
 import shlex
 
 import redis
+import rediscluster
 import logging
 import traceback
 
@@ -27,9 +28,8 @@ class RedisEngine(EngineBase):
     def get_connection(self, db_name=None):
         db_name = db_name or self.db_name
         if self.mode == "cluster":
-            return redis.cluster.RedisCluster(
-                host=self.host,
-                port=self.port,
+            return rediscluster.RedisCluster(
+                startup_nodes=[{"host": self.host, "port": self.port}],
                 username=self.user,
                 password=self.password or None,
                 encoding_errors="ignore",
@@ -53,6 +53,32 @@ class RedisEngine(EngineBase):
     name = "Redis"
 
     info = "Redis engine"
+
+    def get_cluster_master_nodes(self):
+        """
+        获取Redis集群所有主节点的host:port列表
+        单机模式返回当前实例的host:port
+        """
+        if self.mode != "cluster":
+            return [f"{self.host}:{self.port}"]
+        conn = self.get_connection()
+        try:
+            nodes_info = conn.execute_command("CLUSTER", "NODES")
+            masters = []
+            for line in nodes_info.split("\n"):
+                if not line.strip():
+                    continue
+                parts = line.split()
+                if len(parts) >= 8 and "master" in parts[2] and "fail" not in parts[2]:
+                    host_port = parts[1]
+                    # 处理格式: 127.0.0.1:7001@17001
+                    host = host_port.split(":")[0]
+                    port = host_port.split(":")[1].split("@")[0]
+                    masters.append(f"{host}:{port}")
+            return masters if masters else [f"{self.host}:{self.port}"]
+        except Exception as e:
+            logger.warning(f"获取Redis集群节点失败: {e}")
+            return [f"{self.host}:{self.port}"]
 
     def test_connection(self):
         return self.get_all_databases()

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -73,7 +73,13 @@ class RedisEngine(EngineBase):
                     # 处理格式: 127.0.0.1:7001@17001、[2001:db8::10]:6379@16379、2001:db8::10:6379@16379
                     # 截取@之前的字符串，去掉[]即为 host:port
                     # 兼容redis7.2,hostname有可能在@之前，例如：ip:port,hostname@cport
-                    host_port = parts[1].split("@")[0].split(",")[0].replace("[", "").replace("]", "")
+                    host_port = (
+                        parts[1]
+                        .split("@")[0]
+                        .split(",")[0]
+                        .replace("[", "")
+                        .replace("]", "")
+                    )
                     masters.append(host_port)
             return masters if masters else [f"{self.host}:{self.port}"]
         except Exception as e:

--- a/sql/engines/test_redis.py
+++ b/sql/engines/test_redis.py
@@ -1,0 +1,869 @@
+# -*- coding: UTF-8 -*-
+"""
+Redis 引擎单元测试
+对 sql/engines/redis.py 中的 RedisEngine 进行全面的功能覆盖测试
+
+所有测试使用 Mock 对象模拟 Instance，不依赖真实 Redis 服务
+"""
+
+import json
+from unittest.mock import patch, Mock, MagicMock, call
+
+import pytest
+
+from sql.engines.redis import RedisEngine
+from sql.engines.models import ResultSet, ReviewSet, ReviewResult
+
+# ====================== Fixtures ======================
+
+
+@pytest.fixture
+def mock_instance():
+    """模拟 Instance 对象，避免对 Django ORM 和数据库的依赖"""
+    ins = Mock()
+    ins.instance_name = "redis_ins"
+    ins.host = "127.0.0.1"
+    ins.port = 6379
+    ins.db_name = "0"
+    ins.db_type = "redis"
+    ins.mode = ""
+    ins.tunnel = None
+    ins.is_ssl = False
+    ins.get_username_password.return_value = ("ins_user", "some_str")
+    return ins
+
+
+@pytest.fixture
+def mock_cluster_instance():
+    """模拟集群模式 Instance 对象"""
+    ins = Mock()
+    ins.instance_name = "redis_cluster_ins"
+    ins.host = "127.0.0.1"
+    ins.port = 7001
+    ins.db_name = "0"
+    ins.db_type = "redis"
+    ins.mode = "cluster"
+    ins.tunnel = None
+    ins.is_ssl = False
+    ins.get_username_password.return_value = ("ins_user", "some_str")
+    return ins
+
+
+@pytest.fixture
+def redis_engine(mock_instance):
+    """创建 RedisEngine 实例（单机模式）"""
+    return RedisEngine(instance=mock_instance)
+
+
+@pytest.fixture
+def redis_cluster_engine(mock_cluster_instance):
+    """创建 RedisEngine 实例（集群模式）"""
+    return RedisEngine(instance=mock_cluster_instance)
+
+
+# ====================== 基本属性 ======================
+
+
+def test_engine_base_info(redis_engine):
+    """测试引擎基本属性"""
+    assert redis_engine.name == "Redis"
+    assert redis_engine.info == "Redis engine"
+
+
+# ====================== get_connection ======================
+
+
+@patch("sql.engines.redis.redis.Redis")
+def test_get_connection_standalone(mock_redis, redis_engine):
+    """测试单机模式获取连接"""
+    redis_engine.get_connection()
+    mock_redis.assert_called_once()
+    kwargs = mock_redis.call_args.kwargs
+    assert kwargs["host"] == "127.0.0.1"
+    assert kwargs["port"] == 6379
+    assert kwargs["db"] == "0"
+    assert kwargs["username"] == "ins_user"
+    assert kwargs["password"] == "some_str"
+    assert kwargs["decode_responses"] is True
+    assert kwargs["ssl"] is False
+
+
+@patch("sql.engines.redis.redis.Redis")
+def test_get_connection_standalone_with_db_name(mock_redis, redis_engine):
+    """测试单机模式指定 db_name 获取连接"""
+    redis_engine.get_connection(db_name="3")
+    kwargs = mock_redis.call_args.kwargs
+    assert kwargs["db"] == "3"
+
+
+@patch("sql.engines.redis.rediscluster.RedisCluster")
+def test_get_connection_cluster(mock_redis_cluster, redis_cluster_engine):
+    """测试集群模式获取连接"""
+    redis_cluster_engine.get_connection()
+    mock_redis_cluster.assert_called_once()
+    kwargs = mock_redis_cluster.call_args.kwargs
+    assert kwargs["startup_nodes"] == [{"host": "127.0.0.1", "port": 7001}]
+    assert kwargs["username"] == "ins_user"
+    assert kwargs["password"] == "some_str"
+    assert kwargs["decode_responses"] is True
+    assert kwargs["ssl"] is False
+
+
+@patch("sql.engines.redis.rediscluster.RedisCluster")
+def test_get_connection_cluster_ignores_db_name(
+    mock_redis_cluster, redis_cluster_engine
+):
+    """测试集群模式忽略 db_name 参数"""
+    redis_cluster_engine.get_connection(db_name="5")
+    kwargs = mock_redis_cluster.call_args.kwargs
+    # 集群模式不传 db 参数
+    assert "db" not in kwargs
+
+
+@patch("sql.engines.redis.redis.Redis")
+def test_get_connection_empty_password(mock_redis, mock_instance):
+    """测试密码为空时传 None"""
+    mock_instance.get_username_password.return_value = ("user", "")
+    engine = RedisEngine(instance=mock_instance)
+    engine.get_connection()
+    kwargs = mock_redis.call_args.kwargs
+    assert kwargs["password"] is None
+
+
+@patch("sql.engines.redis.redis.Redis")
+def test_get_connection_ssl(mock_redis, mock_instance):
+    """测试 SSL 连接"""
+    mock_instance.is_ssl = True
+    engine = RedisEngine(instance=mock_instance)
+    engine.get_connection()
+    kwargs = mock_redis.call_args.kwargs
+    assert kwargs["ssl"] is True
+
+
+# ====================== get_cluster_master_nodes ======================
+
+
+def test_get_cluster_master_nodes_standalone(redis_engine):
+    """测试单机模式获取主节点，返回自身 host:port"""
+    nodes = redis_engine.get_cluster_master_nodes()
+    assert nodes == ["127.0.0.1:6379"]
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_get_cluster_master_nodes_cluster(mock_get_conn, redis_cluster_engine):
+    """测试集群模式获取主节点列表"""
+    cluster_nodes_output = (
+        "nodeid1 127.0.0.1:7001@17001 myself,master - 0 1600000000 1 connected 0-5460\n"
+        "nodeid2 127.0.0.1:7002@17002 master - 0 1600000000 2 connected 5461-10922\n"
+        "nodeid3 127.0.0.1:7003@17003 slave nodeid2 0 1600000000 3 connected\n"
+    )
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = cluster_nodes_output
+    mock_get_conn.return_value = mock_conn
+
+    nodes = redis_cluster_engine.get_cluster_master_nodes()
+    assert len(nodes) == 2
+    assert "127.0.0.1:7001" in nodes
+    assert "127.0.0.1:7002" in nodes
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_get_cluster_master_nodes_cluster_with_fail(
+    mock_get_conn, redis_cluster_engine
+):
+    """测试集群模式中包含 fail 标记的主节点应被排除"""
+    cluster_nodes_output = (
+        "nodeid1 127.0.0.1:7001@17001 myself,master,fail - 0 1600000000 1 connected 0-5460\n"
+        "nodeid2 127.0.0.1:7002@17002 master - 0 1600000000 2 connected 5461-10922\n"
+    )
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = cluster_nodes_output
+    mock_get_conn.return_value = mock_conn
+
+    nodes = redis_cluster_engine.get_cluster_master_nodes()
+    assert len(nodes) == 1
+    assert "127.0.0.1:7002" in nodes
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_get_cluster_master_nodes_cluster_no_masters(
+    mock_get_conn, redis_cluster_engine
+):
+    """测试集群模式无主节点时回退到自身 host:port"""
+    cluster_nodes_output = (
+        "nodeid3 127.0.0.1:7003@17003 slave nodeid2 0 1600000000 3 connected\n"
+    )
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = cluster_nodes_output
+    mock_get_conn.return_value = mock_conn
+
+    nodes = redis_cluster_engine.get_cluster_master_nodes()
+    # 无 master 时回退到自身
+    assert nodes == ["127.0.0.1:7001"]
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_get_cluster_master_nodes_cluster_exception(
+    mock_get_conn, redis_cluster_engine
+):
+    """测试集群模式获取节点信息异常时回退到自身"""
+    mock_conn = Mock()
+    mock_conn.execute_command.side_effect = Exception("connection error")
+    mock_get_conn.return_value = mock_conn
+
+    nodes = redis_cluster_engine.get_cluster_master_nodes()
+    assert nodes == ["127.0.0.1:7001"]
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_get_cluster_master_nodes_ipv6(mock_get_conn, redis_cluster_engine):
+    """测试集群模式中 IPv6 地址的解析"""
+    cluster_nodes_output = "nodeid1 [2001:db8::10]:6379@16379 myself,master - 0 1600000000 1 connected 0-5460\n"
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = cluster_nodes_output
+    mock_get_conn.return_value = mock_conn
+
+    nodes = redis_cluster_engine.get_cluster_master_nodes()
+    assert len(nodes) == 1
+    assert nodes[0] == "2001:db8::10:6379"
+
+
+# ====================== test_connection ======================
+
+
+@patch.object(RedisEngine, "get_all_databases")
+def test_test_connection(mock_get_all_dbs, redis_engine):
+    """测试连接测试，应委托给 get_all_databases"""
+    expected = ResultSet(full_sql="CONFIG GET databases")
+    expected.rows = ["0", "1"]
+    mock_get_all_dbs.return_value = expected
+
+    result = redis_engine.test_connection()
+    assert result is expected
+    mock_get_all_dbs.assert_called_once()
+
+
+# ====================== get_all_databases ======================
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_get_all_databases_normal(mock_get_conn, redis_engine):
+    """测试正常获取数据库列表"""
+    mock_conn = Mock()
+    mock_conn.config_get.return_value = {"databases": 16}
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.get_all_databases()
+    assert isinstance(result, ResultSet)
+    assert result.rows == [str(x) for x in range(16)]
+    assert result.full_sql == "CONFIG GET databases"
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_get_all_databases_fallback_via_info(mock_get_conn, redis_engine):
+    """测试 CONFIG GET 失败时通过 info(Keyspace) 回退"""
+    mock_conn = Mock()
+    mock_conn.config_get.side_effect = Exception("NOPERM this user has no permissions")
+    mock_conn.info.return_value = {"db0": {}, "db3": {}, "db5": {}}
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.get_all_databases()
+    assert isinstance(result, ResultSet)
+    # max([0,3,5] + [15]) + 1 = 16, 所以 0~15
+    assert result.rows == [str(x) for x in range(16)]
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_get_all_databases_fallback_with_high_db(mock_get_conn, redis_engine):
+    """测试 info(Keyspace) 返回高编号数据库时的回退逻辑"""
+    mock_conn = Mock()
+    mock_conn.config_get.side_effect = Exception("NOPERM")
+    mock_conn.info.return_value = {"db20": {}, "db5": {}}
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.get_all_databases()
+    # max([20,5] + [15]) + 1 = 21, 所以 0~20
+    assert len(result.rows) == 21
+    assert result.rows[0] == "0"
+    assert result.rows[20] == "20"
+
+
+# ====================== get_all_tables ======================
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_get_all_tables_normal(mock_get_conn, redis_engine):
+    """测试获取 key 列表"""
+    mock_conn = Mock()
+    mock_conn.scan_iter.return_value = iter(["key1", "key2", "key3"])
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.get_all_tables(db_name="0")
+    assert isinstance(result, ResultSet)
+    assert result.rows == ["key1", "key2", "key3"]
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_get_all_tables_max_results(mock_get_conn, redis_engine):
+    """测试获取 key 列表不超过最大数量 100"""
+    mock_conn = Mock()
+    # 生成超过100个 key
+    keys = [f"key_{i}" for i in range(150)]
+    mock_conn.scan_iter.return_value = iter(keys)
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.get_all_tables(db_name="0")
+    assert len(result.rows) == 100
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_get_all_tables_error(mock_get_conn, redis_engine):
+    """测试获取 key 列表时出错"""
+    mock_conn = Mock()
+    mock_conn.scan_iter.side_effect = Exception("scan error")
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.get_all_tables(db_name="0")
+    assert isinstance(result, ResultSet)
+    assert result.rows == []
+    assert "scan error" in result.message
+
+
+# ====================== query_check ======================
+
+
+def test_query_check_safe_cmd_get(redis_engine):
+    """测试安全命令 get 通过检查"""
+    result = redis_engine.query_check(sql="get mykey")
+    assert result["bad_query"] is False
+    assert result["msg"] == ""
+
+
+def test_query_check_safe_cmd_ttl(redis_engine):
+    """测试安全命令 ttl 通过检查"""
+    result = redis_engine.query_check(sql="ttl mykey")
+    assert result["bad_query"] is False
+
+
+def test_query_check_safe_cmd_hgetall(redis_engine):
+    """测试安全命令 hgetall 通过检查"""
+    result = redis_engine.query_check(sql="hgetall myhash")
+    assert result["bad_query"] is False
+
+
+def test_query_check_safe_cmd_info(redis_engine):
+    """测试安全命令 info 通过检查"""
+    result = redis_engine.query_check(sql="info")
+    assert result["bad_query"] is False
+
+
+def test_query_check_safe_cmd_scan(redis_engine):
+    """测试安全命令 scan 通过检查"""
+    result = redis_engine.query_check(sql="scan 0 count 10")
+    assert result["bad_query"] is False
+
+
+def test_query_check_unsafe_cmd(redis_engine):
+    """测试不安全命令被拒绝"""
+    result = redis_engine.query_check(sql="set mykey value")
+    assert result["bad_query"] is True
+    assert result["msg"] == "禁止执行该命令！"
+
+
+def test_query_check_unsafe_cmd_del(redis_engine):
+    """测试 del 命令被拒绝"""
+    result = redis_engine.query_check(sql="del mykey")
+    assert result["bad_query"] is True
+
+
+def test_query_check_unsafe_cmd_flushdb(redis_engine):
+    """测试 flushdb 命令被拒绝"""
+    result = redis_engine.query_check(sql="flushdb")
+    assert result["bad_query"] is True
+
+
+def test_query_check_case_insensitive(redis_engine):
+    """测试命令检查大小写不敏感"""
+    result = redis_engine.query_check(sql="GET mykey")
+    assert result["bad_query"] is False
+
+    result2 = redis_engine.query_check(sql="INFO memory")
+    assert result2["bad_query"] is False
+
+
+def test_query_check_filtered_sql_preserved(redis_engine):
+    """测试 query_check 保留原始 sql"""
+    sql = "get mykey"
+    result = redis_engine.query_check(sql=sql)
+    assert result["filtered_sql"] == sql
+
+
+def test_query_check_has_star_default(redis_engine):
+    """测试 query_check has_star 默认为 False"""
+    result = redis_engine.query_check(sql="get mykey")
+    assert result["has_star"] is False
+
+
+# ====================== processlist ======================
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_processlist(mock_get_conn, redis_engine):
+    """测试获取连接列表"""
+    mock_conn = Mock()
+    clients = [
+        {"id": 1, "addr": "127.0.0.1:12345", "idle": 100},
+        {"id": 2, "addr": "127.0.0.1:12346", "idle": 50},
+    ]
+    mock_conn.client_list.return_value = clients
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.processlist(command_type="All")
+    assert isinstance(result, ResultSet)
+    assert result.full_sql == "client list"
+    # 结果按 idle 升序排列
+    assert result.rows[0]["idle"] == 50
+    assert result.rows[1]["idle"] == 100
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_processlist_sorted_by_idle(mock_get_conn, redis_engine):
+    """测试连接列表按 idle 时间排序"""
+    mock_conn = Mock()
+    clients = [
+        {"id": 1, "addr": "127.0.0.1:12345", "idle": 300},
+        {"id": 2, "addr": "127.0.0.1:12346", "idle": 10},
+        {"id": 3, "addr": "127.0.0.1:12347", "idle": 100},
+    ]
+    mock_conn.client_list.return_value = clients
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.processlist(command_type="All")
+    idle_values = [c["idle"] for c in result.rows]
+    assert idle_values == [10, 100, 300]
+
+
+# ====================== query ======================
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_query_list_result(mock_get_conn, redis_engine):
+    """测试查询返回列表结果"""
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = ["val1", "val2", "val3"]
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.query(db_name="0", sql="mget key1 key2 key3")
+    assert isinstance(result, ResultSet)
+    assert result.column_list == ["Result"]
+    assert result.rows == (["val1"], ["val2"], ["val3"])
+    assert result.affected_rows == 3
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_query_dict_result(mock_get_conn, redis_engine):
+    """测试查询返回字典结果"""
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = {"key1": "val1", "key2": "val2"}
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.query(db_name="0", sql="hgetall myhash")
+    assert isinstance(result, ResultSet)
+    assert result.column_list == ["field", "value"]
+    assert result.affected_rows == 2
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_query_dict_with_nested_dict(mock_get_conn, redis_engine):
+    """测试查询返回字典中包含嵌套 dict 时转为 JSON"""
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = {"key1": {"nested": "val"}}
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.query(db_name="0", sql="hgetall myhash")
+    assert result.column_list == ["field", "value"]
+    # 嵌套 dict 应被转为 json 字符串
+    for row in result.rows:
+        if row[0] == "key1":
+            assert row[1] == json.dumps({"nested": "val"})
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_query_dict_with_nested_list(mock_get_conn, redis_engine):
+    """测试查询返回字典中包含 list 时转为 JSON"""
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = {"key1": [1, 2, 3]}
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.query(db_name="0", sql="hgetall myhash")
+    for row in result.rows:
+        if row[0] == "key1":
+            assert row[1] == json.dumps([1, 2, 3])
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_query_scalar_result(mock_get_conn, redis_engine):
+    """测试查询返回标量结果（字符串/数字）"""
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = "hello"
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.query(db_name="0", sql="get mykey")
+    assert isinstance(result, ResultSet)
+    assert result.column_list == ["Result"]
+    assert result.rows == (["hello"],)
+    assert result.affected_rows == 1
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_query_scalar_zero(mock_get_conn, redis_engine):
+    """测试查询返回 0 时的 affected_rows
+    注意：代码中 `1 if rows else 0` 对整数 0 视为 falsy，
+    所以 affected_rows 为 0，这是已知行为"""
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = 0
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.query(db_name="0", sql="exists nonexist")
+    assert result.rows == ([0],)
+    # 0 is falsy in Python, so `1 if rows else 0` evaluates to 0
+    assert result.affected_rows == 0
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_query_scalar_none(mock_get_conn, redis_engine):
+    """测试查询返回 None 时的 affected_rows 为 0"""
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = None
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.query(db_name="0", sql="get nonexist")
+    assert result.rows == ([None],)
+    assert result.affected_rows == 0
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_query_scan_result(mock_get_conn, redis_engine):
+    """测试 scan 命令返回特殊格式结果"""
+    mock_conn = Mock()
+    # scan 返回 (cursor, [keys])
+    mock_conn.execute_command.return_value = ("123", ["key1", "key2"])
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.query(db_name="0", sql="scan 0 count 10")
+    assert isinstance(result, ResultSet)
+    assert result.column_list == ["Result"]
+    # scan 的结果格式: cursor 在第一个, 然后 keys
+    assert result.rows[0] == ["123"]
+    assert result.rows[1] == ["key1"]
+    assert result.rows[2] == ["key2"]
+    assert result.affected_rows == 2
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_query_with_limit(mock_get_conn, redis_engine):
+    """测试查询结果 limit 截断"""
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = ["v1", "v2", "v3", "v4", "v5"]
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.query(db_name="0", sql="mget k1 k2 k3 k4 k5", limit_num=3)
+    assert len(result.rows) == 3
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_query_error(mock_get_conn, redis_engine):
+    """测试查询执行出错"""
+    mock_conn = Mock()
+    mock_conn.execute_command.side_effect = Exception("WRONGTYPE Operation")
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.query(db_name="0", sql="get mykey")
+    assert result.error is not None
+    assert "WRONGTYPE Operation" in result.error
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_query_tuple_result(mock_get_conn, redis_engine):
+    """测试查询返回 tuple 结果"""
+    mock_conn = Mock()
+    mock_conn.execute_command.return_value = ("val1", "val2")
+    mock_get_conn.return_value = mock_conn
+
+    result = redis_engine.query(db_name="0", sql="mget key1 key2")
+    assert result.column_list == ["Result"]
+    assert result.rows == (["val1"], ["val2"])
+    assert result.affected_rows == 2
+
+
+# ====================== filter_sql ======================
+
+
+def test_filter_sql(redis_engine):
+    """测试 filter_sql 仅做 strip"""
+    assert redis_engine.filter_sql(sql="  get mykey  ") == "get mykey"
+
+
+def test_filter_sql_with_limit_num(redis_engine):
+    """测试 filter_sql 忽略 limit_num（Redis 不支持 limit 语法）"""
+    assert redis_engine.filter_sql(sql="get mykey", limit_num=100) == "get mykey"
+
+
+# ====================== query_masking ======================
+
+
+def test_query_masking(redis_engine):
+    """测试 query_masking 不做脱敏，原样返回"""
+    rs = ResultSet(full_sql="get mykey")
+    rs.rows = [["value1"]]
+    result = redis_engine.query_masking(db_name="0", sql="get mykey", resultset=rs)
+    assert result is rs
+
+
+# ====================== execute_check ======================
+
+
+def test_execute_check_single_cmd(redis_engine):
+    """测试审核单条命令"""
+    result = redis_engine.execute_check(db_name="0", sql="set mykey value")
+    assert isinstance(result, ReviewSet)
+    assert len(result.rows) == 1
+    assert result.rows[0].sql == "set mykey value"
+    assert result.rows[0].errlevel == 0
+    assert result.rows[0].stagestatus == "Audit completed"
+    assert result.rows[0].errormessage == "暂不支持显示影响行数"
+
+
+def test_execute_check_multiple_cmds(redis_engine):
+    """测试审核多条命令（按换行分割）"""
+    sql = "set key1 val1\nset key2 val2\nset key3 val3"
+    result = redis_engine.execute_check(db_name="0", sql=sql)
+    assert len(result.rows) == 3
+    for i, row in enumerate(result.rows):
+        assert row.id == i + 1
+        assert row.errlevel == 0
+
+
+def test_execute_check_empty_lines(redis_engine):
+    """测试审核时跳过空行"""
+    sql = "set key1 val1\n\nset key2 val2\n  \n"
+    result = redis_engine.execute_check(db_name="0", sql=sql)
+    assert len(result.rows) == 2
+
+
+def test_execute_check_line_numbers(redis_engine):
+    """测试审核结果的行号递增"""
+    sql = "set key1 val1\nset key2 val2"
+    result = redis_engine.execute_check(db_name="0", sql=sql)
+    assert result.rows[0].id == 1
+    assert result.rows[1].id == 2
+
+
+# ====================== execute_workflow ======================
+
+
+def _build_workflow_mock(sql_content, db_name="0"):
+    """辅助：构造 workflow Mock 对象"""
+    wf = Mock()
+    wf.db_name = db_name
+    wf.sqlworkflowcontent = Mock()
+    wf.sqlworkflowcontent.sql_content = sql_content
+    return wf
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_execute_workflow_all_success(mock_get_conn, redis_engine):
+    """测试执行工作流全部成功"""
+    mock_conn = Mock()
+    mock_get_conn.return_value = mock_conn
+
+    wf = _build_workflow_mock("set key1 val1\nset key2 val2")
+    result = redis_engine.execute_workflow(wf)
+    assert isinstance(result, ReviewSet)
+    assert len(result.rows) == 2
+    assert result.rows[0].errlevel == 0
+    assert result.rows[0].stagestatus == "Execute Successfully"
+    assert result.rows[1].errlevel == 0
+    assert result.rows[1].stagestatus == "Execute Successfully"
+    # 每条命令应调用一次 execute_command
+    assert mock_conn.execute_command.call_count == 2
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_execute_workflow_fail_mid(mock_get_conn, redis_engine):
+    """测试执行工作流中途失败，后续语句标记为未执行"""
+    mock_conn = Mock()
+    mock_conn.execute_command.side_effect = [
+        None,  # 第一条成功
+        Exception("OOM"),  # 第二条失败
+    ]
+    mock_get_conn.return_value = mock_conn
+
+    wf = _build_workflow_mock("set key1 val1\nset key2 val2\nset key3 val3")
+    result = redis_engine.execute_workflow(wf)
+    assert isinstance(result, ReviewSet)
+    # 第一条成功
+    assert result.rows[0].errlevel == 0
+    assert result.rows[0].stagestatus == "Execute Successfully"
+    # 第二条失败
+    assert result.rows[1].errlevel == 2
+    assert result.rows[1].stagestatus == "Execute Failed"
+    assert "OOM" in result.rows[1].errormessage
+    # 第三条未执行
+    assert result.rows[2].errlevel == 0
+    assert result.rows[2].stagestatus == "Audit completed"
+    assert "未执行" in result.rows[2].errormessage
+    # ReviewSet 应有 error
+    assert result.error is not None
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_execute_workflow_single_cmd_success(mock_get_conn, redis_engine):
+    """测试执行工作流单条命令成功"""
+    mock_conn = Mock()
+    mock_get_conn.return_value = mock_conn
+
+    wf = _build_workflow_mock("set key1 val1")
+    result = redis_engine.execute_workflow(wf)
+    assert len(result.rows) == 1
+    assert result.rows[0].errlevel == 0
+    assert result.rows[0].stagestatus == "Execute Successfully"
+    assert result.rows[0].sql == "set key1 val1"
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_execute_workflow_first_cmd_fail(mock_get_conn, redis_engine):
+    """测试执行工作流第一条命令就失败"""
+    mock_conn = Mock()
+    mock_conn.execute_command.side_effect = Exception("CONN REFUSED")
+    mock_get_conn.return_value = mock_conn
+
+    wf = _build_workflow_mock("set key1 val1\nset key2 val2")
+    result = redis_engine.execute_workflow(wf)
+    # 第一条失败
+    assert result.rows[0].errlevel == 2
+    assert result.rows[0].stagestatus == "Execute Failed"
+    # 第二条未执行
+    assert result.rows[1].errlevel == 0
+    assert result.rows[1].stagestatus == "Audit completed"
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_execute_workflow_error_in_result(mock_get_conn, redis_engine):
+    """测试执行工作流失败时 error 被设置"""
+    mock_conn = Mock()
+    mock_conn.execute_command.side_effect = Exception("BOOM")
+    mock_get_conn.return_value = mock_conn
+
+    wf = _build_workflow_mock("set key1 val1")
+    result = redis_engine.execute_workflow(wf)
+    assert result.error is not None
+    assert "BOOM" in result.error
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_execute_workflow_execute_time(mock_get_conn, redis_engine):
+    """测试执行工作流成功时记录执行时间"""
+    mock_conn = Mock()
+    mock_get_conn.return_value = mock_conn
+
+    wf = _build_workflow_mock("set key1 val1")
+    result = redis_engine.execute_workflow(wf)
+    # 执行时间应 >= 0
+    assert result.rows[0].execute_time >= 0
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_execute_workflow_empty_lines(mock_get_conn, redis_engine):
+    """测试执行工作流时空行被跳过"""
+    mock_conn = Mock()
+    mock_get_conn.return_value = mock_conn
+
+    wf = _build_workflow_mock("set key1 val1\n\nset key2 val2\n  \n")
+    result = redis_engine.execute_workflow(wf)
+    assert len(result.rows) == 2
+
+
+@patch.object(RedisEngine, "get_connection")
+def test_execute_workflow_shlex_split(mock_get_conn, redis_engine):
+    """测试执行工作流时使用 shlex 分割命令参数"""
+    mock_conn = Mock()
+    mock_get_conn.return_value = mock_conn
+
+    wf = _build_workflow_mock("set 'my key' 'my value'")
+    redis_engine.execute_workflow(wf)
+    # 验证 execute_command 被调用时参数被正确分割
+    call_args = mock_conn.execute_command.call_args[0]
+    assert "set" in call_args
+    assert "my key" in call_args
+    assert "my value" in call_args
+
+
+# ====================== 综合场景 ======================
+
+
+def test_query_check_all_safe_commands(redis_engine):
+    """测试所有安全命令都能通过检查"""
+    safe_commands = [
+        "scan 0",
+        "exists key",
+        "ttl key",
+        "pttl key",
+        "type key",
+        "get key",
+        "mget key1 key2",
+        "strlen key",
+        "hgetall hash",
+        "hlen hash",
+        "hexists hash field",
+        "hget hash field",
+        "hmget hash f1 f2",
+        "hkeys hash",
+        "hvals hash",
+        "smembers set",
+        "scard set",
+        "sdiff s1 s2",
+        "sunion s1 s2",
+        "sismember set member",
+        "llen list",
+        "lrange list 0 -1",
+        "lindex list 0",
+        "zrange zset 0 -1",
+        "zrangebyscore zset 0 100",
+        "zscore zset member",
+        "zcard zset",
+        "zcount zset 0 100",
+        "zrank zset member",
+        "info",
+    ]
+    for cmd in safe_commands:
+        result = redis_engine.query_check(sql=cmd)
+        assert result["bad_query"] is False, f"Safe command rejected: {cmd}"
+
+
+def test_query_check_all_unsafe_commands(redis_engine):
+    """测试常见的危险命令被拒绝"""
+    unsafe_commands = [
+        "set key val",
+        "del key",
+        "flushdb",
+        "flushall",
+        "rename key1 key2",
+        "expire key 60",
+        "persist key",
+        "incr counter",
+        "decr counter",
+        "lpush list val",
+        "rpush list val",
+        "sadd set member",
+        "zadd zset 1 member",
+        "hset hash field val",
+        "config set maxmemory 100mb",
+        "shutdown",
+        "debug",
+        "slaveof no one",
+        "acl setuser",
+    ]
+    for cmd in unsafe_commands:
+        result = redis_engine.query_check(sql=cmd)
+        assert result["bad_query"] is True, f"Unsafe command allowed: {cmd}"

--- a/sql/models.py
+++ b/sql/models.py
@@ -1316,6 +1316,60 @@ class SlowQueryHistory(models.Model):
         verbose_name_plural = "慢日志明细"
 
 
+class RedisSlowQuery(models.Model):
+    """
+    Redis慢日志统计
+    """
+
+    checksum = models.CharField(max_length=32, primary_key=True)
+    fingerprint = models.TextField()
+    sample = models.TextField()
+    first_seen = models.DateTimeField(blank=True, null=True)
+    last_seen = models.DateTimeField(blank=True, null=True, db_index=True)
+
+    class Meta:
+        managed = False
+        db_table = "redis_slow_query_review"
+        verbose_name = "Redis慢日志统计"
+        verbose_name_plural = "Redis慢日志统计"
+
+
+class RedisSlowQueryHistory(models.Model):
+    """
+    Redis慢日志明细
+    """
+
+    id = models.AutoField(primary_key=True)
+    checksum = models.ForeignKey(
+        RedisSlowQuery,
+        db_constraint=False,
+        to_field="checksum",
+        db_column="checksum",
+        on_delete=models.CASCADE,
+    )
+    sample = models.TextField()
+    hostname = models.CharField(max_length=64)
+    ts_min = models.DateTimeField(db_index=True)
+    ts_max = models.DateTimeField()
+    cnt = models.IntegerField(default=0)
+    duration_sum = models.BigIntegerField(blank=True, null=True)
+    duration_min = models.BigIntegerField(blank=True, null=True)
+    duration_max = models.BigIntegerField(blank=True, null=True)
+    duration_pct_95 = models.BigIntegerField(blank=True, null=True)
+    duration_stddev = models.DecimalField(
+        max_digits=20, decimal_places=4, blank=True, null=True
+    )
+    duration_median = models.BigIntegerField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = "redis_slow_query_review_history"
+        unique_together = ("checksum", "hostname", "ts_min", "ts_max")
+        index_together = ("hostname", "ts_min")
+        verbose_name = "Redis慢日志明细"
+        verbose_name_plural = "Redis慢日志明细"
+
+
 class AuditEntry(models.Model):
     """
     登录审计日志

--- a/sql/slowlog.py
+++ b/sql/slowlog.py
@@ -40,7 +40,11 @@ def slowquery_review(request):
     limit = int(request.POST.get("limit"))
     offset = int(request.POST.get("offset"))
     # 获取实例信息
-    instance_info = Instance.objects.get(instance_name=instance_name)
+    try:
+        instance_info = Instance.objects.get(instance_name=instance_name)
+    except Instance.DoesNotExist:
+        result = {"status": 1, "msg": "实例不存在", "data": []}
+        return HttpResponse(json.dumps(result), content_type="application/json")
     # 服务端权限校验
     try:
         user_instances(request.user, db_type=[instance_info.db_type]).get(
@@ -182,7 +186,11 @@ def slowquery_review_history(request):
     limit = int(request.POST.get("limit"))
     offset = int(request.POST.get("offset"))
     # 获取实例信息
-    instance_info = Instance.objects.get(instance_name=instance_name)
+    try:
+        instance_info = Instance.objects.get(instance_name=instance_name)
+    except Instance.DoesNotExist:
+        result = {"status": 1, "msg": "实例不存在", "data": []}
+        return HttpResponse(json.dumps(result), content_type="application/json")
     # 服务端权限校验
     try:
         user_instances(request.user, db_type=[instance_info.db_type]).get(

--- a/sql/slowlog.py
+++ b/sql/slowlog.py
@@ -15,7 +15,14 @@ from sql.engines import get_engine
 
 from sql.utils.resource_group import user_instances
 from common.utils.extend_json_encoder import ExtendJSONEncoder
-from .models import Instance, SlowQuery, SlowQueryHistory, AliyunRdsConfig
+from .models import (
+    Instance,
+    SlowQuery,
+    SlowQueryHistory,
+    AliyunRdsConfig,
+    RedisSlowQuery,
+    RedisSlowQueryHistory,
+)
 
 
 import logging
@@ -32,22 +39,70 @@ def slowquery_review(request):
     db_name = request.POST.get("db_name")
     limit = int(request.POST.get("limit"))
     offset = int(request.POST.get("offset"))
+    # 获取实例信息
+    instance_info = Instance.objects.get(instance_name=instance_name)
     # 服务端权限校验
     try:
-        user_instances(request.user, db_type=["mysql"]).get(instance_name=instance_name)
+        user_instances(request.user, db_type=[instance_info.db_type]).get(
+            instance_name=instance_name
+        )
     except Exception:
         result = {"status": 1, "msg": "你所在组未关联该实例", "data": []}
         return HttpResponse(json.dumps(result), content_type="application/json")
 
-    # 判断是RDS还是其他实例
-    instance_info = Instance.objects.get(instance_name=instance_name)
-    if AliyunRdsConfig.objects.filter(instance=instance_info, is_enable=True).exists():
-        # 调用阿里云慢日志接口
+    if instance_info.db_type == "redis":
+        # ============ Redis 慢查询 ============
+        query_engine = get_engine(instance=instance_info)
+        hostnames = query_engine.get_cluster_master_nodes()
+        limit = offset + limit
+        search = request.POST.get("search")
+        sortName = str(request.POST.get("sortName"))
+        sortOrder = str(request.POST.get("sortOrder")).lower()
+        # 时间处理
+        end_time = datetime.datetime.strptime(
+            end_time, "%Y-%m-%d"
+        ) + datetime.timedelta(days=1)
+        slowsql_obj = (
+            RedisSlowQuery.objects.filter(
+                redisslowqueryhistory__hostname__in=hostnames,
+                redisslowqueryhistory__ts_min__range=(start_time, end_time),
+                fingerprint__icontains=search,
+            )
+            .annotate(SQLText=Max("fingerprint"), SQLId=F("checksum"))
+            .values("SQLText", "SQLId")
+            .annotate(
+                CreateTime=Max("redisslowqueryhistory__ts_max"),
+                TotalExecutionCounts=Sum("redisslowqueryhistory__cnt"),
+                TotalExecutionTimes=Sum("redisslowqueryhistory__duration_sum"),
+                QueryTimeAvg=Sum("redisslowqueryhistory__duration_sum")
+                / Sum("redisslowqueryhistory__cnt"),
+                DurationPct95=Max("redisslowqueryhistory__duration_pct_95"),
+            )
+        )
+        slow_sql_count = slowsql_obj.count()
+        slow_sql_list = slowsql_obj.order_by(
+            "-" + sortName if "desc".__eq__(sortOrder) else sortName
+        )[offset:limit]
+        sql_slow_log = []
+        for SlowLog in slow_sql_list:
+            avg = SlowLog["QueryTimeAvg"]
+            SlowLog["QueryTimeAvg"] = round(avg, 2) if avg else 0
+            total = SlowLog["TotalExecutionTimes"]
+            SlowLog["TotalExecutionTimes"] = round(total / 1000000, 6) if total else 0
+            pct = SlowLog["DurationPct95"]
+            SlowLog["DurationPct95"] = round(pct, 2) if pct else 0
+            sql_slow_log.append(SlowLog)
+        result = {"total": slow_sql_count, "rows": sql_slow_log}
+    elif AliyunRdsConfig.objects.filter(
+        instance=instance_info, is_enable=True
+    ).exists():
+        # ============ 阿里云RDS ============
         query_engine = get_engine(instance=instance_info)
         result = query_engine.slowquery_review(
             start_time, end_time, db_name, limit, offset
         )
     else:
+        # ============ MySQL 本地实例 ============
         limit = offset + limit
         search = request.POST.get("search")
         sortName = str(request.POST.get("sortName"))
@@ -66,7 +121,7 @@ def slowquery_review(request):
                 ),
                 slowqueryhistory__ts_min__range=(start_time, end_time),
                 fingerprint__icontains=search,
-                **filter_kwargs
+                **filter_kwargs,
             )
             .annotate(SQLText=Max("fingerprint"), SQLId=F("checksum"))
             .values("SQLText", "SQLId")
@@ -92,7 +147,7 @@ def slowquery_review(request):
             )
         )
         slow_sql_count = slowsql_obj.count()
-        # 默认“执行总次数”倒序排列
+        # 默认"执行总次数"倒序排列
         slow_sql_list = slowsql_obj.order_by(
             "-" + sortName if "desc".__eq__(sortOrder) else sortName
         )[offset:limit]
@@ -126,22 +181,73 @@ def slowquery_review_history(request):
     sql_id = request.POST.get("SQLId")
     limit = int(request.POST.get("limit"))
     offset = int(request.POST.get("offset"))
+    # 获取实例信息
+    instance_info = Instance.objects.get(instance_name=instance_name)
     # 服务端权限校验
     try:
-        user_instances(request.user, db_type=["mysql"]).get(instance_name=instance_name)
+        user_instances(request.user, db_type=[instance_info.db_type]).get(
+            instance_name=instance_name
+        )
     except Exception:
         result = {"status": 1, "msg": "你所在组未关联该实例", "data": []}
         return HttpResponse(json.dumps(result), content_type="application/json")
 
-    # 判断是RDS还是其他实例
-    instance_info = Instance.objects.get(instance_name=instance_name)
-    if AliyunRdsConfig.objects.filter(instance=instance_info, is_enable=True).exists():
-        # 调用阿里云慢日志接口
+    if instance_info.db_type == "redis":
+        # ============ Redis 慢查询明细 ============
+        query_engine = get_engine(instance=instance_info)
+        hostnames = query_engine.get_cluster_master_nodes()
+        search = request.POST.get("search")
+        sortName = str(request.POST.get("sortName"))
+        sortOrder = str(request.POST.get("sortOrder")).lower()
+        # 时间处理
+        end_time = datetime.datetime.strptime(
+            end_time, "%Y-%m-%d"
+        ) + datetime.timedelta(days=1)
+        limit = offset + limit
+        filter_kwargs = {}
+        filter_kwargs.update({"checksum": sql_id}) if sql_id else None
+        slow_sql_record_obj = RedisSlowQueryHistory.objects.filter(
+            hostname__in=hostnames,
+            ts_min__range=(start_time, end_time),
+            sample__icontains=search,
+            **filter_kwargs,
+        ).annotate(
+            ExecutionStartTime=F("ts_min"),
+            SQLText=F("sample"),
+            TotalExecutionCounts=F("cnt"),
+            QueryTimePct95=F("duration_pct_95"),
+            QueryTimes=F("duration_sum"),
+            HostName=F("hostname"),
+        )
+        slow_sql_record_count = slow_sql_record_obj.count()
+        slow_sql_record_list = slow_sql_record_obj.order_by(
+            "-" + sortName if "desc".__eq__(sortOrder) else sortName
+        )[offset:limit].values(
+            "ExecutionStartTime",
+            "SQLText",
+            "TotalExecutionCounts",
+            "QueryTimePct95",
+            "QueryTimes",
+            "HostName",
+        )
+        sql_slow_record = []
+        for SlowRecord in slow_sql_record_list:
+            pct = SlowRecord["QueryTimePct95"]
+            SlowRecord["QueryTimePct95"] = round(pct, 2) if pct else 0
+            total = SlowRecord["QueryTimes"]
+            SlowRecord["QueryTimes"] = round(total / 1000000, 6) if total else 0
+            sql_slow_record.append(SlowRecord)
+        result = {"total": slow_sql_record_count, "rows": sql_slow_record}
+    elif AliyunRdsConfig.objects.filter(
+        instance=instance_info, is_enable=True
+    ).exists():
+        # ============ 阿里云RDS ============
         query_engine = get_engine(instance=instance_info)
         result = query_engine.slowquery_review_history(
             start_time, end_time, db_name, sql_id, limit, offset
         )
     else:
+        # ============ MySQL 本地实例 ============
         search = request.POST.get("search")
         sortName = str(request.POST.get("sortName"))
         sortOrder = str(request.POST.get("sortOrder")).lower()
@@ -160,7 +266,7 @@ def slowquery_review_history(request):
             hostname_max=(instance_info.host + ":" + str(instance_info.port)),
             ts_min__range=(start_time, end_time),
             sample__icontains=search,
-            **filter_kwargs
+            **filter_kwargs,
         ).annotate(
             ExecutionStartTime=F(
                 "ts_min"
@@ -203,20 +309,43 @@ def slowquery_review_history(request):
             sql_slow_record.append(SlowRecord)
         result = {"total": slow_sql_record_count, "rows": sql_slow_record}
 
-        # 返回查询结果
+    # 返回查询结果
     return HttpResponse(
         json.dumps(result, cls=ExtendJSONEncoder, bigint_as_string=True),
         content_type="application/json",
     )
 
 
-@cache_page(60 * 10)
+@cache_page(60 * 1)
 def report(request):
     """返回慢SQL历史趋势"""
     checksum = request.GET.get("checksum")
     checksum = pymysql.escape_string(checksum)
-    cnt_data = ChartDao().slow_query_review_history_by_cnt(checksum)
-    pct_data = ChartDao().slow_query_review_history_by_pct_95_time(checksum)
+    instance_name = request.GET.get("instance_name")
+    # 判断是否为Redis实例
+    is_redis = False
+    hostnames = None
+    if instance_name:
+        try:
+            instance_info = Instance.objects.get(instance_name=instance_name)
+            is_redis = instance_info.db_type == "redis"
+            if is_redis:
+                query_engine = get_engine(instance=instance_info)
+                hostnames = query_engine.get_cluster_master_nodes()
+        except Instance.DoesNotExist:
+            pass
+    if is_redis and hostnames:
+        # Redis慢查询历史趋势
+        cnt_data = ChartDao().redis_slow_query_review_history_by_cnt(
+            checksum, hostnames
+        )
+        pct_data = ChartDao().redis_slow_query_review_history_by_pct_95_time(
+            checksum, hostnames
+        )
+    else:
+        # MySQL慢查询历史趋势
+        cnt_data = ChartDao().slow_query_review_history_by_cnt(checksum)
+        pct_data = ChartDao().slow_query_review_history_by_pct_95_time(checksum)
     cnt_x_data = [row[1] for row in cnt_data["rows"]]
     cnt_y_data = [int(row[0]) for row in cnt_data["rows"]]
     pct_y_data = [str(row[0]) for row in pct_data["rows"]]

--- a/sql/templates/slowquery.html
+++ b/sql/templates/slowquery.html
@@ -114,11 +114,25 @@
 
         //实例变动自动获取数据库
         $("#instance_name").change(function () {
-            sessionStorage.setItem('slow_query_instance_name', $("#instance_name").val());
+            var selected = $("#instance_name option:selected");
+            var db_type = selected.data('db-type');
+            sessionStorage.setItem('slow_query_instance_name', selected.val());
+            sessionStorage.setItem('slow_query_db_type', db_type);
             sessionStorage.removeItem('slow_query_db_name');
             sessionStorage.removeItem('SQLId');
-            get_db_list();
-
+            // Redis不显示数据库选择框
+            if (db_type === 'redis') {
+                $("#db_name").closest('.form-group').hide();
+                var slowsql_active_li_id = sessionStorage.getItem('slowsql_active_li_id') || 'slowsql_tab';
+                if (slowsql_active_li_id === 'slowsql_tab') {
+                    slowquery_review()
+                } else if (slowsql_active_li_id === 'slowsqlinfo_tab') {
+                    slowquery_review_history()
+                }
+            } else {
+                $("#db_name").closest('.form-group').show();
+                get_db_list();
+            }
         });
 
         //获取数据库列表,并且获取日志数据
@@ -133,7 +147,7 @@
                     resource_type: "database"
                 },
                 complete: function () {
-                    var slowsql_active_li_id = sessionStorage.getItem('slowsql_active_li_id');
+                    var slowsql_active_li_id = sessionStorage.getItem('slowsql_active_li_id') || 'slowsql_tab';
                     if (slowsql_active_li_id === 'slowsql_tab') {
                         slowquery_review()
                     } else if (slowsql_active_li_id === 'slowsqlinfo_tab') {
@@ -184,7 +198,7 @@
                     url: "/group/user_all_instances/",
                     dataType: "json",
                     data: {
-                        db_type: ['mysql']
+                        db_type: ['mysql', 'redis']
                     },
                     complete: function () {
                         //保留如果已选择instance_name，进入页面自动加载
@@ -207,7 +221,7 @@
                             $("#instance_name").empty();
                             $("#target_instance_name").empty();
                             for (let i = 0; i < result.length; i++) {
-                                let instance = "<option value=\"" + result[i]['instance_name'] + "\">" + result[i]['instance_name'] + "</option>";
+                                let instance = "<option value=\"" + result[i]['instance_name'] + "\" data-db-type=\"" + result[i]['db_type'] + "\">" + result[i]['instance_name'] + "</option>";
                                 $("#instance_name").append(instance);
                                 $("#target_instance_name").append(instance);
                             }
@@ -276,97 +290,56 @@
         function slowquery_review() {
             $("#sqladvisor-toolbar").hide();
             var instance_name = $("#instance_name").val();
+            var db_type = sessionStorage.getItem('slow_query_db_type') || 'mysql';
             if (instance_name) {
-                //初始化table
-                $('#slowsql-list').bootstrapTable('destroy').bootstrapTable({
-                    escape: true,
-                    method: 'post',
-                    contentType: "application/x-www-form-urlencoded",
-                    url: "/slowquery/review/",
-                    striped: true,                      //是否显示行间隔色
-                    cache: false,                       //是否使用缓存，默认为true，所以一般情况下需要设置一下这个属性（*）
-                    pagination: true,                   //是否显示分页（*）
-                    sortable: true,                     //开启排序
-                    sortName: "MySQLTotalExecutionCounts", //默认排序字段名称
-                    sortOrder: "desc",                   //默认排序方式
-                    sidePagination: "server",           //分页方式：client客户端分页，server服务端分页（*）
-                    pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
-                    pageSize: 30,                     //每页的记录行数（*）
-                    pageList: [30, 50, 100, 1000],       //可供选择的每页的行数（*）
-                    search: true,                      //是否显示表格搜索
-                    strictSearch: false,                //是否全匹配搜索
-                    showColumns: true,                  //是否显示所有的列（选择显示的列）
-                    showRefresh: true,                  //是否显示刷新按钮
-                    showExport: true,                   //是否显示导出按钮
-                    exportTypes: ['json', 'sql', 'csv', 'txt', 'xml', 'xlsx'],
-                    exportOptions: {
-                        ignoreColumn: [0],  //忽略某些列的索引数组
-                        fileName: 'slowquery_review'  //文件名称设置
-                    },
-                    minimumCountColumns: 2,             //最少允许的列数
-                    clickToSelect: true,                //是否启用点击选中行
-                    uniqueId: "id",                     //每一行的唯一标识，一般为主键列
-                    showToggle: true,                   //是否显示详细视图和列表视图的切换按钮
-                    cardView: false,                    //是否显示详细视图
-                    detailView: true,                  //是否显示父子表
-                    queryParamsType: 'limit',
-                    queryParams: function (params) {
-                        var instance_name = $("#instance_name").val();
-                        var db_name = $("#db_name").val();
-                        var StartTime = $('#reservation').data('daterangepicker').startDate.format('YYYY-MM-DD');
-                        var EndTime = $("#reservation").data('daterangepicker').endDate.format('YYYY-MM-DD');
-                        //console.info(params);
-                        //console.info('params='+JSON.stringify(params));
-
-                        return {
-                            instance_name: instance_name,
-                            db_name: db_name,
-                            StartTime: StartTime,
-                            EndTime: EndTime,
-                            limit: params.limit,
-                            offset: params.offset,
-                            search: params.search,
-                            sortName: params.sort,
-                            sortOrder: params.order
-                        }
-                    },
-                    //格式化详情
-                    detailFormatter: function (index, row) {
-                        let html = [];
-                        $.each(row, function (key, value) {
-                            if (key === 'SQLText') {
-                                let sql = window.sqlFormatter.format(value);
-                                //替换所有的换行符
-                                sql = sql.replace(/\r\n/g, "<br>");
-                                sql = sql.replace(/\n/g, "<br>");
-                                //替换所有的空格
-                                sql = sql.replace(/\s/g, "&nbsp;");
-                                html.push('<div class="col-lg-4">' + sql + '</div>');
-                            }
-                        });
-                        $.ajax({
-                            type: "get",
-                            url: "/slowquery/report/",
-                            async: false,
-                            dataType: "json",
-                            data: {
-                                checksum: row.SQLId,
-                            },
-                            complete: function () {
-                            },
-                            success: function (data) {
-                                if (data.status === 0) {
-                                    let chart = data.data;
-                                    html.push('<div class="col-lg-8">' + chart + '</div>')
+                var is_redis = db_type === 'redis';
+                var sortName = is_redis ? "TotalExecutionCounts" : "MySQLTotalExecutionCounts";
+                var columns = is_redis ? [{
+                        title: '日志统计时间',
+                        field: 'CreateTime',
+                        sortable:true
+                    }, {
+                        title: '命令模板',
+                        field: 'SQLText',
+                        cellStyle:
+                            function formatTableUnit(value, row, index) {
+                                return {
+                                    css: {
+                                        "color": '#06C',
+                                        "text-decoration": 'underline',
+                                        "cursor": 'pointer'
+                                    }
                                 }
                             },
-                            error: function (XMLHttpRequest, textStatus, errorThrown) {
-                                alert(errorThrown);
+                        formatter: function (value, row, index) {
+                            if (value.length > 100) {
+                                var sql = value.substr(0, 100) + '...';
+                                return sql;
+                            } else {
+                                return value
                             }
-                        });
-                        return html.join('');
-                    },
-                    columns: [{
+                        }
+                    }, {
+                        title: '完整命令',
+                        field: 'SQLText',
+                        visible: false
+                    }, {
+                        title: '执行总次数',
+                        field: 'TotalExecutionCounts',
+                        sortable:true
+                    }, {
+                        title: '执行总时长(秒)',
+                        field: 'TotalExecutionTimes',
+                        sortable:true
+                    }, {
+                        title: '平均执行时长(微秒)',
+                        field: 'QueryTimeAvg',
+                        sortable:true
+                    }, {
+                        title: '95%耗时(微秒)',
+                        field: 'DurationPct95',
+                        sortable:true
+                    }] : [{
                         title: '日志统计时间',
                         field: 'CreateTime',
                         sortable:true
@@ -377,7 +350,7 @@
                     }, {
                         title: 'SQL语句',
                         field: 'SQLText',
-                        cellStyle:      //突出sql统计信息
+                        cellStyle:
                             function formatTableUnit(value, row, index) {
                                 return {
                                     css: {
@@ -398,7 +371,7 @@
                     }, {
                         title: '完整SQL语句',
                         field: 'SQLText',
-                        visible: false // 默认不显示
+                        visible: false
                     }, {
                         title: '执行总次数',
                         field: 'MySQLTotalExecutionCounts',
@@ -427,77 +400,48 @@
                         title: '平均返回行数',
                         field: 'ReturnRowAvg',
                         sortable:true
-                    }],
-                    locale: 'zh-CN',
-                    onLoadError: onLoadErrorCallback,
-                    onSearch: function(e) {
-                        //传搜索参数给服务器
-                        //console.info('search='+e);
-                        //queryParams(e);
-                    },
-                    responseHandler: function(res) {
-                        //在ajax获取到数据，渲染表格之前，修改数据源
-                        return res;
-                    },onSort: function(sortName,order){
-                        //console.info('onSort: name='+sortName+'; order='+order+';');
-                    }
-                });
-            } else {
-                alert('请选择实例')
-            }
-        }
-
-        // 获取慢日志明细
-        function slowquery_review_history() {
-            $("#sqladvisor-toolbar").show();
-            var instance_name = $("#instance_name").val();
-            if (instance_name) {
+                    }];
                 //初始化table
-                $('#slowsqlinfo-list').bootstrapTable('destroy').bootstrapTable({
+                $('#slowsql-list').bootstrapTable('destroy').bootstrapTable({
                     escape: true,
                     method: 'post',
                     contentType: "application/x-www-form-urlencoded",
-                    url: "/slowquery/review_history/",
-                    striped: true,                      //是否显示行间隔色
-                    cache: false,                       //是否使用缓存，默认为true，所以一般情况下需要设置一下这个属性（*）
-                    pagination: true,                   //是否显示分页（*）
-                    sortable: true,                     //开启排序
-                    sortName: "ParseRowCounts",         //默认排序字段名称
-                    sortOrder: "desc",                   //默认排序方式
-                    sidePagination: "server",           //分页方式：client客户端分页，server服务端分页（*）
-                    pageNumber: 1,                      //初始化加载第一页，默认第一页,并记录
-                    pageSize: 30,                     //每页的记录行数（*）
-                    pageList: [30, 50, 100, 1000],       //可供选择的每页的行数（*）
-                    search: true,                      //是否显示表格搜索
-                    strictSearch: false,                //是否全匹配搜索
-                    showColumns: true,                  //是否显示所有的列（选择显示的列）
-                    showRefresh: true,                  //是否显示刷新按钮
-                    showExport: true,                   //是否显示导出按钮
+                    url: "/slowquery/review/",
+                    striped: true,
+                    cache: false,
+                    pagination: true,
+                    sortable: true,
+                    sortName: sortName,
+                    sortOrder: "desc",
+                    sidePagination: "server",
+                    pageNumber: 1,
+                    pageSize: 30,
+                    pageList: [30, 50, 100, 1000],
+                    search: true,
+                    strictSearch: false,
+                    showColumns: true,
+                    showRefresh: true,
+                    showExport: true,
                     exportTypes: ['json', 'sql', 'csv', 'txt', 'xml', 'xlsx'],
                     exportOptions: {
-                        ignoreColumn: [0],  //忽略某些列的索引数组
-                        fileName: 'slowquery_review_history'  //文件名称设置
+                        ignoreColumn: [0],
+                        fileName: 'slowquery_review'
                     },
-                    minimumCountColumns: 2,             //最少允许的列数
-                    clickToSelect: true,                //是否启用点击选中行
-                    uniqueId: "id",                     //每一行的唯一标识，一般为主键列
-                    showToggle: true,                   //是否显示详细视图和列表视图的切换按钮
-                    cardView: false,                    //是否显示详细视图
-                    detailView: true,                  //是否显示父子表
+                    minimumCountColumns: 2,
+                    clickToSelect: true,
+                    uniqueId: "id",
+                    showToggle: true,
+                    cardView: false,
+                    detailView: true,
                     queryParamsType: 'limit',
                     queryParams: function (params) {
                         var instance_name = $("#instance_name").val();
                         var db_name = $("#db_name").val();
-                        var SQLId = sessionStorage.getItem('SQLId');
                         var StartTime = $('#reservation').data('daterangepicker').startDate.format('YYYY-MM-DD');
                         var EndTime = $("#reservation").data('daterangepicker').endDate.format('YYYY-MM-DD');
-                        //console.info(params);
-                        //console.info('params='+JSON.stringify(params));
-
                         return {
                             instance_name: instance_name,
                             db_name: db_name,
-                            SQLId: SQLId,
                             StartTime: StartTime,
                             EndTime: EndTime,
                             limit: params.limit,
@@ -507,23 +451,108 @@
                             sortOrder: params.order
                         }
                     },
-                    //格式化详情
                     detailFormatter: function (index, row) {
-                        var html = [];
+                        let html = [];
                         $.each(row, function (key, value) {
                             if (key === 'SQLText') {
-                                var sql = window.sqlFormatter.format(value);
-                                //替换所有的换行符
-                                sql = sql.replace(/\r\n/g, "<br>");
-                                sql = sql.replace(/\n/g, "<br>");
-                                //替换所有的空格
-                                sql = sql.replace(/\s/g, "&nbsp;");
-                                html.push('<span>' + sql + '</span>');
+                                if (is_redis) {
+                                    html.push('<div class="col-lg-12"><pre>' + value + '</pre></div>');
+                                } else {
+                                    let sql = window.sqlFormatter.format(value);
+                                    sql = sql.replace(/\r\n/g, "<br>");
+                                    sql = sql.replace(/\n/g, "<br>");
+                                    sql = sql.replace(/\s/g, "&nbsp;");
+                                    html.push('<div class="col-lg-4">' + sql + '</div>');
+                                }
+                            }
+                        });
+                        var report_params = {checksum: row.SQLId};
+                        if (is_redis) {
+                            report_params.instance_name = $("#instance_name").val();
+                        }
+                        $.ajax({
+                            type: "get",
+                            url: "/slowquery/report/",
+                            async: false,
+                            dataType: "json",
+                            data: report_params,
+                            complete: function () {
+                            },
+                            success: function (data) {
+                                if (data.status === 0) {
+                                    let chart = data.data;
+                                    html.push('<div class="col-lg-8">' + chart + '</div>')
+                                }
+                            },
+                            error: function (XMLHttpRequest, textStatus, errorThrown) {
+                                alert(errorThrown);
                             }
                         });
                         return html.join('');
                     },
-                    columns: [{
+                    columns: columns,
+                    locale: 'zh-CN',
+                    onLoadError: onLoadErrorCallback,
+                    onSearch: function(e) {
+                    },
+                    responseHandler: function(res) {
+                        return res;
+                    },onSort: function(sortName,order){
+                    }
+                });
+            } else {
+                alert('请选择实例')
+            }
+        }
+
+        // 获取慢日志明细
+        function slowquery_review_history() {
+            var db_type = sessionStorage.getItem('slow_query_db_type') || 'mysql';
+            var is_redis = db_type === 'redis';
+            if (is_redis) {
+                $("#sqladvisor-toolbar").hide();
+            } else {
+                $("#sqladvisor-toolbar").show();
+            }
+            var instance_name = $("#instance_name").val();
+            if (instance_name) {
+                var sortName = is_redis ? "TotalExecutionCounts" : "ParseRowCounts";
+                var columns = is_redis ? [{
+                        title: '执行开始时间',
+                        field: 'ExecutionStartTime',
+                        sortable:true
+                    }, {
+                        title: 'Redis节点',
+                        field: 'HostName',
+                        sortable:true
+                    }, {
+                        title: '命令',
+                        field: 'SQLText',
+                        formatter: function (value, row, index) {
+                            if (value.length > 100) {
+                                var sql = value.substr(0, 100) + '...';
+                                return sql;
+                            } else {
+                                return value
+                            }
+                        }
+                    }, {
+                        title: '完整命令',
+                        field: 'SQLText',
+                        visible: false
+                    }, {
+                        title: '执行次数',
+                        field: 'TotalExecutionCounts',
+                        sortable:true
+                    }, {
+                        title: '95%耗时(微秒)',
+                        field: 'QueryTimePct95',
+                        sortable:true
+                    }, {
+                        title: '总耗时(秒)',
+                        field: 'QueryTimes',
+                        sortable:true
+                    }] : [{
                         title: '',
                         field: 'checkbox',
                         checkbox: true
@@ -553,7 +582,7 @@
                     }, {
                         title: '完整SQL语句',
                         field: 'SQLText',
-                        visible: false // 默认不显示
+                        visible: false
                     }, {
                         title: '执行总次数',
                         field: 'TotalExecutionCounts',
@@ -578,19 +607,86 @@
                         title: '返回总行数',
                         field: 'ReturnRowCounts',
                         sortable:true
-                    }],
-                    singleSelect: true,
-                    toolbar: "#sqladvisor-toolbar", //指明自定义的toolbar
+                    }];
+                //初始化table
+                $('#slowsqlinfo-list').bootstrapTable('destroy').bootstrapTable({
+                    escape: true,
+                    method: 'post',
+                    contentType: "application/x-www-form-urlencoded",
+                    url: "/slowquery/review_history/",
+                    striped: true,
+                    cache: false,
+                    pagination: true,
+                    sortable: true,
+                    sortName: sortName,
+                    sortOrder: "desc",
+                    sidePagination: "server",
+                    pageNumber: 1,
+                    pageSize: 30,
+                    pageList: [30, 50, 100, 1000],
+                    search: true,
+                    strictSearch: false,
+                    showColumns: true,
+                    showRefresh: true,
+                    showExport: true,
+                    exportTypes: ['json', 'sql', 'csv', 'txt', 'xml', 'xlsx'],
+                    exportOptions: {
+                        ignoreColumn: [0],
+                        fileName: 'slowquery_review_history'
+                    },
+                    minimumCountColumns: 2,
+                    clickToSelect: true,
+                    uniqueId: "id",
+                    showToggle: true,
+                    cardView: false,
+                    detailView: true,
+                    queryParamsType: 'limit',
+                    queryParams: function (params) {
+                        var instance_name = $("#instance_name").val();
+                        var db_name = $("#db_name").val();
+                        var SQLId = sessionStorage.getItem('SQLId');
+                        var StartTime = $('#reservation').data('daterangepicker').startDate.format('YYYY-MM-DD');
+                        var EndTime = $("#reservation").data('daterangepicker').endDate.format('YYYY-MM-DD');
+                        return {
+                            instance_name: instance_name,
+                            db_name: db_name,
+                            SQLId: SQLId,
+                            StartTime: StartTime,
+                            EndTime: EndTime,
+                            limit: params.limit,
+                            offset: params.offset,
+                            search: params.search,
+                            sortName: params.sort,
+                            sortOrder: params.order
+                        }
+                    },
+                    detailFormatter: function (index, row) {
+                        var html = [];
+                        $.each(row, function (key, value) {
+                            if (key === 'SQLText') {
+                                if (is_redis) {
+                                    html.push('<pre>' + value + '</pre>');
+                                } else {
+                                    var sql = window.sqlFormatter.format(value);
+                                    sql = sql.replace(/\r\n/g, "<br>");
+                                    sql = sql.replace(/\n/g, "<br>");
+                                    sql = sql.replace(/\s/g, "&nbsp;");
+                                    html.push('<span>' + sql + '</span>');
+                                }
+                            }
+                        });
+                        return html.join('');
+                    },
+                    columns: columns,
+                    singleSelect: !is_redis,
+                    toolbar: is_redis ? undefined : "#sqladvisor-toolbar",
                     locale: 'zh-CN',
                     onLoadError: onLoadErrorCallback,
                     onSearch: function (e) {
-                        //传搜索参数给服务器
                         queryParams(e)
                     },onSort: function(sortName,order){
-                        //console.info('onSort: name='+sortName+'; order='+order+';');
                     },
                     responseHandler: function (res) {
-                        //在ajax获取到数据，渲染表格之前，修改数据源
                         return res;
                     }
                 });

--- a/sql/test_slowlog.py
+++ b/sql/test_slowlog.py
@@ -1,0 +1,491 @@
+# -*- coding: UTF-8 -*-
+import json
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+from django.contrib.auth.models import Permission
+from django.test import Client, TestCase
+
+from sql.models import Instance, ResourceGroup, Users, AliyunRdsConfig
+
+
+class TestSlowQueryReview(TestCase):
+    """测试 slowquery_review 视图"""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = Users.objects.create(
+            username="test_user", display="测试用户", is_active=True
+        )
+        # 赋予慢查菜单权限
+        perm = Permission.objects.get(codename="menu_slowquery")
+        self.user.user_permissions.add(perm)
+        # 赋予查询所有实例权限，简化权限校验
+        perm_all = Permission.objects.get(codename="query_all_instances")
+        self.user.user_permissions.add(perm_all)
+        self.client.force_login(self.user)
+
+        self.instance = Instance.objects.create(
+            instance_name="test_mysql",
+            type="slave",
+            db_type="mysql",
+            host="127.0.0.1",
+            port=3306,
+            user="root",
+            password="password",
+        )
+
+    def tearDown(self):
+        Users.objects.all().delete()
+        Instance.objects.all().delete()
+        ResourceGroup.objects.all().delete()
+        AliyunRdsConfig.objects.all().delete()
+
+    def test_instance_not_exist(self):
+        """实例不存在时应返回错误"""
+        data = {
+            "instance_name": "not_exist",
+            "StartTime": "2024-01-01",
+            "EndTime": "2024-01-02",
+            "db_name": "",
+            "limit": 10,
+            "offset": 0,
+        }
+        r = self.client.post("/slowquery/review/", data=data)
+        self.assertEqual(r.status_code, 200)
+        resp = r.json()
+        self.assertEqual(resp["status"], 1)
+        self.assertEqual(resp["msg"], "实例不存在")
+
+    def test_no_permission(self):
+        """用户没有实例权限时应返回错误"""
+        self.user.user_permissions.remove(
+            Permission.objects.get(codename="query_all_instances")
+        )
+        data = {
+            "instance_name": self.instance.instance_name,
+            "StartTime": "2024-01-01",
+            "EndTime": "2024-01-02",
+            "db_name": "",
+            "limit": 10,
+            "offset": 0,
+        }
+        r = self.client.post("/slowquery/review/", data=data)
+        self.assertEqual(r.status_code, 200)
+        resp = r.json()
+        self.assertEqual(resp["status"], 1)
+        self.assertEqual(resp["msg"], "你所在组未关联该实例")
+
+    @patch("sql.slowlog.SlowQuery.objects")
+    def test_mysql_local(self, mock_slow_query_objects):
+        """MySQL本地实例慢查统计"""
+        mock_qs = MagicMock()
+        mock_slow_query_objects.filter.return_value = mock_qs
+        mock_qs.annotate.return_value = mock_qs
+        mock_qs.values.return_value = mock_qs
+        mock_qs.count.return_value = 1
+        mock_qs.order_by.return_value = [
+            {
+                "SQLText": "SELECT * FROM t",
+                "SQLId": "abc123",
+                "CreateTime": datetime.now(),
+                "DBName": "test_db",
+                "QueryTimeAvg": 1.234567,
+                "MySQLTotalExecutionCounts": 10,
+                "MySQLTotalExecutionTimes": 2.345678,
+                "ParseTotalRowCounts": 100,
+                "ReturnTotalRowCounts": 10,
+                "ParseRowAvg": 10.0,
+                "ReturnRowAvg": 1.0,
+            }
+        ]
+
+        data = {
+            "instance_name": self.instance.instance_name,
+            "StartTime": "2024-01-01",
+            "EndTime": "2024-01-02",
+            "db_name": "",
+            "limit": 10,
+            "offset": 0,
+            "search": "",
+            "sortName": "MySQLTotalExecutionCounts",
+            "sortOrder": "desc",
+        }
+        r = self.client.post("/slowquery/review/", data=data)
+        self.assertEqual(r.status_code, 200)
+        resp = json.loads(r.content)
+        self.assertEqual(resp["total"], 1)
+        self.assertEqual(len(resp["rows"]), 1)
+        self.assertEqual(resp["rows"][0]["SQLId"], "abc123")
+
+    @patch("sql.slowlog.get_engine")
+    @patch("sql.slowlog.AliyunRdsConfig.objects")
+    def test_aliyun_rds(self, mock_rds_config_objects, mock_get_engine):
+        """阿里云RDS慢查统计"""
+        mock_rds_config_objects.filter.return_value.exists.return_value = True
+        mock_engine = MagicMock()
+        mock_engine.slowquery_review.return_value = {
+            "total": 2,
+            "rows": [{"SQLText": "SELECT 1"}],
+        }
+        mock_get_engine.return_value = mock_engine
+
+        data = {
+            "instance_name": self.instance.instance_name,
+            "StartTime": "2024-01-01",
+            "EndTime": "2024-01-02",
+            "db_name": "",
+            "limit": 10,
+            "offset": 0,
+        }
+        r = self.client.post("/slowquery/review/", data=data)
+        self.assertEqual(r.status_code, 200)
+        resp = json.loads(r.content)
+        self.assertEqual(resp["total"], 2)
+        mock_engine.slowquery_review.assert_called_once()
+
+    @patch("sql.slowlog.get_engine")
+    @patch("sql.slowlog.RedisSlowQuery.objects")
+    def test_redis(self, mock_redis_slow_query_objects, mock_get_engine):
+        """Redis慢查统计"""
+        redis_instance = Instance.objects.create(
+            instance_name="test_redis",
+            type="slave",
+            db_type="redis",
+            host="127.0.0.1",
+            port=6379,
+            user="",
+            password="",
+        )
+        mock_engine = MagicMock()
+        mock_engine.get_cluster_master_nodes.return_value = ["node1"]
+        mock_get_engine.return_value = mock_engine
+
+        mock_qs = MagicMock()
+        mock_redis_slow_query_objects.filter.return_value = mock_qs
+        mock_qs.annotate.return_value = mock_qs
+        mock_qs.values.return_value = mock_qs
+        mock_qs.count.return_value = 1
+        mock_qs.order_by.return_value = [
+            {
+                "SQLText": "GET key",
+                "SQLId": "redis123",
+                "CreateTime": datetime.now(),
+                "TotalExecutionCounts": 5,
+                "TotalExecutionTimes": 1000000,
+                "QueryTimeAvg": 200000.0,
+                "DurationPct95": 300000.0,
+            }
+        ]
+
+        data = {
+            "instance_name": redis_instance.instance_name,
+            "StartTime": "2024-01-01",
+            "EndTime": "2024-01-02",
+            "db_name": "",
+            "limit": 10,
+            "offset": 0,
+            "search": "",
+            "sortName": "TotalExecutionCounts",
+            "sortOrder": "desc",
+        }
+        r = self.client.post("/slowquery/review/", data=data)
+        self.assertEqual(r.status_code, 200)
+        resp = json.loads(r.content)
+        self.assertEqual(resp["total"], 1)
+        self.assertEqual(len(resp["rows"]), 1)
+
+
+class TestSlowQueryReviewHistory(TestCase):
+    """测试 slowquery_review_history 视图"""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = Users.objects.create(
+            username="test_user", display="测试用户", is_active=True
+        )
+        perm = Permission.objects.get(codename="menu_slowquery")
+        self.user.user_permissions.add(perm)
+        perm_all = Permission.objects.get(codename="query_all_instances")
+        self.user.user_permissions.add(perm_all)
+        self.client.force_login(self.user)
+
+        self.instance = Instance.objects.create(
+            instance_name="test_mysql",
+            type="slave",
+            db_type="mysql",
+            host="127.0.0.1",
+            port=3306,
+            user="root",
+            password="password",
+        )
+
+    def tearDown(self):
+        Users.objects.all().delete()
+        Instance.objects.all().delete()
+        ResourceGroup.objects.all().delete()
+        AliyunRdsConfig.objects.all().delete()
+
+    def test_instance_not_exist(self):
+        """实例不存在时应返回错误"""
+        data = {
+            "instance_name": "not_exist",
+            "StartTime": "2024-01-01",
+            "EndTime": "2024-01-02",
+            "db_name": "",
+            "SQLId": "",
+            "limit": 10,
+            "offset": 0,
+        }
+        r = self.client.post("/slowquery/review_history/", data=data)
+        self.assertEqual(r.status_code, 200)
+        resp = r.json()
+        self.assertEqual(resp["status"], 1)
+        self.assertEqual(resp["msg"], "实例不存在")
+
+    def test_no_permission(self):
+        """用户没有实例权限时应返回错误"""
+        self.user.user_permissions.remove(
+            Permission.objects.get(codename="query_all_instances")
+        )
+        data = {
+            "instance_name": self.instance.instance_name,
+            "StartTime": "2024-01-01",
+            "EndTime": "2024-01-02",
+            "db_name": "",
+            "SQLId": "",
+            "limit": 10,
+            "offset": 0,
+        }
+        r = self.client.post("/slowquery/review_history/", data=data)
+        self.assertEqual(r.status_code, 200)
+        resp = r.json()
+        self.assertEqual(resp["status"], 1)
+        self.assertEqual(resp["msg"], "你所在组未关联该实例")
+
+    @patch("sql.slowlog.SlowQueryHistory.objects")
+    def test_mysql_local(self, mock_slow_query_history_objects):
+        """MySQL本地实例慢查明细"""
+        mock_qs = MagicMock()
+        mock_slow_query_history_objects.filter.return_value = mock_qs
+        mock_qs.annotate.return_value = mock_qs
+        mock_qs.count.return_value = 1
+        mock_qs.order_by.return_value = mock_qs
+        mock_qs.__getitem__.return_value = mock_qs
+        mock_qs.values.return_value = [
+            {
+                "ExecutionStartTime": datetime.now(),
+                "DBName": "test_db",
+                "HostAddress": "'user'@'localhost'",
+                "SQLText": "SELECT * FROM t",
+                "TotalExecutionCounts": 5,
+                "QueryTimePct95": 1.234567,
+                "QueryTimes": 2.345678,
+                "LockTimes": 0.5,
+                "ParseRowCounts": 100,
+                "ReturnRowCounts": 10,
+            }
+        ]
+
+        data = {
+            "instance_name": self.instance.instance_name,
+            "StartTime": "2024-01-01",
+            "EndTime": "2024-01-02",
+            "db_name": "",
+            "SQLId": "",
+            "limit": 10,
+            "offset": 0,
+            "search": "",
+            "sortName": "ExecutionStartTime",
+            "sortOrder": "desc",
+        }
+        r = self.client.post("/slowquery/review_history/", data=data)
+        self.assertEqual(r.status_code, 200)
+        resp = json.loads(r.content)
+        self.assertEqual(resp["total"], 1)
+        self.assertEqual(len(resp["rows"]), 1)
+        self.assertEqual(resp["rows"][0]["DBName"], "test_db")
+
+    @patch("sql.slowlog.get_engine")
+    @patch("sql.slowlog.AliyunRdsConfig.objects")
+    def test_aliyun_rds(self, mock_rds_config_objects, mock_get_engine):
+        """阿里云RDS慢查明细"""
+        mock_rds_config_objects.filter.return_value.exists.return_value = True
+        mock_engine = MagicMock()
+        mock_engine.slowquery_review_history.return_value = {
+            "total": 2,
+            "rows": [{"SQLText": "SELECT 1"}],
+        }
+        mock_get_engine.return_value = mock_engine
+
+        data = {
+            "instance_name": self.instance.instance_name,
+            "StartTime": "2024-01-01",
+            "EndTime": "2024-01-02",
+            "db_name": "",
+            "SQLId": "",
+            "limit": 10,
+            "offset": 0,
+        }
+        r = self.client.post("/slowquery/review_history/", data=data)
+        self.assertEqual(r.status_code, 200)
+        resp = json.loads(r.content)
+        self.assertEqual(resp["total"], 2)
+        mock_engine.slowquery_review_history.assert_called_once()
+
+    @patch("sql.slowlog.get_engine")
+    @patch("sql.slowlog.RedisSlowQueryHistory.objects")
+    def test_redis(self, mock_redis_history_objects, mock_get_engine):
+        """Redis慢查明细"""
+        redis_instance = Instance.objects.create(
+            instance_name="test_redis",
+            type="slave",
+            db_type="redis",
+            host="127.0.0.1",
+            port=6379,
+            user="",
+            password="",
+        )
+        mock_engine = MagicMock()
+        mock_engine.get_cluster_master_nodes.return_value = ["node1"]
+        mock_get_engine.return_value = mock_engine
+
+        mock_qs = MagicMock()
+        mock_redis_history_objects.filter.return_value = mock_qs
+        mock_qs.annotate.return_value = mock_qs
+        mock_qs.count.return_value = 1
+        mock_qs.order_by.return_value = mock_qs
+        mock_qs.__getitem__.return_value = mock_qs
+        mock_qs.values.return_value = [
+            {
+                "ExecutionStartTime": datetime.now(),
+                "SQLText": "GET key",
+                "TotalExecutionCounts": 5,
+                "QueryTimePct95": 100000.0,
+                "QueryTimes": 500000,
+                "HostName": "node1",
+            }
+        ]
+
+        data = {
+            "instance_name": redis_instance.instance_name,
+            "StartTime": "2024-01-01",
+            "EndTime": "2024-01-02",
+            "db_name": "",
+            "SQLId": "",
+            "limit": 10,
+            "offset": 0,
+            "search": "",
+            "sortName": "ExecutionStartTime",
+            "sortOrder": "desc",
+        }
+        r = self.client.post("/slowquery/review_history/", data=data)
+        self.assertEqual(r.status_code, 200)
+        resp = json.loads(r.content)
+        self.assertEqual(resp["total"], 1)
+        self.assertEqual(len(resp["rows"]), 1)
+
+
+class TestSlowQueryReport(TestCase):
+    """测试 report 视图"""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = Users.objects.create(
+            username="test_user", display="测试用户", is_active=True
+        )
+        self.client.force_login(self.user)
+        self.instance = Instance.objects.create(
+            instance_name="test_mysql",
+            type="slave",
+            db_type="mysql",
+            host="127.0.0.1",
+            port=3306,
+            user="root",
+            password="password",
+        )
+
+    def tearDown(self):
+        Users.objects.all().delete()
+        Instance.objects.all().delete()
+
+    @patch("sql.slowlog.ChartDao")
+    def test_report_mysql(self, mock_chart_dao_class):
+        """MySQL慢查历史趋势"""
+        mock_chart_dao = MagicMock()
+        mock_chart_dao_class.return_value = mock_chart_dao
+        mock_chart_dao.slow_query_review_history_by_cnt.return_value = {
+            "rows": [(10, "2024-01-01"), (20, "2024-01-02")]
+        }
+        mock_chart_dao.slow_query_review_history_by_pct_95_time.return_value = {
+            "rows": [(0.5, "2024-01-01"), (1.2, "2024-01-02")]
+        }
+
+        r = self.client.get(
+            "/slowquery/report/",
+            {"checksum": "abc123", "instance_name": self.instance.instance_name},
+        )
+        self.assertEqual(r.status_code, 200)
+        resp = r.json()
+        self.assertEqual(resp["status"], 0)
+        self.assertIn("data", resp)
+        mock_chart_dao.slow_query_review_history_by_cnt.assert_called_once_with(
+            "abc123"
+        )
+
+    @patch("sql.slowlog.ChartDao")
+    @patch("sql.slowlog.get_engine")
+    def test_report_redis(self, mock_get_engine, mock_chart_dao_class):
+        """Redis慢查历史趋势"""
+        redis_instance = Instance.objects.create(
+            instance_name="test_redis",
+            type="slave",
+            db_type="redis",
+            host="127.0.0.1",
+            port=6379,
+            user="",
+            password="",
+        )
+        mock_engine = MagicMock()
+        mock_engine.get_cluster_master_nodes.return_value = ["node1", "node2"]
+        mock_get_engine.return_value = mock_engine
+
+        mock_chart_dao = MagicMock()
+        mock_chart_dao_class.return_value = mock_chart_dao
+        mock_chart_dao.redis_slow_query_review_history_by_cnt.return_value = {
+            "rows": [(5, "2024-01-01")]
+        }
+        mock_chart_dao.redis_slow_query_review_history_by_pct_95_time.return_value = {
+            "rows": [(100000, "2024-01-01")]
+        }
+
+        r = self.client.get(
+            "/slowquery/report/",
+            {"checksum": "redis123", "instance_name": redis_instance.instance_name},
+        )
+        self.assertEqual(r.status_code, 200)
+        resp = r.json()
+        self.assertEqual(resp["status"], 0)
+        mock_chart_dao.redis_slow_query_review_history_by_cnt.assert_called_once_with(
+            "redis123", ["node1", "node2"]
+        )
+
+    @patch("sql.slowlog.ChartDao")
+    def test_report_no_instance(self, mock_chart_dao_class):
+        """无实例参数时使用MySQL默认逻辑"""
+        mock_chart_dao = MagicMock()
+        mock_chart_dao_class.return_value = mock_chart_dao
+        mock_chart_dao.slow_query_review_history_by_cnt.return_value = {
+            "rows": [(10, "2024-01-01")]
+        }
+        mock_chart_dao.slow_query_review_history_by_pct_95_time.return_value = {
+            "rows": [(0.5, "2024-01-01")]
+        }
+
+        r = self.client.get("/slowquery/report/", {"checksum": "abc123"})
+        self.assertEqual(r.status_code, 200)
+        resp = r.json()
+        self.assertEqual(resp["status"], 0)
+        mock_chart_dao.slow_query_review_history_by_cnt.assert_called_once_with(
+            "abc123"
+        )

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update \
     && apt-get install -yq --no-install-recommends nginx mariadb-client \
     && source venv4archery/bin/activate \
     && pip install -r /opt/archery/requirements.txt \
-    && pip install "redis>=4.1.0" \
     && cp -f /opt/archery/src/docker/nginx.conf /etc/nginx/ \
     && cp -f /opt/archery/src/docker/supervisord.conf /etc/ \
     && mv /opt/sqladvisor /opt/archery/src/plugins/ \

--- a/src/init_sql/redis_slow_query_review.sql
+++ b/src/init_sql/redis_slow_query_review.sql
@@ -1,0 +1,36 @@
+CREATE TABLE `redis_slow_query_review` (
+  `checksum` char(32) NOT NULL COMMENT '指纹MD5值',
+  `fingerprint` text NOT NULL COMMENT '参数化后的命令模板，如 "SET user:* *"',
+  `sample` text NOT NULL COMMENT '原始命令示例（首次出现的那条）',
+  `first_seen` datetime(6) DEFAULT NULL COMMENT '该指纹首次出现时间',
+  `last_seen` datetime(6) DEFAULT NULL COMMENT '该指纹最后出现时间',
+  PRIMARY KEY (`checksum`),
+  KEY `idx_last_seen` (`last_seen`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Redis慢查询指纹表';
+
+CREATE TABLE `redis_slow_query_review_history` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `checksum` char(32) NOT NULL COMMENT '关联指纹表',
+  `sample` text NOT NULL COMMENT '原始命令示例（首次出现的那条）',
+  `hostname` varchar(64) NOT NULL COMMENT 'Redis实例标识（IP:PORT或自定义名称）',
+  `ts_min` datetime(6) NOT NULL COMMENT '本窗口内该指纹的最小执行时间',
+  `ts_max` datetime(6) NOT NULL COMMENT '本窗口内该指纹的最大执行时间',
+  `cnt` int(11) NOT NULL DEFAULT '0' COMMENT '本窗口内出现次数',
+  `duration_sum` bigint(20) DEFAULT NULL COMMENT '总耗时（微秒）',
+  `duration_min` bigint(20) DEFAULT NULL COMMENT '最小耗时（微秒）',
+  `duration_max` bigint(20) DEFAULT NULL COMMENT '最大耗时（微秒）',
+  `duration_pct_95` bigint(20) DEFAULT NULL COMMENT '95分位耗时（微秒）',
+  `duration_stddev` decimal(20,4) DEFAULT NULL COMMENT '耗时标准差',
+  `duration_median` bigint(20) DEFAULT NULL COMMENT '中位数耗时（微秒）',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_checksum_window` (`checksum`, `hostname`, `ts_min`, `ts_max`),
+  KEY `idx_hostname_ts` (`hostname`, `ts_min`),
+  KEY `idx_checksum` (`checksum`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Redis慢查询历史统计表';
+
+CREATE TABLE `redis_slowlog_cursor` (
+  `hostname` varchar(64) NOT NULL COMMENT 'Redis实例标识',
+  `last_processed_id` bigint(20) NOT NULL DEFAULT '0' COMMENT '已处理的最后一条slowlog ID',
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`hostname`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Redis慢查询游标表';

--- a/src/script/collect_redis_slow_log.py
+++ b/src/script/collect_redis_slow_log.py
@@ -1,0 +1,220 @@
+import redis
+import hashlib
+from datetime import datetime
+import pymysql
+import re
+
+# 配置
+# redis节点信息，由于redis cluster架构每个节点都有单独的slowlog，所以需要写全redis cluster所有节点
+REDIS_LIST = [
+    {"host": "127.0.0.1", "port": 6379, "username": "", "password": ""},
+    {"host": "127.0.0.1", "port": 7001, "username": "", "password": ""},
+    {"host": "127.0.0.1", "port": 7002, "username": "", "password": ""},
+    {"host": "127.0.0.1", "port": 7003, "username": "", "password": ""},
+    {
+        "host": "127.0.0.1",
+        "port": 8001,
+        "username": "",
+        "password": "123456",
+    },
+    {
+        "host": "127.0.0.1",
+        "port": 8002,
+        "username": "",
+        "password": "123456",
+    },
+    {
+        "host": "127.0.0.1",
+        "port": 8003,
+        "username": "",
+        "password": "123456",
+    },
+    {"host": "127.0.0.1", "port": 9001, "username": "", "password": ""},
+    {"host": "127.0.0.1", "port": 9002, "username": "", "password": ""},
+    {"host": "127.0.0.1", "port": 9003, "username": "", "password": ""},
+]
+MYSQL_DSN = {
+    "host": "127.0.0.1",
+    "user": "root",
+    "password": "123456",
+    "db": "archery",
+}
+
+
+def normalize_command(cmd_str):
+    """参数化命令：将第一个词转为小写，第二个词中的连续数字替换为*，忽略其余部分"""
+    if not cmd_str or not cmd_str.strip():
+        return ""
+    # 按空格分割，多个空格自动合并
+    parts = cmd_str.split()
+    if len(parts) == 0:
+        return ""
+    # 第一个词转为小写
+    cmd = parts[0].lower()
+    if len(parts) == 1:
+        return cmd
+    # 处理第二个词：连续数字替换为 *
+    arg1 = parts[1]
+    arg1_processed = re.sub(r"\d+", "*", arg1)
+    return f"{cmd} {arg1_processed}"
+
+
+def collect_slowlog_for_node(
+    redis_host, redis_port, redis_username=None, redis_password=None
+):
+    """采集单个 Redis 节点的慢日志"""
+    node_name = f"{redis_host}:{redis_port}"
+    print(f"=== 开始采集 {node_name} ===")
+
+    r = redis.Redis(
+        host=redis_host,
+        port=redis_port,
+        username=redis_username,
+        password=redis_password,
+    )
+    db = pymysql.connect(**MYSQL_DSN)
+    cursor = db.cursor()
+
+    # 1. 获取上次处理的最大ID
+    cursor.execute(
+        "SELECT last_processed_id FROM redis_slowlog_cursor WHERE hostname = %s",
+        (node_name,),
+    )
+    row = cursor.fetchone()
+    last_id = row[0] if row else 0
+
+    # 2. 获取最近5000条慢日志
+    slowlogs = r.slowlog_get(5000)
+    if not slowlogs:
+        print(f"  {node_name} 无慢日志，跳过")
+        cursor.close()
+        db.close()
+        return
+
+    new_logs = []
+    max_new_id = last_id
+    for entry in slowlogs:
+        entry_id = entry["id"]
+        if entry_id > last_id:
+            new_logs.append(entry)
+            if entry_id > max_new_id:
+                max_new_id = entry_id
+
+    if not new_logs:
+        print(f"  {node_name} 无新增慢日志，跳过")
+        cursor.close()
+        db.close()
+        return
+
+    # 3. 处理每条新日志
+    groups = {}
+    for log in new_logs:
+        fingerprint = normalize_command(log["command"].decode("utf-8"))
+        checksum = hashlib.md5(fingerprint.encode()).hexdigest()
+        timestamp = datetime.fromtimestamp(log["start_time"])
+        duration = log["duration"]  # 微秒
+
+        # 更新指纹表
+        sql_review = """
+            INSERT INTO redis_slow_query_review (checksum, fingerprint, sample, first_seen, last_seen)
+            VALUES (%s, %s, %s, %s, %s)
+            ON DUPLICATE KEY UPDATE
+                last_seen = IF(VALUES(last_seen) > last_seen, VALUES(last_seen), last_seen)
+        """
+        sample = log["command"].decode("utf-8")
+        cursor.execute(
+            sql_review, (checksum, fingerprint, sample, timestamp, timestamp)
+        )
+        db.commit()
+
+        # 暂存用于聚合
+        key = checksum
+        if key not in groups:
+            groups[key] = {"durations": [], "timestamps": [], "sample": sample}
+        groups[key]["durations"].append(duration)
+        groups[key]["timestamps"].append(timestamp)
+
+    # 4. 聚合写入历史表
+    for checksum, data in groups.items():
+        durations = data["durations"]
+        timestamps = data["timestamps"]
+        history_sample = data["sample"]
+        cnt = len(durations)
+        duration_sum = sum(durations)
+        duration_min = min(durations)
+        duration_max = max(durations)
+        durations_sorted = sorted(durations)
+        duration_median = durations_sorted[cnt // 2]
+        p95_idx = int(cnt * 0.95) - 1
+        duration_pct_95 = (
+            durations_sorted[p95_idx] if p95_idx >= 0 else durations_sorted[-1]
+        )
+        # 计算标准差
+        mean = duration_sum / cnt
+        variance = sum((x - mean) ** 2 for x in durations) / cnt
+        duration_stddev = variance**0.5
+
+        ts_min = min(timestamps)
+        ts_max = max(timestamps)
+
+        sql_history = """
+            INSERT INTO redis_slow_query_review_history
+            (checksum, sample, hostname, ts_min, ts_max, cnt, duration_sum, duration_min, duration_max,
+             duration_pct_95, duration_stddev, duration_median)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON DUPLICATE KEY UPDATE
+                cnt = VALUES(cnt), duration_sum = VALUES(duration_sum), duration_min = VALUES(duration_min),
+                duration_max = VALUES(duration_max), duration_pct_95 = VALUES(duration_pct_95),
+                duration_stddev = VALUES(duration_stddev), duration_median = VALUES(duration_median)
+        """
+        cursor.execute(
+            sql_history,
+            (
+                checksum,
+                history_sample,
+                node_name,
+                ts_min,
+                ts_max,
+                cnt,
+                duration_sum,
+                duration_min,
+                duration_max,
+                duration_pct_95,
+                duration_stddev,
+                duration_median,
+            ),
+        )
+        db.commit()
+
+    # 5. 更新游标
+    cursor.execute(
+        """
+        INSERT INTO redis_slowlog_cursor (hostname, last_processed_id, updated_at)
+        VALUES (%s, %s, NOW())
+        ON DUPLICATE KEY UPDATE last_processed_id = VALUES(last_processed_id), updated_at = NOW()
+    """,
+        (node_name, max_new_id),
+    )
+    db.commit()
+
+    cursor.close()
+    db.close()
+    print(f"=== 采集完成 {node_name}，新增 {len(new_logs)} 条慢日志 ===")
+
+
+def collect_slowlog():
+    """分批采集所有 Redis 节点的慢日志"""
+    for node in REDIS_LIST:
+        try:
+            collect_slowlog_for_node(
+                redis_host=node["host"],
+                redis_port=node["port"],
+                redis_username=node.get("username"),
+                redis_password=node.get("password"),
+            )
+        except Exception as e:
+            print(f"采集 {node['host']}:{node['port']} 失败: {e}")
+
+
+if __name__ == "__main__":
+    collect_slowlog()

--- a/src/script/collect_redis_slow_log.py
+++ b/src/script/collect_redis_slow_log.py
@@ -2,7 +2,9 @@ import redis
 import hashlib
 from datetime import datetime
 import pymysql
+import calendar
 import re
+import math
 
 # 配置
 # redis节点信息，由于redis cluster架构每个节点都有单独的slowlog，所以需要写全redis cluster所有节点
@@ -33,6 +35,7 @@ REDIS_LIST = [
     {"host": "127.0.0.1", "port": 9002, "username": "", "password": ""},
     {"host": "127.0.0.1", "port": 9003, "username": "", "password": ""},
 ]
+# archery数据库
 MYSQL_DSN = {
     "host": "127.0.0.1",
     "user": "root",
@@ -75,13 +78,21 @@ def collect_slowlog_for_node(
     db = pymysql.connect(**MYSQL_DSN)
     cursor = db.cursor()
 
+    # 查询 MySQL 时区偏移（秒），用于将 naive datetime 转为 UTC 时间戳
+    cursor.execute("SELECT TIMEDIFF(NOW(), UTC_TIMESTAMP)")
+    tz_offset_seconds = cursor.fetchone()[0].total_seconds()
+
     # 1. 获取上次处理的最大ID
     cursor.execute(
-        "SELECT last_processed_id FROM redis_slowlog_cursor WHERE hostname = %s",
+        "SELECT last_processed_id,updated_at FROM redis_slowlog_cursor WHERE hostname = %s",
         (node_name,),
     )
     row = cursor.fetchone()
     last_id = row[0] if row else 0
+    # 将 MySQL naive datetime 转为 UTC 时间戳，与 Redis start_time 对齐
+    last_updated_at = (
+        calendar.timegm(row[1].timetuple()) - tz_offset_seconds if row and row[1] else 0
+    )
 
     # 2. 获取最近5000条慢日志
     slowlogs = r.slowlog_get(5000)
@@ -95,7 +106,9 @@ def collect_slowlog_for_node(
     max_new_id = last_id
     for entry in slowlogs:
         entry_id = entry["id"]
-        if entry_id > last_id:
+        if entry_id > last_id or entry["start_time"] > last_updated_at:
+            # print(entry["start_time"],last_updated_at)
+            # print(entry)
             new_logs.append(entry)
             if entry_id > max_new_id:
                 max_new_id = entry_id
@@ -109,7 +122,9 @@ def collect_slowlog_for_node(
     # 3. 处理每条新日志
     groups = {}
     for log in new_logs:
-        fingerprint = normalize_command(log["command"].decode("utf-8"))
+        fingerprint = normalize_command(
+            log["command"].decode("utf-8", errors="replace")
+        )
         checksum = hashlib.md5(fingerprint.encode()).hexdigest()
         timestamp = datetime.fromtimestamp(log["start_time"])
         duration = log["duration"]  # 微秒
@@ -121,7 +136,7 @@ def collect_slowlog_for_node(
             ON DUPLICATE KEY UPDATE
                 last_seen = IF(VALUES(last_seen) > last_seen, VALUES(last_seen), last_seen)
         """
-        sample = log["command"].decode("utf-8")
+        sample = log["command"].decode("utf-8", errors="replace")
         cursor.execute(
             sql_review, (checksum, fingerprint, sample, timestamp, timestamp)
         )
@@ -144,8 +159,13 @@ def collect_slowlog_for_node(
         duration_min = min(durations)
         duration_max = max(durations)
         durations_sorted = sorted(durations)
-        duration_median = durations_sorted[cnt // 2]
-        p95_idx = int(cnt * 0.95) - 1
+        if cnt % 2 == 1:
+            duration_median = durations_sorted[cnt // 2]
+        else:
+            duration_median = (
+                durations_sorted[cnt // 2 - 1] + durations_sorted[cnt // 2]
+            ) / 2
+        p95_idx = math.ceil(cnt * 0.95) - 1
         duration_pct_95 = (
             durations_sorted[p95_idx] if p95_idx >= 0 else durations_sorted[-1]
         )
@@ -189,9 +209,9 @@ def collect_slowlog_for_node(
     # 5. 更新游标
     cursor.execute(
         """
-        INSERT INTO redis_slowlog_cursor (hostname, last_processed_id, updated_at)
-        VALUES (%s, %s, NOW())
-        ON DUPLICATE KEY UPDATE last_processed_id = VALUES(last_processed_id), updated_at = NOW()
+        INSERT INTO redis_slowlog_cursor (hostname, last_processed_id)
+        VALUES (%s, %s)
+        ON DUPLICATE KEY UPDATE last_processed_id = VALUES(last_processed_id)
     """,
         (node_name, max_new_id),
     )


### PR DESCRIPTION
背景：
参考pt_query_digest的思路，采集redis日志信息到Archery的mysql数据库，然后在slowquery页面展示，展示样例参考现有的mysql样式。

现有的redis engine有一个已知bug未合并，[#2748](https://github.com/hhyo/Archery/pull/2748)
由于使用到了redis cluster相关功能，先合并了相关代码。

新增功能：
1、新增redis的日志表：src\init_sql\redis_slow_query_review.sql
2、新增redis的采集程序：src\script\collect_redis_slow_log.py
3、新增redis的慢查询日志展示：和mysql慢查询日志差不多，只是去掉了8小时时区问题。

注：mysql不同实例相似命令基本没有，所以checksum基本唯一，但是redis命令虚拟化之后，相似命令过多，checksum在不同实例重复也多，所以和mysql查询慢查询不同，会增加where hostname in {hostnamelist}的约束。

使用方法：

1、设置redis的慢查询日志：
注意：对于redis cluster，每个节点都有单独的slowlog，所以在每个节点以下配置都要跑一次。参数量级按业务实际情况调整。

// 设置慢查询最大容量为5000秒
config set slowlog-max-len 5000
// 设置大于200微秒的redis命令记录到慢查询
config set slowlog-log-slower-than 200
// 查询慢查询总数
slowlog len
// 查询最近5000条慢查询
slowlog get 5000

2、Archery库新增redis的采集表：
mysql的Archery数据库，新增三个表：src\init_sql\redis_slow_query_review.sql

3、采集redis日志：
修改src\script\collect_redis_slow_log.py采集表的redis节点信息，REDIS_LIST。
将对应脚本放服务器，通过crontab定时执行。按业务实际情况，每10分钟或每小时执行。
注：有考虑去重ID，相关去重使用slowlog本身的ID自增属性，记录信息到redis_slowlog_cursor表。

4、页面查看：
【SQL优化】->【慢查日志】页面即可查询redis慢查询日志，
其中如果选择的redis实例是cluster集群模式，会展示集群节点下的所有主节点的慢查询日志。


架构和版本：
已测试：
1、redis单节点，版本4.0.9。
2、redis cluster集群，版本4.0.9和版本6.2.13。
未测试：
1、redis sentinel哨兵。
