### PR TITLE
add(tablespace):Top表空间：新增mongo和clickhouse数据库的支持

### DIFF
--- a/sql/engines/clickhouse.py
+++ b/sql/engines/clickhouse.py
@@ -642,20 +642,20 @@ class ClickHouseEngine(EngineBase):
     def tablespace(self, offset=0, row_count=14):
         """获取表空间信息"""
         sql = """SELECT
-            database AS table_schema,
-            table AS table_name,
-            engine AS engine,
-            round((sum(bytes_on_disk) + sum(marks_bytes)) / 1024 / 1024, 2) AS total_size,
+            database,
+            table,
+            engine,
             sum(rows) AS table_rows,
-            round(sum(bytes_on_disk) / 1024 / 1024, 2) AS data_size,
-            round(sum(marks_bytes) / 1024 / 1024, 2) AS index_size,
-            0 AS data_free,
-            0 AS pct_free
+            formatReadableSize(sum(bytes_on_disk)) AS total_size,
+            formatReadableSize(sum(marks_bytes)) AS marks_bytes,
+            formatReadableSize(sum(data_uncompressed_bytes)) AS data_uncompressed,
+            formatReadableSize(sum(data_compressed_bytes)) AS data_compressed,
+            round((sum(data_compressed_bytes) / sum(data_uncompressed_bytes)) * 100, 2) AS compress_ratio
         FROM system.parts
-        WHERE active
+        WHERE active = 1
             AND database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
         GROUP BY database, table, engine
-        ORDER BY total_size DESC
+        ORDER BY table_rows DESC
         LIMIT {},{};""".format(offset, row_count)
         return self.query(sql=sql)
 

--- a/sql/engines/clickhouse.py
+++ b/sql/engines/clickhouse.py
@@ -639,6 +639,34 @@ class ClickHouseEngine(EngineBase):
             table_metas.append(_meta)
         return table_metas
 
+    def tablespace(self, offset=0, row_count=14):
+        """获取表空间信息"""
+        sql = """SELECT
+            database AS table_schema,
+            table AS table_name,
+            engine AS engine,
+            round((sum(bytes_on_disk) + sum(marks_bytes)) / 1024 / 1024, 2) AS total_size,
+            sum(rows) AS table_rows,
+            round(sum(bytes_on_disk) / 1024 / 1024, 2) AS data_size,
+            round(sum(marks_bytes) / 1024 / 1024, 2) AS index_size,
+            0 AS data_free,
+            0 AS pct_free
+        FROM system.parts
+        WHERE active
+            AND database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+        GROUP BY database, table, engine
+        ORDER BY total_size DESC
+        LIMIT {},{};""".format(offset, row_count)
+        return self.query(sql=sql)
+
+    def tablespace_count(self):
+        """获取表空间数量"""
+        sql = """SELECT count(DISTINCT (database, table))
+        FROM system.parts
+        WHERE active
+            AND database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')"""
+        return self.query(sql=sql)
+
     def close(self):
         if self.conn:
             self.conn.close()

--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -1741,6 +1741,113 @@ class MongoEngine(EngineBase):
                 result.error = str(e)
         return result
 
