### PR TITLE
fix(mariadb):mariadb兼容性修复和错误修复

### DIFF
--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -766,9 +766,13 @@ class MysqlEngine(EngineBase):
             cursor = conn.cursor(cursorclass)
             try:
                 if self.server_fork_type == MysqlForkType.MARIADB:
-                    cursor.execute(f"set session max_statement_time={max_execution_time / 1000};")
+                    cursor.execute(
+                        f"set session max_statement_time={max_execution_time / 1000};"
+                    )
                 else:
-                    cursor.execute(f"set session max_execution_time={max_execution_time};")
+                    cursor.execute(
+                        f"set session max_execution_time={max_execution_time};"
+                    )
             except MySQLdb.OperationalError:
                 pass
             effect_row = cursor.execute(sql, parameters)

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -765,7 +765,10 @@ class MysqlEngine(EngineBase):
             conn.autocommit(True)
             cursor = conn.cursor(cursorclass)
             try:
-                cursor.execute(f"set session max_execution_time={max_execution_time};")
+                if self.server_fork_type == MysqlForkType.MARIADB:
+                    cursor.execute(f"set session max_statement_time={max_execution_time / 1000};")
+                else:
+                    cursor.execute(f"set session max_execution_time={max_execution_time};")
             except MySQLdb.OperationalError:
                 pass
             effect_row = cursor.execute(sql, parameters)
@@ -986,12 +989,7 @@ class MysqlEngine(EngineBase):
                 if isinstance(variables, list)
                 else "','".join(list(variables))
             )
-            db = (
-                "performance_schema"
-                if self.server_version > (5, 7)
-                else "information_schema"
-            )
-            sql = f"""select * from {db}.global_variables where variable_name in ('{variables}');"""
+            sql = f"""show global variables where variable_name in ('{variables}');"""
         else:
             sql = "show global variables;"
         return self.query(sql=sql)

--- a/sql/sql_tuning.py
+++ b/sql/sql_tuning.py
@@ -5,6 +5,7 @@ import time
 from common.utils.const import SQLTuning
 from sql.engines import get_engine
 from sql.models import Instance
+from sql.engines.mysql import MysqlForkType
 from sql.utils.sql_utils import extract_tables
 
 
@@ -66,8 +67,11 @@ class SqlTuning(object):
     def sys_parameter(self):
         # 获取mysql版本信息
         server_version = self.engine.server_version
-        if server_version >= (5, 7, 6):
-            sql = self.sql_variable.replace("information_schema.global_variables", "performance_schema.global_variables")
+        if self.engine.server_fork_type != MysqlForkType.MARIADB and server_version >= (5, 7, 6):
+            sql = self.sql_variable.replace(
+                "information_schema.global_variables", 
+                "performance_schema.global_variables"
+                )
         else:
             sql = self.sql_variable
         return self.engine.query(sql=sql).to_sep_dict()

--- a/sql/sql_tuning.py
+++ b/sql/sql_tuning.py
@@ -19,12 +19,12 @@ class SqlTuning(object):
     select
       lower(variable_name),
       variable_value
-    from performance_schema.global_variables
+    from information_schema.global_variables
     where upper(variable_name) in ('%s')
     order by variable_name;""" % ("','".join(SQLTuning.SYS_PARM_FILTER))
         self.sql_optimizer_switch = """
     select variable_value
-    from performance_schema.global_variables
+    from information_schema.global_variables
     where upper(variable_name) = 'OPTIMIZER_SWITCH';
     """
         self.sql_table_info = """
@@ -61,16 +61,16 @@ class SqlTuning(object):
         return [i["name"].strip("`") for i in extract_tables(self.sqltext)]
 
     def basic_information(self):
-        return self.engine.query(sql="select @@version", close_conn=False).to_sep_dict()
+        return self.engine.query(sql="select @@version").to_sep_dict()
 
     def sys_parameter(self):
         # 获取mysql版本信息
         server_version = self.engine.server_version
-        if server_version < (5, 7, 0):
-            sql = self.sql_variable.replace("performance_schema", "information_schema")
+        if server_version >= (5, 7, 6):
+            sql = self.sql_variable.replace("information_schema.global_variables", "performance_schema.global_variables")
         else:
             sql = self.sql_variable
-        return self.engine.query(sql=sql, close_conn=False).to_sep_dict()
+        return self.engine.query(sql=sql).to_sep_dict()
 
     def optimizer_switch(self):
         # 获取mysql版本信息