+    # 排除的系统库
+    forbidden_databases = [
+        "admin",
+        "config",
+        "local",
+    ]
+
+    def tablespace(self, offset=0, row_count=14):
+        """获取表空间信息"""
+        result_set = ResultSet(
+            full_sql="db.collection.aggregate([ { $collStats: { storageStats: { } } } ])"
+        )
+        try:
+            conn = self.get_connection()
+            try:
+                db_list = conn.list_database_names()
+            except OperationFailure:
+                db_list = [self.db_name]
+
+            rows = []
+            for db_name in db_list:
+                if db_name in self.forbidden_databases:
+                    continue
+                db = conn[db_name]
+                collection_names = db.list_collection_names()
+                for coll_name in collection_names:
+                    try:
+                        stats_cursor = db[coll_name].aggregate(
+                            [{"$collStats": {"storageStats": {}}}]
+                        )
+                        for stats in stats_cursor:
+                            storage = stats.get("storageStats", {})
+                            row = {
+                                "ns": storage.get("ns", f"{db_name}.{coll_name}"),
+                                "totalSize": round(
+                                    storage.get("totalSize", 0) / 1024 / 1024, 2
+                                ),
+                                "count": storage.get("count", 0),
+                                "size": round(storage.get("size", 0) / 1024 / 1024, 2),
+                                "avgObjSize": storage.get("avgObjSize", 0),
+                                "storageSize": round(
+                                    storage.get("storageSize", 0) / 1024 / 1024, 2
+                                ),
+                                "freeStorageSize": round(
+                                    storage.get("freeStorageSize", 0) / 1024 / 1024, 2
+                                ),
+                                "capped": storage.get("capped", False),
+                                "nindexes": storage.get("nindexes", 0),
+                                "totalIndexSize": round(
+                                    storage.get("totalIndexSize", 0) / 1024 / 1024, 2
+                                ),
+                            }
+                            rows.append(row)
+                    except Exception as e:
+                        logger.warning(
+                            f"mongodb获取集合{db_name}.{coll_name}存储信息错误，错误信息{str(e)}"
+                        )
+                        continue
+
+            # 按照 totalSize 倒序
+            rows.sort(key=lambda x: x["totalSize"], reverse=True)
+            # 分页
+            rows = rows[offset : offset + row_count]
+            result_set.rows = rows
+            result_set.column_list = [
+                "ns",
+                "totalSize",
+                "count",
+                "size",
+                "avgObjSize",
+                "storageSize",
+                "freeStorageSize",
+                "capped",
+                "nindexes",
+                "totalIndexSize",
+            ]
+        except Exception as e:
+            logger.warning(
+                f"mongodb获取表空间信息错误，错误信息{traceback.format_exc()}"
+            )
+            result_set.error = str(e)
+        return result_set
+
+    def tablespace_count(self):
+        """获取表空间数量"""
+        result_set = ResultSet()
+        try:
+            conn = self.get_connection()
+            try:
+                db_list = conn.list_database_names()
+            except OperationFailure:
+                db_list = [self.db_name]
+
+            count = 0
+            for db_name in db_list:
+                if db_name in self.forbidden_databases:
+                    continue
+                db = conn[db_name]
+                count += len(db.list_collection_names())
+            result_set.rows = [(count,)]
+        except Exception as e:
+            logger.warning(
+                f"mongodb获取表空间数量错误，错误信息{traceback.format_exc()}"
+            )
+            result_set.error = str(e)
+        return result_set
+
     def get_all_databases_summary(self):
         """实例数据库管理功能，获取实例所有的数据库描述信息"""
         query_result = self.get_all_databases()

--- a/sql/engines/test_clickhouse.py
+++ b/sql/engines/test_clickhouse.py
@@ -603,3 +603,86 @@ def test_get_tables_metas_data(mock_query, mock_instance):
     assert ret[0]["TABLE_INFO"]["TABLE_NAME"] == "t1"
     assert len(ret[0]["COLUMNS"]) == 2
     assert ret[0]["COLUMNS"][0]["COLUMN_NAME"] == "id"
+
+
+# ----------------- tablespace -----------------
+@patch.object(ClickHouseEngine, "query")
+def test_tablespace(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        column_list=[
+            "table_schema",
+            "table_name",
+            "engine",
+            "total_size",
+            "table_rows",
+            "data_size",
+            "index_size",
+            "data_free",
+            "pct_free",
+        ],
+        rows=[
+            ("my_db", "t1", "MergeTree", 1024.5, 1000000, 800.0, 224.5, 0, 0),
+            ("my_db", "t2", "ReplacingMergeTree", 512.0, 500000, 400.0, 112.0, 0, 0),
+        ],
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.tablespace(offset=0, row_count=14)
+    mock_query.assert_called_once()
+    assert isinstance(rs, ResultSet)
+    assert rs.column_list[0] == "table_schema"
+    assert rs.rows[0][0] == "my_db"
+    assert rs.rows[0][1] == "t1"
+    assert rs.rows[0][2] == "MergeTree"
+    assert len(rs.rows) == 2
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_tablespace_with_offset(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        column_list=[
+            "table_schema",
+            "table_name",
+            "engine",
+            "total_size",
+            "table_rows",
+            "data_size",
+            "index_size",
+            "data_free",
+            "pct_free",
+        ],
+        rows=[
+            ("my_db", "t3", "MergeTree", 256.0, 200000, 200.0, 56.0, 0, 0),
+        ],
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.tablespace(offset=14, row_count=14)
+    mock_query.assert_called_once()
+    # 验证传给 query 的 SQL 包含正确的 LIMIT 偏移
+    call_sql = mock_query.call_args.kwargs.get("sql", "") or mock_query.call_args[
+        1
+    ].get("sql", "")
+    assert "LIMIT 14,14" in call_sql
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_tablespace_count(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        column_list=["count()"],
+        rows=[(42,)],
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.tablespace_count()
+    mock_query.assert_called_once()
+    assert isinstance(rs, ResultSet)
+    assert rs.rows[0][0] == 42
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_tablespace_count_empty(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        column_list=["count()"],
+        rows=[(0,)],
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.tablespace_count()
+    assert rs.rows[0][0] == 0

--- a/sql/engines/test_clickhouse.py
+++ b/sql/engines/test_clickhouse.py
@@ -605,84 +605,100 @@ def test_get_tables_metas_data(mock_query, mock_instance):
     assert ret[0]["COLUMNS"][0]["COLUMN_NAME"] == "id"
 
 
-# ----------------- tablespace -----------------
 @patch.object(ClickHouseEngine, "query")
-def test_tablespace(mock_query, mock_instance):
+def test_tablespace_default(mock_query, mock_instance):
     mock_query.return_value = ResultSet(
         column_list=[
-            "table_schema",
-            "table_name",
+            "database",
+            "table",
             "engine",
-            "total_size",
             "table_rows",
-            "data_size",
-            "index_size",
-            "data_free",
-            "pct_free",
+            "total_size",
+            "marks_bytes",
+            "data_uncompressed",
+            "data_compressed",
+            "compress_ratio",
         ],
         rows=[
-            ("my_db", "t1", "MergeTree", 1024.5, 1000000, 800.0, 224.5, 0, 0),
-            ("my_db", "t2", "ReplacingMergeTree", 512.0, 500000, 400.0, 112.0, 0, 0),
+            (
+                "my_db",
+                "t1",
+                "MergeTree",
+                1000000,
+                "1.00 GiB",
+                "10.00 MiB",
+                "2.00 GiB",
+                "500.00 MiB",
+                24.41,
+            )
         ],
     )
     engine = ClickHouseEngine(instance=mock_instance)
-    rs = engine.tablespace(offset=0, row_count=14)
+    rs = engine.tablespace()
     mock_query.assert_called_once()
+    call_sql = mock_query.call_args.kwargs.get(
+        "sql", mock_query.call_args[1].get("sql")
+    )
+    assert "LIMIT 0,14" in call_sql
     assert isinstance(rs, ResultSet)
-    assert rs.column_list[0] == "table_schema"
     assert rs.rows[0][0] == "my_db"
     assert rs.rows[0][1] == "t1"
-    assert rs.rows[0][2] == "MergeTree"
-    assert len(rs.rows) == 2
 
 
 @patch.object(ClickHouseEngine, "query")
-def test_tablespace_with_offset(mock_query, mock_instance):
+def test_tablespace_custom_pagination(mock_query, mock_instance):
     mock_query.return_value = ResultSet(
-        column_list=[
-            "table_schema",
-            "table_name",
-            "engine",
-            "total_size",
-            "table_rows",
-            "data_size",
-            "index_size",
-            "data_free",
-            "pct_free",
-        ],
-        rows=[
-            ("my_db", "t3", "MergeTree", 256.0, 200000, 200.0, 56.0, 0, 0),
-        ],
+        column_list=["database", "table", "engine", "table_rows"],
+        rows=[("my_db", "t2", "Log", 1000000)],
     )
     engine = ClickHouseEngine(instance=mock_instance)
-    rs = engine.tablespace(offset=14, row_count=14)
+    rs = engine.tablespace(offset=14, row_count=7)
     mock_query.assert_called_once()
-    # 验证传给 query 的 SQL 包含正确的 LIMIT 偏移
-    call_sql = mock_query.call_args.kwargs.get("sql", "") or mock_query.call_args[
-        1
-    ].get("sql", "")
-    assert "LIMIT 14,14" in call_sql
+    call_sql = mock_query.call_args.kwargs.get(
+        "sql", mock_query.call_args[1].get("sql")
+    )
+    assert "LIMIT 14,7" in call_sql
+    assert rs.rows[0][1] == "t2"
+
+
+@patch.object(ClickHouseEngine, "query")
+def test_tablespace_empty(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(
+        column_list=[
+            "database",
+            "table",
+            "engine",
+            "table_rows",
+            "total_size",
+            "marks_bytes",
+            "data_uncompressed",
+            "data_compressed",
+            "compress_ratio",
+        ],
+        rows=[],
+    )
+    engine = ClickHouseEngine(instance=mock_instance)
+    rs = engine.tablespace()
+    assert rs.rows == []
 
 
 @patch.object(ClickHouseEngine, "query")
 def test_tablespace_count(mock_query, mock_instance):
-    mock_query.return_value = ResultSet(
-        column_list=["count()"],
-        rows=[(42,)],
-    )
+    mock_query.return_value = ResultSet(rows=[(5,)])
     engine = ClickHouseEngine(instance=mock_instance)
     rs = engine.tablespace_count()
     mock_query.assert_called_once()
-    assert isinstance(rs, ResultSet)
-    assert rs.rows[0][0] == 42
+    call_sql = mock_query.call_args.kwargs.get(
+        "sql", mock_query.call_args[1].get("sql")
+    )
+    assert "count(DISTINCT" in call_sql
+    assert "system.parts" in call_sql
+    assert rs.rows[0][0] == 5
 
 
 @patch.object(ClickHouseEngine, "query")
-def test_tablespace_count_empty(mock_query, mock_instance):
-    mock_query.return_value = ResultSet(
-        column_list=["count()"],
-        rows=[(0,)],
-    )
+def test_tablespace_count_zero(mock_query, mock_instance):
+    mock_query.return_value = ResultSet(rows=[(0,)])
     engine = ClickHouseEngine(instance=mock_instance)
     rs = engine.tablespace_count()
     assert rs.rows[0][0] == 0

--- a/sql/engines/test_mongo.py
+++ b/sql/engines/test_mongo.py
@@ -1303,3 +1303,401 @@ class TestParseTuple:
         )
         # 缺失的字段被填充为 "(N/A)"
         assert any("(N/A)" in str(item) for row in rows for item in row)
+
+
+# ====================== tablespace / tablespace_count ======================
+
+
+class TestTablespace:
+    def _build_mock_conn(self, mongo_engine, db_collections):
+        """构建 mock 连接对象。
+
+        db_collections 格式：
+            {
+                "db1": {
+                    "collections": ["coll1", "coll2"],
+                    "stats": {
+                        "coll1": {"storageStats": {"ns": "db1.coll1", ...}},
+                        "coll2": {...},
+                    }
+                }
+            }
+        如果省略 stats，则 aggregate 默认返回空迭代器。
+        """
+        mock_conn = MagicMock()
+
+        def _get_db(name):
+            db_mock = MagicMock()
+            db_mock.list_collection_names.return_value = db_collections[name][
+                "collections"
+            ]
+
+            stats_map = db_collections[name].get("stats", {})
+
+            def _get_coll(coll_name):
+                coll_mock = MagicMock()
+                stat_data = stats_map.get(coll_name)
+                if stat_data is not None:
+                    coll_mock.aggregate.return_value = [stat_data]
+                else:
+                    coll_mock.aggregate.return_value = iter([])
+                return coll_mock
+
+            db_mock.__getitem__ = MagicMock(side_effect=_get_coll)
+            return db_mock
+
+        mock_conn.__getitem__ = MagicMock(side_effect=_get_db)
+        mock_conn.list_database_names.return_value = list(db_collections.keys())
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+        return mock_conn
+
+    def test_tablespace_basic(self, mongo_engine):
+        """基本功能：两个集合，验证字段和排序"""
+        db_collections = {
+            "mydb": {
+                "collections": ["small_coll", "big_coll"],
+                "stats": {
+                    "small_coll": {
+                        "storageStats": {
+                            "ns": "mydb.small_coll",
+                            "totalSize": 10 * 1024 * 1024,  # 10 MB
+                            "count": 100,
+                            "size": 8 * 1024 * 1024,
+                            "avgObjSize": 80,
+                            "storageSize": 4 * 1024 * 1024,
+                            "freeStorageSize": 1 * 1024 * 1024,
+                            "capped": False,
+                            "nindexes": 2,
+                            "totalIndexSize": 2 * 1024 * 1024,
+                        }
+                    },
+                    "big_coll": {
+                        "storageStats": {
+                            "ns": "mydb.big_coll",
+                            "totalSize": 100 * 1024 * 1024,  # 100 MB
+                            "count": 1000,
+                            "size": 80 * 1024 * 1024,
+                            "avgObjSize": 800,
+                            "storageSize": 50 * 1024 * 1024,
+                            "freeStorageSize": 5 * 1024 * 1024,
+                            "capped": True,
+                            "nindexes": 3,
+                            "totalIndexSize": 10 * 1024 * 1024,
+                        }
+                    },
+                },
+            }
+        }
+        self._build_mock_conn(mongo_engine, db_collections)
+
+        result = mongo_engine.tablespace(offset=0, row_count=14)
+        assert result.error is None
+        assert len(result.rows) == 2
+        # 按 totalSize 倒序
+        assert result.rows[0]["ns"] == "mydb.big_coll"
+        assert result.rows[1]["ns"] == "mydb.small_coll"
+        # 验证 MB 转换
+        assert result.rows[0]["totalSize"] == 100.0
+        assert result.rows[1]["totalSize"] == 10.0
+        assert result.rows[0]["size"] == 80.0
+        assert result.rows[0]["storageSize"] == 50.0
+        assert result.rows[0]["freeStorageSize"] == 5.0
+        assert result.rows[0]["totalIndexSize"] == 10.0
+        # 不转换的字段
+        assert result.rows[0]["count"] == 1000
+        assert result.rows[0]["avgObjSize"] == 800
+        assert result.rows[0]["capped"] is True
+        assert result.rows[0]["nindexes"] == 3
+        # column_list
+        assert result.column_list == [
+            "ns",
+            "totalSize",
+            "count",
+            "size",
+            "avgObjSize",
+            "storageSize",
+            "freeStorageSize",
+            "capped",
+            "nindexes",
+            "totalIndexSize",
+        ]
+
+    def test_tablespace_excludes_system_dbs(self, mongo_engine):
+        """排除系统库 admin / config / local"""
+        db_collections = {
+            "admin": {"collections": ["system.users"], "stats": {}},
+            "config": {"collections": ["mongos"], "stats": {}},
+            "local": {"collections": ["startup_log"], "stats": {}},
+            "mydb": {
+                "collections": ["users"],
+                "stats": {
+                    "users": {
+                        "storageStats": {
+                            "ns": "mydb.users",
+                            "totalSize": 1 * 1024 * 1024,
+                            "count": 10,
+                            "size": 0.5 * 1024 * 1024,
+                            "avgObjSize": 50,
+                            "storageSize": 0.3 * 1024 * 1024,
+                            "freeStorageSize": 0,
+                            "capped": False,
+                            "nindexes": 1,
+                            "totalIndexSize": 0,
+                        }
+                    }
+                },
+            },
+        }
+        self._build_mock_conn(mongo_engine, db_collections)
+
+        result = mongo_engine.tablespace()
+        assert result.error is None
+        assert len(result.rows) == 1
+        assert result.rows[0]["ns"] == "mydb.users"
+
+    def test_tablespace_pagination(self, mongo_engine):
+        """分页：offset 和 row_count"""
+        db_collections = {
+            "mydb": {
+                "collections": ["c1", "c2", "c3"],
+                "stats": {
+                    "c1": {
+                        "storageStats": {
+                            "ns": "mydb.c1",
+                            "totalSize": 30 * 1024 * 1024,
+                            "count": 1,
+                            "size": 0,
+                            "avgObjSize": 0,
+                            "storageSize": 0,
+                            "freeStorageSize": 0,
+                            "capped": False,
+                            "nindexes": 0,
+                            "totalIndexSize": 0,
+                        }
+                    },
+                    "c2": {
+                        "storageStats": {
+                            "ns": "mydb.c2",
+                            "totalSize": 20 * 1024 * 1024,
+                            "count": 1,
+                            "size": 0,
+                            "avgObjSize": 0,
+                            "storageSize": 0,
+                            "freeStorageSize": 0,
+                            "capped": False,
+                            "nindexes": 0,
+                            "totalIndexSize": 0,
+                        }
+                    },
+                    "c3": {
+                        "storageStats": {
+                            "ns": "mydb.c3",
+                            "totalSize": 10 * 1024 * 1024,
+                            "count": 1,
+                            "size": 0,
+                            "avgObjSize": 0,
+                            "storageSize": 0,
+                            "freeStorageSize": 0,
+                            "capped": False,
+                            "nindexes": 0,
+                            "totalIndexSize": 0,
+                        }
+                    },
+                },
+            }
+        }
+        self._build_mock_conn(mongo_engine, db_collections)
+
+        # 第1页，每页2条
+        result = mongo_engine.tablespace(offset=0, row_count=2)
+        assert len(result.rows) == 2
+        assert result.rows[0]["ns"] == "mydb.c1"
+        assert result.rows[1]["ns"] == "mydb.c2"
+
+        # 第2页，每页2条
+        result = mongo_engine.tablespace(offset=2, row_count=2)
+        assert len(result.rows) == 1
+        assert result.rows[0]["ns"] == "mydb.c3"
+
+    def test_tablespace_operation_failure_fallback(self, mongo_engine):
+        """list_database_names 抛出 OperationFailure 时回退到 db_name"""
+        from pymongo.errors import OperationFailure
+
+        mock_conn = MagicMock()
+        mock_conn.list_database_names.side_effect = OperationFailure("no auth")
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["coll1"]
+        mock_coll = MagicMock()
+        mock_coll.aggregate.return_value = [
+            {
+                "storageStats": {
+                    "ns": "test_db.coll1",
+                    "totalSize": 5 * 1024 * 1024,
+                    "count": 50,
+                    "size": 3 * 1024 * 1024,
+                    "avgObjSize": 60,
+                    "storageSize": 2 * 1024 * 1024,
+                    "freeStorageSize": 0,
+                    "capped": False,
+                    "nindexes": 1,
+                    "totalIndexSize": 1 * 1024 * 1024,
+                }
+            }
+        ]
+        mock_db.__getitem__ = MagicMock(return_value=mock_coll)
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+        mongo_engine.db_name = "test_db"
+
+        result = mongo_engine.tablespace()
+        assert result.error is None
+        assert len(result.rows) == 1
+        assert result.rows[0]["ns"] == "test_db.coll1"
+
+    def test_tablespace_collection_error_skipped(self, mongo_engine):
+        """单个集合获取存储信息报错时跳过，不影响其他集合"""
+        mock_conn = MagicMock()
+        mock_conn.list_database_names.return_value = ["mydb"]
+
+        db_mock = MagicMock()
+        db_mock.list_collection_names.return_value = ["good_coll", "bad_coll"]
+
+        good_coll_mock = MagicMock()
+        good_coll_mock.aggregate.return_value = [
+            {
+                "storageStats": {
+                    "ns": "mydb.good_coll",
+                    "totalSize": 1 * 1024 * 1024,
+                    "count": 5,
+                    "size": 0,
+                    "avgObjSize": 0,
+                    "storageSize": 0,
+                    "freeStorageSize": 0,
+                    "capped": False,
+                    "nindexes": 0,
+                    "totalIndexSize": 0,
+                }
+            }
+        ]
+
+        bad_coll_mock = MagicMock()
+        bad_coll_mock.aggregate.side_effect = Exception("stats error")
+
+        def _get_coll(name):
+            if name == "good_coll":
+                return good_coll_mock
+            return bad_coll_mock
+
+        db_mock.__getitem__ = MagicMock(side_effect=_get_coll)
+        mock_conn.__getitem__ = MagicMock(return_value=db_mock)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.tablespace()
+        assert result.error is None
+        assert len(result.rows) == 1
+        assert result.rows[0]["ns"] == "mydb.good_coll"
+
+    def test_tablespace_connection_error(self, mongo_engine):
+        """连接失败时返回错误"""
+        mongo_engine.get_connection = MagicMock(side_effect=Exception("conn failed"))
+
+        result = mongo_engine.tablespace()
+        assert result.error is not None
+        assert "conn failed" in result.error
+
+    def test_tablespace_defaults_on_missing_stats(self, mongo_engine):
+        """storageStats 中部分字段缺失时使用默认值"""
+        db_collections = {
+            "mydb": {
+                "collections": ["sparse_coll"],
+                "stats": {
+                    "sparse_coll": {
+                        "storageStats": {
+                            # 只提供 ns 和 totalSize
+                            "ns": "mydb.sparse_coll",
+                            "totalSize": 2 * 1024 * 1024,
+                        }
+                    }
+                },
+            }
+        }
+        self._build_mock_conn(mongo_engine, db_collections)
+
+        result = mongo_engine.tablespace()
+        assert result.error is None
+        assert len(result.rows) == 1
+        row = result.rows[0]
+        assert row["ns"] == "mydb.sparse_coll"
+        assert row["totalSize"] == 2.0
+        assert row["count"] == 0
+        assert row["size"] == 0.0
+        assert row["avgObjSize"] == 0
+        assert row["storageSize"] == 0.0
+        assert row["freeStorageSize"] == 0.0
+        assert row["capped"] is False
+        assert row["nindexes"] == 0
+        assert row["totalIndexSize"] == 0.0
+
+
+class TestTablespaceCount:
+    def test_tablespace_count_basic(self, mongo_engine):
+        """基本功能：统计非系统库的集合数量"""
+        mock_conn = MagicMock()
+        mock_conn.list_database_names.return_value = ["mydb", "admin", "mydb2"]
+
+        db_mydb = MagicMock()
+        db_mydb.list_collection_names.return_value = ["coll1", "coll2"]
+
+        db_admin = MagicMock()
+        db_admin.list_collection_names.return_value = ["system.users"]
+
+        db_mydb2 = MagicMock()
+        db_mydb2.list_collection_names.return_value = ["coll3"]
+
+        def _get_db(name):
+            if name == "mydb":
+                return db_mydb
+            elif name == "admin":
+                return db_admin
+            return db_mydb2
+
+        mock_conn.__getitem__ = MagicMock(side_effect=_get_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.tablespace_count()
+        assert result.error is None
+        assert result.rows[0][0] == 3  # 2 (mydb) + 1 (mydb2), admin excluded
+
+    def test_tablespace_count_operation_failure(self, mongo_engine):
+        """list_database_names 抛出 OperationFailure 时回退"""
+        from pymongo.errors import OperationFailure
+
+        mock_conn = MagicMock()
+        mock_conn.list_database_names.side_effect = OperationFailure("no auth")
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["coll1", "coll2"]
+        mock_conn.__getitem__ = MagicMock(return_value=mock_db)
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+        mongo_engine.db_name = "test_db"
+
+        result = mongo_engine.tablespace_count()
+        assert result.error is None
+        assert result.rows[0][0] == 2
+
+    def test_tablespace_count_connection_error(self, mongo_engine):
+        """连接失败时返回错误"""
+        mongo_engine.get_connection = MagicMock(side_effect=Exception("conn failed"))
+
+        result = mongo_engine.tablespace_count()
+        assert result.error is not None
+        assert "conn failed" in result.error
+
+    def test_tablespace_count_empty(self, mongo_engine):
+        """没有任何非系统库时返回 0"""
+        mock_conn = MagicMock()
+        mock_conn.list_database_names.return_value = ["admin", "config", "local"]
+        mongo_engine.get_connection = MagicMock(return_value=mock_conn)
+
+        result = mongo_engine.tablespace_count()
+        assert result.error is None
+        assert result.rows[0][0] == 0

--- a/sql/templates/dbdiagnostic.html
+++ b/sql/templates/dbdiagnostic.html
@@ -252,7 +252,36 @@
         ]
         let dorisTableInfo = ['doris',tablespaceListTableInfos[0][1]]
         tablespaceListTableInfos.push(dorisTableInfo)
-        let clickhouseTableInfo = ['clickhouse',tablespaceListTableInfos[0][1]]
+        let clickhouseTableInfo = ['clickhouse',
+            [{
+                title: '数据库',
+                field: 'database'
+            }, {
+                title: '表名',
+                field: 'table'
+            }, {
+                title: '存储引擎',
+                field: 'engine'
+            }, {
+                title: '行数',
+                field: 'table_rows'
+            }, {
+                title: '总空间',
+                field: 'total_size'
+            }, {
+                title: '索引空间',
+                field: 'marks_bytes'
+            }, {
+                title: '数据空间(未压缩)',
+                field: 'data_uncompressed'
+            }, {
+                title: '数据空间(压缩后)',
+                field: 'data_compressed'
+            }, {
+                title: '压缩率',
+                field: 'compress_ratio'
+            }]
+        ]
         tablespaceListTableInfos.push(clickhouseTableInfo)
         let mongoTableInfo = [
             'mongo',

--- a/sql/templates/dbdiagnostic.html
+++ b/sql/templates/dbdiagnostic.html
@@ -30,6 +30,7 @@
                         <optgroup id="optgroup-redis" label="Redis"></optgroup>
                         <optgroup id="optgroup-pgsql" label="PgSQL"></optgroup>
                         <optgroup id="optgroup-doris" label="Doris"></optgroup>
+                        <optgroup id="optgroup-clickhouse" label="ClickHouse"></optgroup>
                 </select>
             </div>
             <div id="command-div" class="form-group">
@@ -251,6 +252,43 @@
         ]
         let dorisTableInfo = ['doris',tablespaceListTableInfos[0][1]]
         tablespaceListTableInfos.push(dorisTableInfo)
+        let clickhouseTableInfo = ['clickhouse',tablespaceListTableInfos[0][1]]
+        tablespaceListTableInfos.push(clickhouseTableInfo)
+        let mongoTableInfo = [
+            'mongo',
+            [{
+                title: '集合名',
+                field: 'ns'
+            }, {
+                title: '总空间(MB)',
+                field: 'totalSize'
+            }, {
+                title: '行数',
+                field: 'count'
+            }, {
+                title: '未压缩的数据空间(MB)',
+                field: 'size'
+            }, {
+                title: '每行平均(B)',
+                field: 'avgObjSize'
+            }, {
+                title: '压缩后的数据空间(MB)',
+                field: 'storageSize'
+            }, {
+                title: '碎片空间(MB)',
+                field: 'freeStorageSize'
+            }, {
+                title: '固定集合',
+                field: 'capped'
+            }, {
+                title: '索引数',
+                field: 'nindexes'
+            }, {
+                title: '索引空间(MB)',
+                field: 'totalIndexSize'
+            }]
+        ]
+        tablespaceListTableInfos.push(mongoTableInfo)
 
         // 问题诊断--表空间列表
         function get_space_list() {
@@ -734,7 +772,7 @@
                 //获取用户实例列表
                 $(function () {
                     // 会话管理-支持的数据库类型
-                    supportedDbType=['mysql','mongo', 'oracle','redis','pgsql','doris']
+                    supportedDbType=['mysql','mongo', 'oracle','redis','pgsql','doris','clickhouse']
                     $.ajax({
                         type: "get",
                         url: "/group/user_all_instances/",


### PR DESCRIPTION
1、新增mongo的表空间查询。
使用：db.follow.aggregate( [ { $collStats: { storageStats: { } } } ] )

colStats命令已过期，使用聚合方法$colStats
https://www.mongodb.com/zh-cn/docs/manual/reference/command/collStats/

https://www.mongodb.com/zh-cn/docs/manual/reference/operator/aggregation/collStats/#mongodb-pipeline-pipe.-collStats

排除了系统库（"admin","config","local"），未排除正常库中的系统表（例如慢查询表system.profile）。

2、新增clickhouse的表空间查询。

使用系统表查询对应空间数据：system.parts。

有些低版本没有对应的primary_key_size（主键索引空间）字段，目前先不取。

排除了系统库（'system', 'INFORMATION_SCHEMA', 'information_schema'）。