@@ -81,7 +81,7 @@ class SqlTuning(object):
             )
         else:
             sql = self.sql_optimizer_switch
-        return self.engine.query(sql=sql, close_conn=False).to_sep_dict()
+        return self.engine.query(sql=sql).to_sep_dict()
 
     def sqlplan(self):
         plan = self.engine.query(

--- a/sql/sql_tuning.py
+++ b/sql/sql_tuning.py
@@ -67,11 +67,14 @@ class SqlTuning(object):
     def sys_parameter(self):
         # 获取mysql版本信息
         server_version = self.engine.server_version
-        if self.engine.server_fork_type != MysqlForkType.MARIADB and server_version >= (5, 7, 6):
+        if (
+            self.engine.server_fork_type != MysqlForkType.MARIADB
+            and server_version >= (5, 7, 6)
+        ):
             sql = self.sql_variable.replace(
-                "information_schema.global_variables", 
-                "performance_schema.global_variables"
-                )
+                "information_schema.global_variables",
+                "performance_schema.global_variables",
+            )
         else:
             sql = self.sql_variable
         return self.engine.query(sql=sql).to_sep_dict()

--- a/sql/templates/sqladvisor.html
+++ b/sql/templates/sqladvisor.html
@@ -831,7 +831,10 @@
                                 var template = $(div_obj_stat_tmp).html();
                                 $("#div_obj_stat-panel-body").empty();
                                 $.each(result['object_statistics'], function (i, result) {
-                                    if (result['structure']['column_list'].length > 0) {
+                                    var has_structure = result['structure']['column_list'].length > 0;
+                                    var has_table_info = result['table_info']['column_list'].length > 0;
+                                    var has_index_info = result['index_info']['column_list'].length > 0;
+                                    if (has_structure || has_table_info || has_index_info) {
                                         $("#div_obj_stat-panel-body").append(template);
                                         var tb_table_structure_id = 'tb_table_structure_' + i;
                                         var tb_table_info_id = 'tb_table_info_' + i;
@@ -841,75 +844,87 @@
                                         $('#tb_index_info').attr('id', tb_index_info_id);
 
                                         //===== TABLE STRUCTURE =====
-                                        //异步获取要动态生成的列
-                                        var columns = [];
-                                        $.each(result['structure']['column_list'], function (i, column) {
-                                            columns.push({
-                                                "field": i,
-                                                "title": column,
-                                                formatter: function (value, row, index) {
-                                                    if (value.length > 200) {
-                                                        var sql = value.substr(0, 200) + '...';
-                                                        return sql;
-                                                    } else {
-                                                        return value
+                                        if (has_structure) {
+                                            //异步获取要动态生成的列
+                                            var columns = [];
+                                            $.each(result['structure']['column_list'], function (i, column) {
+                                                columns.push({
+                                                    "field": i,
+                                                    "title": column,
+                                                    formatter: function (value, row, index) {
+                                                        if (value.length > 200) {
+                                                            var sql = value.substr(0, 200) + '...';
+                                                            return sql;
+                                                        } else {
+                                                            return value
+                                                        }
                                                     }
-                                                }
-                                            })
-                                        });
-                                        //初始化查询结果
-                                        $("#" + tb_table_structure_id).bootstrapTable('destroy').bootstrapTable({
-                                            escape: true,
-                                            data: result['structure']['rows'],
-                                            columns: columns,
-                                            detailView: true,   //是否显示父子表
-                                            //格式化详情
-                                            detailFormatter: function (index, row) {
-                                                var html = [];
-                                                $.each(row, function (key, value) {
-                                                    if (index === 0) {
-                                                        var sql = window.sqlFormatter.format(value);
-                                                        //替换所有的换行符
-                                                        sql = sql.replace(/\r\n/g, "<br>");
-                                                        sql = sql.replace(/\n/g, "<br>");
-                                                        //替换所有的空格
-                                                        sql = sql.replace(/\s/g, "&nbsp;");
-                                                        html.push('<span>' + sql + '</span>');
-                                                    }
-                                                });
-                                                return html.join('');
-                                            },
-                                        });
+                                                })
+                                            });
+                                            //初始化查询结果
+                                            $("#" + tb_table_structure_id).bootstrapTable('destroy').bootstrapTable({
+                                                escape: true,
+                                                data: result['structure']['rows'],
+                                                columns: columns,
+                                                detailView: true,   //是否显示父子表
+                                                //格式化详情
+                                                detailFormatter: function (index, row) {
+                                                    var html = [];
+                                                    $.each(row, function (key, value) {
+                                                        if (index === 0) {
+                                                            var sql = window.sqlFormatter.format(value);
+                                                            //替换所有的换行符
+                                                            sql = sql.replace(/\r\n/g, "<br>");
+                                                            sql = sql.replace(/\n/g, "<br>");
+                                                            //替换所有的空格
+                                                            sql = sql.replace(/\s/g, "&nbsp;");
+                                                            html.push('<span>' + sql + '</span>');
+                                                        }
+                                                    });
+                                                    return html.join('');
+                                                },
+                                            });
+                                        } else {
+                                            $("#" + tb_table_structure_id).replaceWith("<p>解析表结构出错或者无权限查看表结构</p>");
+                                        }
                                         //===== TABLE INFO =====
-                                        //异步获取要动态生成的列
-                                        var columns = [];
-                                        $.each(result['table_info']['column_list'], function (i, column) {
-                                            columns.push({
-                                                "field": i,
-                                                "title": column
-                                            })
-                                        });
-                                        //初始化查询结果
-                                        $("#" + tb_table_info_id).bootstrapTable('destroy').bootstrapTable({
-                                            escape: true,
-                                            data: result['table_info']['rows'],
-                                            columns: columns
-                                        });
+                                        if (has_table_info) {
+                                            //异步获取要动态生成的列
+                                            var columns = [];
+                                            $.each(result['table_info']['column_list'], function (i, column) {
+                                                columns.push({
+                                                    "field": i,
+                                                    "title": column
+                                                })
+                                            });
+                                            //初始化查询结果
+                                            $("#" + tb_table_info_id).bootstrapTable('destroy').bootstrapTable({
+                                                escape: true,
+                                                data: result['table_info']['rows'],
+                                                columns: columns
+                                            });
+                                        } else {
+                                            $("#" + tb_table_info_id).replaceWith("<p>未获取到表统计信息</p>");
+                                        }
                                         //===== INDEX INFO =====
-                                        //异步获取要动态生成的列
-                                        var columns = [];
-                                        $.each(result['index_info']['column_list'], function (i, column) {
-                                            columns.push({
-                                                "field": i,
-                                                "title": column
-                                            })
-                                        });
-                                        //初始化查询结果
-                                        $("#" + tb_index_info_id).bootstrapTable('destroy').bootstrapTable({
-                                            escape: true,
-                                            data: result['index_info']['rows'],
-                                            columns: columns
-                                        });
+                                        if (has_index_info) {
+                                            //异步获取要动态生成的列
+                                            var columns = [];
+                                            $.each(result['index_info']['column_list'], function (i, column) {
+                                                columns.push({
+                                                    "field": i,
+                                                    "title": column
+                                                })
+                                            });
+                                            //初始化查询结果
+                                            $("#" + tb_index_info_id).bootstrapTable('destroy').bootstrapTable({
+                                                escape: true,
+                                                data: result['index_info']['rows'],
+                                                columns: columns
+                                            });
+                                        } else {
+                                            $("#" + tb_index_info_id).replaceWith("<p>未获取到索引统计信息</p>");
+                                        }
                                     } else {
                                         $("#div_obj_stat-panel-body").append("<p>解析表出错或者表不存在，无法展示表信息</p>");
                                     }


### PR DESCRIPTION
1、兼容mariadb参数：已有mysql参数max_execution_time，增加兼容mariadb版本对应参数max_statement_time，注意单位不一致。 
2、参数获取：global_variables表在mysql5.7之后在performance_schema库中，而mariadb版本一直使用information_schema.global_variables。不再考虑global_variables表是哪个库中，统一使用show global variables where variable_name in ({}); 的方式。 
3、修复链接关闭问题：sql\sql_tuning.py的全局查询basic_information()、sys_parameter()、optimizer_switch()未关闭链接，导致如果方法报错，后续其他正常查询复用链接的时候，还是取默认库，而不是前端db_name传参，导致报错（No database selected）。 
4、兼容mariadb表：sql\sql_tuning.py中的参数查询，改为默认使用information_schema.global_variables，超过指定版本才替换为performance_schema.global_variables。
5、sqladvisor界面优化：MySQLTuning返回数组的部分子项为空的时候，不影响前端页面的整体布局，只是子组件为空。