### PR TITLE
feat(workflow):增加SQL上线工单的批量操作（如批量提交、审核、执行、终止）

### DIFF
--- a/sql/templates/sqlsubmit.html
+++ b/sql/templates/sqlsubmit.html
@@ -189,6 +189,55 @@
             sessionStorage.removeItem('my2sqlSubmitWorkflowName');
         }
 
+        function getSelectValueList(selector) {
+            var value = $(selector).val();
+            if (!value) {
+                return [];
+            }
+            return $.isArray(value) ? value : [value];
+        }
+
+        function getSelectedInstanceOptions() {
+            return $("#instance_name option:selected");
+        }
+
+        function getFirstSelectedInstanceOption() {
+            return getSelectedInstanceOptions().first();
+        }
+
+        function getSelectedInstanceIds() {
+            return getSelectedInstanceOptions().map(function () {
+                return $(this).attr("instance-id");
+            }).get();
+        }
+
+        function getFirstSelectedInstanceId() {
+            var instanceIds = getSelectedInstanceIds();
+            return instanceIds.length > 0 ? instanceIds[0] : "";
+        }
+
+        function getSelectedDbNames() {
+            return getSelectValueList("#db_name");
+        }
+
+        function getFirstDbName() {
+            var dbNames = getSelectedDbNames();
+            return dbNames.length > 0 ? dbNames[0] : "";
+        }
+
+        function initBatchSubmitSelects() {
+            $("#instance_name, #db_name").each(function () {
+                var $select = $(this);
+                $select.attr("multiple", "multiple");
+                $select.selectpicker('destroy');
+                $select.selectpicker({
+                    actionsBox: true,
+                    countSelectedText: "已选中{0}项",
+                    selectedTextFormat: "count > 3"
+                });
+            });
+        }
+
         function selectMy2sqlSubmitInstance() {
             if (!my2sqlSubmitState.pending || !my2sqlSubmitState.instanceName) {
                 return;
@@ -197,7 +246,10 @@
                 return $(this).val() === my2sqlSubmitState.instanceName;
             });
             if (matchedOption.length > 0) {
-                $('#instance_name').selectpicker('val', my2sqlSubmitState.instanceName);
+                $('#instance_name').selectpicker(
+                    'val',
+                    [my2sqlSubmitState.instanceName]
+                );
                 if ($("#instance_name").val()) {
                     $("#instance_name").selectpicker().trigger("change");
                 }
@@ -212,7 +264,10 @@
                 return $(this).val() === my2sqlSubmitState.dbName;
             });
             if (matchedOption.length > 0) {
-                $('#db_name').selectpicker('val', my2sqlSubmitState.dbName);
+                $('#db_name').selectpicker(
+                    'val',
+                    [my2sqlSubmitState.dbName]
+                );
                 if ($("#db_name").val()) {
                     $("#db_name").selectpicker().trigger("change");
                 }
@@ -303,7 +358,25 @@
     <script>
         // 实例变更获取数据库补全提示
         $("#instance_name").change(function () {
-            var optgroup = $('#instance_name :selected').parent().attr('label');
+            var selectedOptions = getSelectedInstanceOptions();
+            if (selectedOptions.length === 0) {
+                $("#db_name").empty().selectpicker('render').selectpicker('refresh');
+                return;
+            }
+            var selectedDbTypes = [];
+            selectedOptions.each(function () {
+                var label = $(this).parent().attr('label');
+                if (selectedDbTypes.indexOf(label) === -1) {
+                    selectedDbTypes.push(label);
+                }
+            });
+            if (selectedDbTypes.length > 1) {
+                alert("批量提交请选择同一种数据库类型的实例！");
+                $("#db_name").empty().selectpicker('render').selectpicker('refresh');
+                return;
+            }
+            var optgroup = selectedDbTypes[0];
+            var firstInstanceName = selectedOptions.first().val();
             $("#div-backup").show();
             if (optgroup != "MySQL" && optgroup != "Oracle") {
                 $("#div-backup").hide();
@@ -321,14 +394,14 @@
                 url: "/api/v1/sqlquery/resources/",
                 dataType: "json",
                 data: {
-                    instance_name: $("#instance_name").val(),
+                    instance_name: firstInstanceName,
                     resource_type: "database"
                 },
                 complete: function () {
                     var pathname = window.location.pathname;
                     if (pathname === "/editsql/") {
                         //填充库名
-                        $("#db_name").selectpicker('val', sessionStorage.getItem('editDbname'));
+                        $("#db_name").selectpicker('val', [sessionStorage.getItem('editDbname')]);
                         if ($("#db_name").val()) {
                             $("#db_name").selectpicker().trigger("change");
                         }
@@ -366,14 +439,19 @@
         });
         //数据库变更获取表名称补全提示
         $("#db_name").change(function () {
+            var firstInstanceName = getFirstSelectedInstanceOption().val();
+            var firstDbName = getFirstDbName();
+            if (!firstInstanceName || !firstDbName) {
+                return;
+            }
             //将数据通过ajax提交给获取db_name
             $.ajax({
                 type: "get",
                 url: "/api/v1/sqlquery/resources/",
                 dataType: "json",
                 data: {
-                    instance_name: $("#instance_name").val(),
-                    db_name: $("#db_name").val(),
+                    instance_name: firstInstanceName,
+                    db_name: firstDbName,
                     resource_type: "table"
                 },
                 complete: function () {
@@ -402,7 +480,9 @@
                     var fieldId = $(this).attr('id');
                     //如果为null则设置为''
                     var value = fieldElement.val() || '';
-                    if (value) {
+                    if ($.isArray(value)) {
+                        value = value.length > 0 ? value : '';
+                    } else if (value) {
                         value = value.trim();
                     }
                     if (!value || value === fieldElement.attr('data-placeholder')) {
@@ -515,8 +595,8 @@
                 contentType: 'application/json;',
                 data: JSON.stringify({
                     full_sql: editor.getValue(),
-                    instance_id: $("#instance_name option:selected").attr("instance-id"),
-                    db_name: $("#db_name").val()
+                    instance_id: getFirstSelectedInstanceId(),
+                    db_name: getFirstDbName()
                 }),
                 beforeSend: function (xhr) {
                     $('#btn-autoreview').button('loading')
@@ -654,23 +734,34 @@
                 obj[item.name] = item.value;
                 return obj;
             }, {})
+            let workflow = {
+                workflow_name: formData.workflow_name,
+                demand_url: formData.demand_url,
+                group_id: $("#group_name option:selected").attr("group-id"),
+                is_backup: formData.is_backup === 'True',
+                run_date_start: formData.run_date_start,
+                run_date_end: formData.run_date_end,
+                is_offline_export: 0,
+            };
+            let selectedInstanceIds = getSelectedInstanceIds();
+            let selectedDbNames = getSelectedDbNames();
+            let isBatchSubmit = selectedInstanceIds.length > 1 || selectedDbNames.length > 1;
+            let submitUrl = "/api/v1/workflow/";
+            if (isBatchSubmit) {
+                workflow.instances = selectedInstanceIds;
+                workflow.db_names = selectedDbNames;
+                submitUrl = "/api/v1/workflow/batch/submit/";
+            } else {
+                workflow.instance = getFirstSelectedInstanceId();
+                workflow.db_name = getFirstDbName();
+            }
             $.ajax({
                 type: "post",
-                url: "/api/v1/workflow/",
+                url: submitUrl,
                 dataType: "json",
                 contentType: 'application/json;',
                 data: JSON.stringify({
-                        workflow: {
-                            workflow_name: formData.workflow_name,
-                            demand_url: formData.demand_url,
-                            group_id: $("#group_name option:selected").attr("group-id"),
-                            instance: $("#instance_name option:selected").attr("instance-id"),
-                            db_name: formData.db_name,
-                            is_backup: formData.is_backup === 'True',
-                            run_date_start: formData.run_date_start,
-                            run_date_end: formData.run_date_end,
-                            is_offline_export: 0,
-                        },
+                        workflow: workflow,
                         sql_content: formData.sql_content
                     }
                 ),
@@ -681,7 +772,16 @@
                     $('#btn-submitsql').button('reset')
                 },
                 success: function (data) {
-                    window.location.href = "/detail/"+ data.workflow_id
+                    if (isBatchSubmit) {
+                        if (data.workflow_count > 1) {
+                            alert("批量提交成功，共生成" + data.workflow_count + "个工单");
+                            window.location.href = "/sqlworkflow/";
+                        } else {
+                            window.location.href = "/detail/" + data.first_workflow_id + "/";
+                        }
+                    } else {
+                        window.location.href = "/detail/"+ data.workflow_id
+                    }
                 },
                 error: function (XMLHttpRequest, textStatus, errorThrown) {
                     if (XMLHttpRequest.responseJSON) {
@@ -710,7 +810,7 @@
                     var pathname = window.location.pathname;
                     if (pathname === "/editsql/") {
                         //填充实例信息
-                        $('#instance_name').selectpicker('val', sessionStorage.getItem('editClustername'));
+                        $('#instance_name').selectpicker('val', [sessionStorage.getItem('editClustername')]);
                         if ($("#instance_name").val()) {
                             $("#instance_name").selectpicker().trigger("change");
                         }
@@ -769,6 +869,7 @@
         $(document).ready(function () {
             // 初始化上传控件
             init_upload();
+            initBatchSubmitSelects();
             // 清空id, 只允许新增不允许修改
             sessionStorage.removeItem('editWorkflowDetailId');
             var pathname = window.location.pathname;

--- a/sql/templates/sqlworkflow.html
+++ b/sql/templates/sqlworkflow.html
@@ -43,6 +43,18 @@
                 提交SQL
             </button>
         </div>
+        <div class="form-group">
+            <div class="btn-group">
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                    批量操作 <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a href="javascript:;" class="batch-operation" data-operation="audit">批量审核SQL</a></li>
+                    <li><a href="javascript:;" class="batch-operation" data-operation="execute">批量执行SQL</a></li>
+                    <li><a href="javascript:;" class="batch-operation" data-operation="cancel">批量终止工单</a></li>
+                </ul>
+            </div>
+        </div>
     </div>
     <!-- 审核列表的表格-->
     <div class="table-responsive">
@@ -186,6 +198,8 @@
                         }
                     },
                 columns: [{
+                    checkbox: true
+                }, {
                     title: '工单名称',
                     field: 'workflow_name',
                     formatter: function (value, row, index) {
@@ -281,6 +295,93 @@
             });
 
         }
+
+        function getBatchSelectedRows(operation) {
+            var selectedRows = $("#sqlaudit-list").bootstrapTable('getSelections');
+            if (selectedRows.length === 0) {
+                alert("请先勾选工单");
+                return null;
+            }
+            var firstStatus = selectedRows[0].status;
+            for (var i = 0; i < selectedRows.length; i++) {
+                if (selectedRows[i].status !== firstStatus) {
+                    alert("批量操作的工单必须处于同一个状态");
+                    return null;
+                }
+            }
+            if (operation === "audit" && firstStatus !== "workflow_manreviewing") {
+                alert("仅待审核工单可批量审核");
+                return null;
+            }
+            if (operation === "execute" && ["workflow_review_pass", "workflow_timingtask"].indexOf(firstStatus) === -1) {
+                alert("仅审核通过或定时执行工单可批量执行");
+                return null;
+            }
+            if (operation === "cancel" && ["workflow_manreviewing", "workflow_review_pass", "workflow_timingtask"].indexOf(firstStatus) === -1) {
+                alert("当前状态不支持批量终止");
+                return null;
+            }
+            return selectedRows;
+        }
+
+        function batchOperate(operation) {
+            var selectedRows = getBatchSelectedRows(operation);
+            if (!selectedRows) {
+                return;
+            }
+            var remark = "";
+            if (operation === "audit") {
+                remark = prompt("请输入审核备注：", "") || "";
+            } else if (operation === "cancel") {
+                remark = prompt("请输入终止原因：", "") || "";
+                if (!remark) {
+                    alert("终止原因不能为空");
+                    return;
+                }
+            } else if (operation === "execute") {
+                var hasNoBackup = selectedRows.some(function (row) {
+                    return String(row.is_backup) !== "true";
+                });
+                var message = hasNoBackup
+                    ? "选中的工单存在未备份工单，将不会自动备份数据，请确认是否立即批量执行？"
+                    : "请确认是否立即批量执行？";
+                if (!confirm(message)) {
+                    return;
+                }
+            }
+            $.ajax({
+                type: "post",
+                url: "/api/v1/workflow/batch/operate/",
+                dataType: "json",
+                contentType: "application/json;",
+                data: JSON.stringify({
+                    operation: operation,
+                    workflow_ids: selectedRows.map(function (row) {
+                        return row.id;
+                    }),
+                    remark: remark,
+                    mode: "auto"
+                }),
+                success: function (data) {
+                    alert(data.msg);
+                    $("#sqlaudit-list").bootstrapTable('uncheckAll');
+                    get_workflow_list();
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                    if (XMLHttpRequest.responseJSON && XMLHttpRequest.responseJSON.errors) {
+                        alert(XMLHttpRequest.responseJSON.errors);
+                    } else if (XMLHttpRequest.responseText) {
+                        alert(XMLHttpRequest.responseText);
+                    } else {
+                        alert(errorThrown);
+                    }
+                }
+            });
+        }
+
+        $(".batch-operation").click(function () {
+            batchOperate($(this).data("operation"));
+        });
 
         // 获取操作日志
         function getLog(obj) {

--- a/sql/templates/sqlworkflow.html
+++ b/sql/templates/sqlworkflow.html
@@ -331,7 +331,10 @@
             }
             var remark = "";
             if (operation === "audit") {
-                remark = prompt("请输入审核备注：", "") || "";
+                remark = prompt("请输入审核备注：", "");
+                if (remark === null) {
+                    return;
+                }
             } else if (operation === "cancel") {
                 remark = prompt("请输入终止原因：", "") || "";
                 if (!remark) {

--- a/sql/utils/test_workflow_audit.py
+++ b/sql/utils/test_workflow_audit.py
@@ -714,7 +714,7 @@ def test_can_operate_abort_by_others(
     super_user,
     create_auth_group,
 ):
-    """测试非工单创建者不能撤回工单"""
+    """测试非工单创建者或执行人不能撤回工单"""
     fake_generate_audit_setting.return_value = AuditSetting(
         auto_pass=False, audit_auth_groups=[create_auth_group.id]
     )
@@ -724,7 +724,7 @@ def test_can_operate_abort_by_others(
     audit.audit.save()
     with pytest.raises(AuditException) as exc_info:
         audit.can_operate(WorkflowAction.ABORT, super_user)
-    assert "只有工单提交者可以撤回工单" in str(exc_info.value)
+    assert "只有工单提交者或执行人可以撤回工单" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -409,9 +409,16 @@ class AuditV2:
             raise AuditException(f"不支持的工单类型: {self.workflow_type}")
 
         if action == WorkflowAction.ABORT:
-            if actor.username != self.audit.create_user:
-                raise AuditException(f"只有工单提交者可以撤回工单")
-            return True
+            if actor.username == self.audit.create_user:
+                return True
+            if self.workflow_type == WorkflowType.SQL_REVIEW and getattr(
+                self.workflow, "id", None
+            ):
+                from sql.utils.sql_review import can_execute
+
+                if can_execute(actor, self.workflow.id):
+                    return True
+            raise AuditException(f"只有工单提交者或执行人可以撤回工单")
         if action in [WorkflowAction.PASS, WorkflowAction.REJECT]:
             # 需要检查权限
             # 超级用户可以审批所有工单

--- a/sql/utils/workflow_audit.py
+++ b/sql/utils/workflow_audit.py
@@ -435,9 +435,16 @@ class AuditV2:
             raise AuditException(f"不支持的工单类型: {self.workflow_type}")
 
         if action == WorkflowAction.ABORT:
-            if actor.username != self.audit.create_user:
-                raise AuditException(f"只有工单提交者可以撤回工单")
-            return True
+            if actor.username == self.audit.create_user:
+                return True
+            if self.workflow_type == WorkflowType.SQL_REVIEW and getattr(
+                self.workflow, "id", None
+            ):
+                from sql.utils.sql_review import can_execute
+
+                if can_execute(actor, self.workflow.id):
+                    return True
+            raise AuditException(f"只有工单提交者或执行人可以撤回工单")
         if action in [WorkflowAction.PASS, WorkflowAction.REJECT]:
             # 需要检查权限
             # 超级用户可以审批所有工单

--- a/sql_api/api_workflow.py
+++ b/sql_api/api_workflow.py
@@ -41,9 +41,64 @@ from .serializers import (
     WorkflowLogListSerializer,
     AuditWorkflowSerializer,
     ExecuteWorkflowSerializer,
+    BatchWorkflowSubmitSerializer,
+    BatchWorkflowOperationSerializer,
 )
 
 logger = logging.getLogger("default")
+
+
+def _is_notify_enabled(phase):
+    sys_config = SysConfig()
+    return (
+        phase in sys_config.get("notify_phase_control").split(",")
+        if sys_config.get("notify_phase_control")
+        else True
+    )
+
+
+def _notify_submit_workflow(workflow_content):
+    if workflow_content.workflow.status in [
+        "workflow_manreviewing",
+        "workflow_review_pass",
+    ] and _is_notify_enabled("Apply"):
+        workflow_audit = Audit.detail_by_workflow_id(
+            workflow_id=workflow_content.workflow.id,
+            workflow_type=WorkflowType.SQL_REVIEW,
+        )
+        async_task(
+            notify_for_audit,
+            workflow_audit=workflow_audit,
+            timeout=60,
+            task_name=f"sqlreview-submit-{workflow_content.workflow.id}",
+        )
+
+
+def _execute_sql_workflow(workflow, user):
+    audit_id = Audit.detail_by_workflow_id(
+        workflow_id=workflow.id,
+        workflow_type=WorkflowType.SQL_REVIEW,
+    ).audit_id
+    SqlWorkflow(id=workflow.id, status="workflow_queuing").save(
+        update_fields=["status"]
+    )
+    del_schedule(f"sqlreview-timing-{workflow.id}")
+    Audit.add_log(
+        audit_id=audit_id,
+        operation_type=5,
+        operation_type_desc="执行工单",
+        operation_info="工单执行排队中",
+        operator=user.username,
+        operator_display=user.display,
+    )
+    async_task(
+        "sql.utils.execute_sql.execute",
+        workflow.id,
+        user,
+        hook="sql.utils.execute_sql.execute_callback",
+        timeout=-1,
+        task_name=f"sqlreview-execute-{workflow.id}",
+    )
 
 
 class ExecuteCheck(views.APIView):
@@ -137,29 +192,46 @@ class WorkflowList(generics.ListAPIView):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         workflow_content = serializer.save()
-        sys_config = SysConfig()
-        is_notified = (
-            "Apply" in sys_config.get("notify_phase_control").split(",")
-            if sys_config.get("notify_phase_control")
-            else True
-        )
-        if (
-            workflow_content.workflow.status
-            in ["workflow_manreviewing", "workflow_review_pass"]
-            and is_notified
-        ):
-            # 获取审核信息
-            workflow_audit = Audit.detail_by_workflow_id(
-                workflow_id=workflow_content.workflow.id,
-                workflow_type=WorkflowType.SQL_REVIEW,
-            )
-            async_task(
-                notify_for_audit,
-                workflow_audit=workflow_audit,
-                timeout=60,
-                task_name=f"sqlreview-submit-{workflow_content.workflow.id}",
-            )
+        _notify_submit_workflow(workflow_content)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class BatchWorkflowSubmit(views.APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        summary="批量提交SQL上线工单",
+        request=BatchWorkflowSubmitSerializer,
+        description="按实例和数据库组合批量提交SQL上线工单",
+    )
+    @method_decorator(permission_required("sql.sql_submit", raise_exception=True))
+    def post(self, request):
+        serializer = BatchWorkflowSubmitSerializer(
+            data=request.data, context={"request": request}
+        )
+        serializer.is_valid(raise_exception=True)
+        workflow_contents = serializer.save()
+        for workflow_content in workflow_contents:
+            _notify_submit_workflow(workflow_content)
+        workflows = [
+            {
+                "id": workflow_content.workflow.id,
+                "workflow_name": workflow_content.workflow.workflow_name,
+                "instance": workflow_content.workflow.instance_id,
+                "instance_name": workflow_content.workflow.instance.instance_name,
+                "db_name": workflow_content.workflow.db_name,
+                "status": workflow_content.workflow.status,
+            }
+            for workflow_content in workflow_contents
+        ]
+        return Response(
+            {
+                "workflow_count": len(workflow_contents),
+                "first_workflow_id": workflows[0]["id"] if workflows else None,
+                "workflows": workflows,
+            },
+            status=status.HTTP_201_CREATED,
+        )
 
 
 class WorkflowAuditList(generics.ListAPIView):
@@ -353,31 +425,7 @@ class ExecuteWorkflow(views.APIView):
 
             # 交由系统执行
             if mode == "auto":
-                # 修改工单状态为排队中
-                SqlWorkflow(id=workflow_id, status="workflow_queuing").save(
-                    update_fields=["status"]
-                )
-                # 删除定时执行任务
-                schedule_name = f"sqlreview-timing-{workflow_id}"
-                del_schedule(schedule_name)
-                # 加入执行队列
-                async_task(
-                    "sql.utils.execute_sql.execute",
-                    workflow_id,
-                    user,
-                    hook="sql.utils.execute_sql.execute_callback",
-                    timeout=-1,
-                    task_name=f"sqlreview-execute-{workflow_id}",
-                )
-                # 增加工单日志
-                Audit.add_log(
-                    audit_id=audit_id,
-                    operation_type=5,
-                    operation_type_desc="执行工单",
-                    operation_info="工单执行排队中",
-                    operator=user.username,
-                    operator_display=user.display,
-                )
+                _execute_sql_workflow(SqlWorkflow.objects.get(id=workflow_id), user)
 
             # 线下手工执行
             elif mode == "manual":
@@ -417,6 +465,134 @@ class ExecuteWorkflow(views.APIView):
             )
 
         return Response({"msg": "开始执行，执行结果请到工单详情页查看"})
+
+
+class BatchWorkflowOperate(views.APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        summary="批量操作SQL上线工单",
+        request=BatchWorkflowOperationSerializer,
+        description="批量审核、执行或终止SQL上线工单",
+    )
+    def post(self, request):
+        serializer = BatchWorkflowOperationSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        operation = serializer.validated_data["operation"]
+        workflows = serializer.validated_data["workflows"]
+        remark = serializer.validated_data.get("remark", "")
+        user = request.user
+        status_value = workflows[0].status
+
+        if operation == "audit":
+            if status_value != "workflow_manreviewing":
+                raise serializers.ValidationError({"errors": "仅待审核工单可批量审核"})
+            for workflow in workflows:
+                auditor = get_auditor(workflow=workflow)
+                try:
+                    auditor.can_operate(WorkflowAction.PASS, user)
+                except AuditException as e:
+                    raise serializers.ValidationError(
+                        {"errors": f"工单 {workflow.id} 无审核权限，{str(e)}"}
+                    )
+            notify_args = []
+            with transaction.atomic():
+                for workflow in workflows:
+                    auditor = get_auditor(workflow=workflow)
+                    workflow_audit_detail = auditor.operate(
+                        WorkflowAction.PASS, user, remark
+                    )
+                    if auditor.audit.current_status == WorkflowStatus.PASSED:
+                        auditor.workflow.status = "workflow_review_pass"
+                        auditor.workflow.save(update_fields=["status"])
+                    notify_args.append((auditor.audit, workflow_audit_detail))
+            if _is_notify_enabled("Pass"):
+                for workflow_audit, workflow_audit_detail in notify_args:
+                    async_task(
+                        notify_for_audit,
+                        workflow_audit=workflow_audit,
+                        workflow_audit_detail=workflow_audit_detail,
+                        timeout=60,
+                        task_name=f"notify-audit-{workflow_audit}-{WorkflowType(workflow_audit.workflow_type).label}",
+                    )
+
+        elif operation == "execute":
+            if status_value not in ["workflow_review_pass", "workflow_timingtask"]:
+                raise serializers.ValidationError(
+                    {"errors": "仅审核通过工单可批量执行"}
+                )
+            if not (
+                user.has_perm("sql.sql_execute")
+                or user.has_perm("sql.sql_execute_for_resource_group")
+            ):
+                raise serializers.ValidationError({"errors": "你无权执行当前工单！"})
+            for workflow in workflows:
+                if can_execute(user, workflow.id) is False:
+                    raise serializers.ValidationError(
+                        {"errors": f"工单 {workflow.id} 无执行权限"}
+                    )
+                if on_correct_time_period(workflow.id) is False:
+                    raise serializers.ValidationError(
+                        {"errors": f"工单 {workflow.id} 不在可执行时间范围内"}
+                    )
+            for workflow in workflows:
+                _execute_sql_workflow(workflow, user)
+
+        elif operation == "cancel":
+            if status_value not in [
+                "workflow_manreviewing",
+                "workflow_review_pass",
+                "workflow_timingtask",
+            ]:
+                raise serializers.ValidationError({"errors": "当前状态不支持批量终止"})
+            actions = []
+            for workflow in workflows:
+                if can_cancel(user, workflow.id) is False:
+                    raise serializers.ValidationError(
+                        {"errors": f"工单 {workflow.id} 无终止权限"}
+                    )
+                if user.username == workflow.engineer:
+                    action = WorkflowAction.ABORT
+                elif user.has_perm("sql.sql_review"):
+                    action = WorkflowAction.REJECT
+                else:
+                    raise serializers.ValidationError(
+                        {"errors": f"工单 {workflow.id} 无终止权限"}
+                    )
+                auditor = get_auditor(workflow=workflow)
+                try:
+                    auditor.can_operate(action, user)
+                except AuditException as e:
+                    raise serializers.ValidationError(
+                        {"errors": f"工单 {workflow.id} 无终止权限，{str(e)}"}
+                    )
+                actions.append((workflow, action))
+            notify_args = []
+            schedules_to_delete = []
+            with transaction.atomic():
+                for workflow, action in actions:
+                    was_timingtask = workflow.status == "workflow_timingtask"
+                    auditor = get_auditor(workflow=workflow)
+                    workflow_audit_detail = auditor.operate(action, user, remark)
+                    auditor.workflow.status = "workflow_abort"
+                    auditor.workflow.save(update_fields=["status"])
+                    if was_timingtask:
+                        schedules_to_delete.append(f"sqlreview-timing-{workflow.id}")
+                    notify_args.append((auditor.audit, workflow_audit_detail))
+            for schedule_name in schedules_to_delete:
+                del_schedule(schedule_name)
+            if _is_notify_enabled("Cancel"):
+                for workflow_audit, workflow_audit_detail in notify_args:
+                    async_task(
+                        notify_for_audit,
+                        workflow_audit=workflow_audit,
+                        workflow_audit_detail=workflow_audit_detail,
+                        timeout=60,
+                        task_name=f"notify-audit-{workflow_audit}-{WorkflowType(workflow_audit.workflow_type).label}",
+                    )
+
+        return Response({"msg": "批量操作完成", "processed_count": len(workflows)})
 
 
 class WorkflowLogList(generics.ListAPIView):

--- a/sql_api/api_workflow.py
+++ b/sql_api/api_workflow.py
@@ -48,6 +48,7 @@ logger = logging.getLogger("default")
 
 
 def _is_notify_enabled(phase):
+    """判断指定工单阶段是否开启消息通知。"""
     sys_config = SysConfig()
     return (
         phase in sys_config.get("notify_phase_control").split(",")
@@ -56,7 +57,8 @@ def _is_notify_enabled(phase):
     )
 
 
-def _notify_submit_workflow(workflow_content):
+def _notify_pending_auditors(workflow_content):
+    """SQL工单提交后，通知待审核人进行审核。"""
     if workflow_content.workflow.status in [
         "workflow_manreviewing",
         "workflow_review_pass",
@@ -74,6 +76,7 @@ def _notify_submit_workflow(workflow_content):
 
 
 def _execute_sql_workflow(workflow, user):
+    """将SQL上线工单置为执行排队状态，并提交异步执行任务。"""
     audit_id = Audit.detail_by_workflow_id(
         workflow_id=workflow.id,
         workflow_type=WorkflowType.SQL_REVIEW,
@@ -192,11 +195,17 @@ class WorkflowList(generics.ListAPIView):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         workflow_content = serializer.save()
-        _notify_submit_workflow(workflow_content)
+        _notify_pending_auditors(workflow_content)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 class BatchWorkflowSubmit(views.APIView):
+    """
+    批量提交SQL上线工单。
+
+    根据请求中的实例和数据库组合创建多条SQL上线工单，提交后按通知配置提醒待审核人。
+    """
+
     permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(
@@ -212,7 +221,7 @@ class BatchWorkflowSubmit(views.APIView):
         serializer.is_valid(raise_exception=True)
         workflow_contents = serializer.save()
         for workflow_content in workflow_contents:
-            _notify_submit_workflow(workflow_content)
+            _notify_pending_auditors(workflow_content)
         workflows = [
             {
                 "id": workflow_content.workflow.id,
@@ -476,6 +485,13 @@ class ExecuteWorkflow(views.APIView):
 
 
 class BatchWorkflowOperate(views.APIView):
+    """
+    批量操作SQL上线工单。
+
+    支持批量审核通过、批量执行和批量终止工单，并按操作类型处理权限校验、状态流转、
+    定时任务清理和消息通知。
+    """
+
     permission_classes = [permissions.IsAuthenticated]
 
     @extend_schema(

--- a/sql_api/api_workflow.py
+++ b/sql_api/api_workflow.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import traceback
 
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.models import Group
@@ -126,7 +125,8 @@ class ExecuteCheck(views.APIView):
                 db_name=db_name, sql=request.data["full_sql"].strip()
             )
         except Exception as e:
-            raise serializers.ValidationError({"errors": f"{e}"})
+            logger.error(f"SQL检查失败: {e}", exc_info=True)
+            raise serializers.ValidationError({"errors": "SQL检查失败，请联系管理员"})
         check_result.rows = check_result.to_dict()
         serializer_obj = ExecuteCheckResultSerializer(check_result)
         return Response(serializer_obj.data)
@@ -329,7 +329,15 @@ class AuditWorkflow(views.APIView):
                 action, user, serializer.data["audit_remark"]
             )
         except AuditException as e:
-            raise serializers.ValidationError({"errors": f"操作失败, {str(e)}"})
+            logger.error(
+                f"工单 {workflow_audit.workflow_id} 审核操作失败: {e}",
+                exc_info=True,
+            )
+            raise serializers.ValidationError(
+                {
+                    "errors": f"工单 {workflow_audit.workflow_id} 操作权限不足，请联系管理员"
+                }
+            )
 
         # 最后处置一下原本工单的状态
         if auditor.workflow_type == WorkflowType.QUERY:
@@ -493,8 +501,9 @@ class BatchWorkflowOperate(views.APIView):
                 try:
                     auditor.can_operate(WorkflowAction.PASS, user)
                 except AuditException as e:
+                    logger.error(f"工单 {workflow.id} 审核失败: {e}", exc_info=True)
                     raise serializers.ValidationError(
-                        {"errors": f"工单 {workflow.id} 无审核权限，{str(e)}"}
+                        {"errors": f"工单 {workflow.id} 操作权限不足，请联系管理员"}
                     )
             notify_args = []
             with transaction.atomic():
@@ -554,6 +563,11 @@ class BatchWorkflowOperate(views.APIView):
                     )
                 if user.username == workflow.engineer:
                     action = WorkflowAction.ABORT
+                elif workflow.status in [
+                    "workflow_review_pass",
+                    "workflow_timingtask",
+                ] and can_execute(user, workflow.id):
+                    action = WorkflowAction.ABORT
                 elif user.has_perm("sql.sql_review"):
                     action = WorkflowAction.REJECT
                 else:
@@ -564,8 +578,9 @@ class BatchWorkflowOperate(views.APIView):
                 try:
                     auditor.can_operate(action, user)
                 except AuditException as e:
+                    logger.error(f"工单 {workflow.id} 终止失败: {e}", exc_info=True)
                     raise serializers.ValidationError(
-                        {"errors": f"工单 {workflow.id} 无终止权限，{str(e)}"}
+                        {"errors": f"工单 {workflow.id} 操作权限不足，请联系管理员"}
                     )
                 actions.append((workflow, action))
             notify_args = []

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -20,6 +20,7 @@ from django.db import transaction
 from sql.engines import get_engine
 from sql.utils.workflow_audit import Audit, get_auditor
 from sql.utils.resource_group import user_instances
+from sql.utils.sql_utils import filter_db_list
 from common.utils.const import WorkflowType, WorkflowStatus
 from common.config import SysConfig
 import traceback
@@ -461,6 +462,74 @@ class WorkflowSerializer(serializers.ModelSerializer):
         }
 
 
+def _get_submit_user(request_user, engineer):
+    # 管理员可以指定提交人信息，其他用户只能替自己提交。
+    if request_user.is_superuser and engineer:
+        try:
+            return Users.objects.get(username=engineer)
+        except Users.DoesNotExist:
+            raise serializers.ValidationError({"errors": f"不存在用户：{engineer}"})
+    return request_user
+
+
+def _normalize_db_resource_value(item):
+    if isinstance(item, dict):
+        return str(item.get("value"))
+    if isinstance(item, (list, tuple)) and len(item) == 1:
+        return str(item[0])
+    return str(item)
+
+
+def _visible_db_names(instance):
+    query_engine = get_engine(instance=instance)
+    resource = query_engine.get_all_databases()
+    if getattr(resource, "error", None):
+        raise serializers.ValidationError(
+            {"errors": f"{instance.instance_name}: {resource.error}"}
+        )
+    db_list = filter_db_list(
+        db_list=resource.rows,
+        db_name_regex=instance.show_db_name_regex,
+        is_match_regex=True,
+    )
+    db_list = filter_db_list(
+        db_list=db_list,
+        db_name_regex=instance.denied_db_name_regex,
+        is_match_regex=False,
+    )
+    return {_normalize_db_resource_value(db) for db in db_list}
+
+
+def _build_batch_workflow_name(base_name, instance_name, db_name):
+    suffix = f"-{instance_name}-{db_name}"
+    if len(suffix) >= 50:
+        return suffix[:50]
+    return f"{base_name[: 50 - len(suffix)]}{suffix}"
+
+
+def _create_workflow_content(workflow_data, sql_content, check_result):
+    try:
+        with transaction.atomic():
+            workflow = SqlWorkflow(**workflow_data)
+            workflow.save()
+            workflow_content = SqlWorkflowContent.objects.create(
+                workflow=workflow,
+                sql_content=sql_content,
+                review_content=check_result.json(),
+            )
+            auditor = get_auditor(workflow=workflow)
+            auditor.create_audit()
+            if auditor.audit.current_status == WorkflowStatus.REJECTED:
+                auditor.workflow.status = "workflow_autoreviewwrong"
+            elif auditor.audit.current_status == WorkflowStatus.PASSED:
+                auditor.workflow.status = "workflow_review_pass"
+            auditor.workflow.save()
+            return workflow_content
+    except Exception as e:
+        logger.error(f"提交工单报错，错误信息：{traceback.format_exc()}")
+        raise serializers.ValidationError({"errors": str(e)})
+
+
 class WorkflowContentSerializer(serializers.ModelSerializer):
     workflow = WorkflowSerializer()
 
@@ -470,17 +539,9 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
         instance = workflow_data["instance"]
         sql_content = validated_data["sql_content"].strip()
         group = ResourceGroup.objects.get(pk=workflow_data["group_id"])
-        engineer = workflow_data.get("engineer")
-
-        # 管理员可以指定提交人信息
-        if self.context["request"].user.is_superuser and engineer:
-            try:
-                user = Users.objects.get(username=engineer)
-            except Users.DoesNotExist:
-                raise serializers.ValidationError({"errors": f"不存在用户：{engineer}"})
-        # 提交人只能是自己
-        else:
-            user = self.context["request"].user
+        user = _get_submit_user(
+            self.context["request"].user, workflow_data.get("engineer")
+        )
 
         # 验证提交用户的组权限（用户是否在该组、该组是否有指定实例）
         tag_codes = (
@@ -527,27 +588,7 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
             group_name=group.group_name,
             audit_auth_groups="",
         )
-        try:
-            with transaction.atomic():
-                workflow = SqlWorkflow(**workflow_data)
-                validated_data["review_content"] = check_result.json()
-                workflow.save()
-                workflow_content = SqlWorkflowContent.objects.create(
-                    workflow=workflow, **validated_data
-                )
-                # 自动创建工作流
-                auditor = get_auditor(workflow=workflow)
-                auditor.create_audit()
-        except Exception as e:
-            logger.error(f"提交工单报错，错误信息：{traceback.format_exc()}")
-            raise serializers.ValidationError({"errors": str(e)})
-        # 有时候提交后自动审批通过, 在这里改写一下 workflow 状态
-        if auditor.audit.current_status == WorkflowStatus.REJECTED:
-            auditor.workflow.status = "workflow_autoreviewwrong"
-        elif auditor.audit.current_status == WorkflowStatus.PASSED:
-            auditor.workflow.status = "workflow_review_pass"
-        auditor.workflow.save()
-        return workflow_content
+        return _create_workflow_content(workflow_data, sql_content, check_result)
 
     class Meta:
         model = SqlWorkflowContent
@@ -560,6 +601,169 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
             "execute_result",
         )
         read_only_fields = ["review_content", "execute_result"]
+
+
+class BatchWorkflowSubmitSerializer(serializers.Serializer):
+    workflow = serializers.DictField()
+    sql_content = serializers.CharField(label="SQL内容")
+
+    @staticmethod
+    def _dedupe_check(values, field_name):
+        normalized = [str(value) for value in values]
+        if len(normalized) != len(set(normalized)):
+            raise serializers.ValidationError({"errors": f"{field_name} 存在重复项"})
+        return normalized
+
+    def validate(self, attrs):
+        workflow_payload = attrs["workflow"].copy()
+        sql_content = attrs["sql_content"].strip()
+        if not sql_content:
+            raise serializers.ValidationError({"errors": "SQL内容不能为空"})
+
+        instance_ids = workflow_payload.pop("instances", None)
+        db_names = workflow_payload.pop("db_names", None)
+        if not instance_ids:
+            raise serializers.ValidationError({"errors": "请选择实例"})
+        if not db_names:
+            raise serializers.ValidationError({"errors": "请选择数据库"})
+
+        try:
+            instance_ids = [int(value) for value in instance_ids]
+        except (TypeError, ValueError):
+            raise serializers.ValidationError({"errors": "实例ID格式错误"})
+        self._dedupe_check(instance_ids, "实例")
+        db_names = self._dedupe_check(db_names, "数据库")
+
+        workflow_payload.setdefault("is_offline_export", 0)
+        if int(workflow_payload.get("is_offline_export") or 0) != 0:
+            raise serializers.ValidationError({"errors": "批量提交不支持离线导出工单"})
+
+        instances_by_id = Instance.objects.in_bulk(instance_ids)
+        missing_ids = [pk for pk in instance_ids if pk not in instances_by_id]
+        if missing_ids:
+            raise serializers.ValidationError(
+                {"errors": f"不存在实例：{','.join(str(pk) for pk in missing_ids)}"}
+            )
+        instances = [instances_by_id[pk] for pk in instance_ids]
+        if len({instance.db_type for instance in instances}) > 1:
+            raise serializers.ValidationError(
+                {"errors": "批量提交实例必须属于同一数据库类型"}
+            )
+
+        single_payload = workflow_payload.copy()
+        single_payload["instance"] = instances[0].id
+        single_payload["db_name"] = db_names[0]
+        workflow_serializer = WorkflowSerializer(data=single_payload)
+        workflow_serializer.is_valid(raise_exception=True)
+        base_workflow_data = workflow_serializer.validated_data
+        group = ResourceGroup.objects.get(pk=base_workflow_data["group_id"])
+        user = _get_submit_user(
+            self.context["request"].user, base_workflow_data.get("engineer")
+        )
+
+        accessible_instances = user_instances(user, tag_codes=["can_write"]).filter(
+            id__in=instance_ids
+        )
+        accessible_ids = set(accessible_instances.values_list("id", flat=True))
+        for instance in instances:
+            if instance.id not in accessible_ids:
+                raise serializers.ValidationError({"errors": "你所在组未关联该实例！"})
+            if not group.instance_set.filter(id=instance.id).exists():
+                raise serializers.ValidationError(
+                    {"errors": f"资源组未关联实例：{instance.instance_name}"}
+                )
+
+        for instance in instances:
+            visible_db_names = _visible_db_names(instance)
+            invisible_db_names = [
+                db_name for db_name in db_names if db_name not in visible_db_names
+            ]
+            if invisible_db_names:
+                raise serializers.ValidationError(
+                    {
+                        "errors": "{} 不存在或无权限访问数据库：{}".format(
+                            instance.instance_name, ",".join(invisible_db_names)
+                        )
+                    }
+                )
+
+        attrs["sql_content"] = sql_content
+        attrs["base_workflow_data"] = base_workflow_data
+        attrs["instances"] = instances
+        attrs["db_names"] = db_names
+        attrs["group"] = group
+        attrs["submit_user"] = user
+        return attrs
+
+    def create(self, validated_data):
+        sql_content = validated_data["sql_content"]
+        instances = validated_data["instances"]
+        db_names = validated_data["db_names"]
+        group = validated_data["group"]
+        user = validated_data["submit_user"]
+        base_workflow_data = validated_data["base_workflow_data"]
+
+        first_instance = instances[0]
+        first_db_name = db_names[0]
+        try:
+            check_engine = get_engine(instance=first_instance)
+            check_result = check_engine.execute_check(
+                db_name=first_db_name, sql=sql_content
+            )
+        except Exception as e:
+            raise serializers.ValidationError({"errors": str(e)})
+
+        is_backup = base_workflow_data.get("is_backup", False)
+        sys_config = SysConfig()
+        if not sys_config.get("enable_backup_switch") and check_engine.auto_backup:
+            is_backup = True
+
+        target_count = len(instances) * len(db_names)
+        workflow_contents = []
+        try:
+            with transaction.atomic():
+                for instance in instances:
+                    for db_name in db_names:
+                        workflow_data = base_workflow_data.copy()
+                        if target_count > 1:
+                            workflow_data["workflow_name"] = _build_batch_workflow_name(
+                                base_workflow_data["workflow_name"],
+                                instance.instance_name,
+                                db_name,
+                            )
+                        workflow_data.update(
+                            group_name=group.group_name,
+                            instance=instance,
+                            db_name=db_name,
+                            status="workflow_manreviewing",
+                            is_backup=is_backup,
+                            is_manual=0,
+                            is_offline_export=0,
+                            syntax_type=check_result.syntax_type,
+                            engineer=user.username,
+                            engineer_display=user.display,
+                            audit_auth_groups="",
+                        )
+                        workflow = SqlWorkflow(**workflow_data)
+                        workflow.save()
+                        workflow_content = SqlWorkflowContent.objects.create(
+                            workflow=workflow,
+                            sql_content=sql_content,
+                            review_content=check_result.json(),
+                        )
+                        auditor = get_auditor(workflow=workflow)
+                        auditor.create_audit()
+                        if auditor.audit.current_status == WorkflowStatus.REJECTED:
+                            auditor.workflow.status = "workflow_autoreviewwrong"
+                        elif auditor.audit.current_status == WorkflowStatus.PASSED:
+                            auditor.workflow.status = "workflow_review_pass"
+                        auditor.workflow.save()
+                        workflow_contents.append(workflow_content)
+        except Exception as e:
+            logger.error(f"批量提交工单报错，错误信息：{traceback.format_exc()}")
+            raise serializers.ValidationError({"errors": str(e)})
+
+        return workflow_contents
 
 
 class AuditWorkflowSerializer(serializers.Serializer):
@@ -687,4 +891,44 @@ class ExecuteWorkflowSerializer(serializers.Serializer):
         except WorkflowAudit.DoesNotExist:
             raise serializers.ValidationError({"errors": "不存在该工单"})
 
+        return attrs
+
+
+class BatchWorkflowOperationSerializer(serializers.Serializer):
+    operation = serializers.ChoiceField(
+        choices=["audit", "execute", "cancel"], label="批量操作类型"
+    )
+    workflow_ids = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        allow_empty=False,
+        label="工单ID列表",
+    )
+    remark = serializers.CharField(required=False, allow_blank=True, default="")
+    mode = serializers.ChoiceField(
+        choices=["auto"], required=False, default="auto", label="执行模式"
+    )
+
+    def validate(self, attrs):
+        workflow_ids = attrs["workflow_ids"]
+        if len(workflow_ids) != len(set(workflow_ids)):
+            raise serializers.ValidationError({"errors": "工单ID存在重复项"})
+        if attrs["operation"] == "cancel" and not attrs.get("remark"):
+            raise serializers.ValidationError({"errors": "终止原因不能为空"})
+        workflows = list(
+            SqlWorkflow.objects.filter(id__in=workflow_ids).order_by(
+                "create_time", "id"
+            )
+        )
+        if len(workflows) != len(workflow_ids):
+            found_ids = {workflow.id for workflow in workflows}
+            missing_ids = [str(pk) for pk in workflow_ids if pk not in found_ids]
+            raise serializers.ValidationError(
+                {"errors": f"不存在工单：{','.join(missing_ids)}"}
+            )
+        statuses = {workflow.status for workflow in workflows}
+        if len(statuses) != 1:
+            raise serializers.ValidationError(
+                {"errors": "批量操作的工单必须处于同一状态"}
+            )
+        attrs["workflows"] = workflows
         return attrs

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -464,6 +464,7 @@ class WorkflowSerializer(serializers.ModelSerializer):
 
 
 def _get_submit_user(request_user, engineer):
+    """根据当前请求用户和指定用户名确定工单提交人。"""
     # 管理员可以指定提交人信息，其他用户只能替自己提交。
     if request_user.is_superuser and engineer:
         try:
@@ -474,6 +475,7 @@ def _get_submit_user(request_user, engineer):
 
 
 def _normalize_db_resource_value(item):
+    """将数据库资源列表中的不同返回格式统一转换为数据库名称字符串。"""
     if isinstance(item, dict):
         return str(item.get("value"))
     if isinstance(item, (list, tuple)) and len(item) == 1:
@@ -482,6 +484,7 @@ def _normalize_db_resource_value(item):
 
 
 def _visible_db_names(instance):
+    """获取实例中经过展示和屏蔽规则过滤后的可见数据库名称集合。"""
     query_engine = get_engine(instance=instance)
     resource = query_engine.get_all_databases()
     if getattr(resource, "error", None):
@@ -503,6 +506,7 @@ def _visible_db_names(instance):
 
 
 def _build_batch_workflow_name(base_name, instance_name, db_name):
+    """为批量提交的子工单生成包含实例名和数据库名的工单名称。"""
     suffix = f"-{instance_name}-{db_name}"
     if len(suffix) >= 50:
         return suffix[:50]
@@ -510,6 +514,7 @@ def _build_batch_workflow_name(base_name, instance_name, db_name):
 
 
 def _create_workflow_content(workflow_data, sql_content, check_result):
+    """创建单个 SQL 工单、保存 SQL 内容并初始化审批流程。"""
     try:
         with transaction.atomic():
             workflow = SqlWorkflow(**workflow_data)
@@ -607,17 +612,21 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
 
 
 class BatchWorkflowSubmitSerializer(serializers.Serializer):
+    """批量提交 SQL 上线工单的参数校验和工单创建序列化器。"""
+
     workflow = serializers.DictField()
     sql_content = serializers.CharField(label="SQL内容")
 
     @staticmethod
     def _dedupe_check(values, field_name):
+        """校验列表字段是否存在重复值，并统一转换为字符串列表。"""
         normalized = [str(value) for value in values]
         if len(normalized) != len(set(normalized)):
             raise serializers.ValidationError({"errors": f"{field_name} 存在重复项"})
         return normalized
 
     def validate(self, attrs):
+        """校验批量提交参数、实例权限、资源组关系和数据库可见性。"""
         workflow_payload = attrs["workflow"].copy()
         sql_content = attrs["sql_content"].strip()
         if not sql_content:
@@ -699,6 +708,7 @@ class BatchWorkflowSubmitSerializer(serializers.Serializer):
         return attrs
 
     def create(self, validated_data):
+        """按实例和数据库组合批量创建 SQL 上线工单及其审批记录。"""
         sql_content = validated_data["sql_content"]
         instances = validated_data["instances"]
         db_names = validated_data["db_names"]
@@ -901,6 +911,8 @@ class ExecuteWorkflowSerializer(serializers.Serializer):
 
 
 class BatchWorkflowOperationSerializer(serializers.Serializer):
+    """批量审核、执行或终止 SQL 工单的参数校验序列化器。"""
+
     operation = serializers.ChoiceField(
         choices=["audit", "execute", "cancel"], label="批量操作类型"
     )
@@ -915,6 +927,7 @@ class BatchWorkflowOperationSerializer(serializers.Serializer):
     )
 
     def validate(self, attrs):
+        """校验批量操作工单是否存在、状态是否一致以及终止原因是否完整。"""
         workflow_ids = attrs["workflow_ids"]
         if len(workflow_ids) != len(set(workflow_ids)):
             raise serializers.ValidationError({"errors": "工单ID存在重复项"})

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -23,7 +23,6 @@ from sql.utils.resource_group import user_instances
 from sql.utils.sql_utils import filter_db_list
 from common.utils.const import WorkflowType, WorkflowStatus
 from common.config import SysConfig
-import traceback
 import logging
 from sql.offlinedownload import OffLineDownLoad
 
@@ -240,8 +239,10 @@ class AliyunRdsSerializer(serializers.ModelSerializer):
                 ak = CloudAccessKey.objects.create(**rds_data)
                 rds = AliyunRdsConfig.objects.create(ak=ak, **validated_data)
         except Exception as e:
-            logger.error(f"创建AliyunRds报错，错误信息：{traceback.format_exc()}")
-            raise serializers.ValidationError({"errors": str(e)})
+            logger.error(f"创建AliyunRds失败: {e}", exc_info=True)
+            raise serializers.ValidationError(
+                {"errors": "创建AliyunRds失败，请联系管理员"}
+            )
         else:
             return rds
 
@@ -484,8 +485,9 @@ def _visible_db_names(instance):
     query_engine = get_engine(instance=instance)
     resource = query_engine.get_all_databases()
     if getattr(resource, "error", None):
+        logger.error(f"获取实例 {instance.id} 数据库列表失败: {resource.error}")
         raise serializers.ValidationError(
-            {"errors": f"{instance.instance_name}: {resource.error}"}
+            {"errors": f"{instance.instance_name}: 获取数据库列表失败，请联系管理员"}
         )
     db_list = filter_db_list(
         db_list=resource.rows,
@@ -526,8 +528,8 @@ def _create_workflow_content(workflow_data, sql_content, check_result):
             auditor.workflow.save()
             return workflow_content
     except Exception as e:
-        logger.error(f"提交工单报错，错误信息：{traceback.format_exc()}")
-        raise serializers.ValidationError({"errors": str(e)})
+        logger.error(f"提交工单失败: {e}", exc_info=True)
+        raise serializers.ValidationError({"errors": "提交工单失败，请联系管理员"})
 
 
 class WorkflowContentSerializer(serializers.ModelSerializer):
@@ -565,7 +567,8 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
                     db_name=workflow_data["db_name"], sql=sql_content
                 )
         except Exception as e:
-            raise serializers.ValidationError({"errors": str(e)})
+            logger.error(f"提交工单SQL检查失败: {e}", exc_info=True)
+            raise serializers.ValidationError({"errors": "SQL检查失败，请联系管理员"})
 
         # 未开启备份选项，并且engine支持备份，强制设置备份
         is_backup = (
@@ -711,7 +714,8 @@ class BatchWorkflowSubmitSerializer(serializers.Serializer):
                 db_name=first_db_name, sql=sql_content
             )
         except Exception as e:
-            raise serializers.ValidationError({"errors": str(e)})
+            logger.error(f"批量提交工单SQL检查失败: {e}", exc_info=True)
+            raise serializers.ValidationError({"errors": "SQL检查失败，请联系管理员"})
 
         is_backup = base_workflow_data.get("is_backup", False)
         sys_config = SysConfig()
@@ -760,8 +764,10 @@ class BatchWorkflowSubmitSerializer(serializers.Serializer):
                         auditor.workflow.save()
                         workflow_contents.append(workflow_content)
         except Exception as e:
-            logger.error(f"批量提交工单报错，错误信息：{traceback.format_exc()}")
-            raise serializers.ValidationError({"errors": str(e)})
+            logger.error(f"批量提交工单失败: {e}", exc_info=True)
+            raise serializers.ValidationError(
+                {"errors": "批量提交工单失败，请联系管理员"}
+            )
 
         return workflow_contents
 

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -23,7 +23,6 @@ from sql.utils.resource_group import user_instances
 from sql.utils.sql_utils import filter_db_list
 from common.utils.const import WorkflowType, WorkflowStatus
 from common.config import SysConfig
-import traceback
 import logging
 from sql.offlinedownload import OffLineDownLoad
 
@@ -240,8 +239,10 @@ class AliyunRdsSerializer(serializers.ModelSerializer):
                 ak = CloudAccessKey.objects.create(**rds_data)
                 rds = AliyunRdsConfig.objects.create(ak=ak, **validated_data)
         except Exception as e:
-            logger.error(f"创建AliyunRds报错，错误信息：{traceback.format_exc()}")
-            raise serializers.ValidationError({"errors": str(e)})
+            logger.error(f"创建AliyunRds失败: {e}", exc_info=True)
+            raise serializers.ValidationError(
+                {"errors": "创建AliyunRds失败，请联系管理员"}
+            )
         else:
             return rds
 
@@ -485,8 +486,9 @@ def _visible_db_names(instance):
     query_engine = get_engine(instance=instance)
     resource = query_engine.get_all_databases()
     if getattr(resource, "error", None):
+        logger.error(f"获取实例 {instance.id} 数据库列表失败: {resource.error}")
         raise serializers.ValidationError(
-            {"errors": f"{instance.instance_name}: {resource.error}"}
+            {"errors": f"{instance.instance_name}: 获取数据库列表失败，请联系管理员"}
         )
     db_list = filter_db_list(
         db_list=resource.rows,
@@ -527,8 +529,8 @@ def _create_workflow_content(workflow_data, sql_content, check_result):
             auditor.workflow.save()
             return workflow_content
     except Exception as e:
-        logger.error(f"提交工单报错，错误信息：{traceback.format_exc()}")
-        raise serializers.ValidationError({"errors": str(e)})
+        logger.error(f"提交工单失败: {e}", exc_info=True)
+        raise serializers.ValidationError({"errors": "提交工单失败，请联系管理员"})
 
 
 class WorkflowContentSerializer(serializers.ModelSerializer):
@@ -566,7 +568,8 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
                     db_name=workflow_data["db_name"], sql=sql_content
                 )
         except Exception as e:
-            raise serializers.ValidationError({"errors": str(e)})
+            logger.error(f"提交工单SQL检查失败: {e}", exc_info=True)
+            raise serializers.ValidationError({"errors": "SQL检查失败，请联系管理员"})
 
         # 未开启备份选项，并且engine支持备份，强制设置备份
         is_backup = (
@@ -712,7 +715,8 @@ class BatchWorkflowSubmitSerializer(serializers.Serializer):
                 db_name=first_db_name, sql=sql_content
             )
         except Exception as e:
-            raise serializers.ValidationError({"errors": str(e)})
+            logger.error(f"批量提交工单SQL检查失败: {e}", exc_info=True)
+            raise serializers.ValidationError({"errors": "SQL检查失败，请联系管理员"})
 
         is_backup = base_workflow_data.get("is_backup", False)
         sys_config = SysConfig()
@@ -761,8 +765,10 @@ class BatchWorkflowSubmitSerializer(serializers.Serializer):
                         auditor.workflow.save()
                         workflow_contents.append(workflow_content)
         except Exception as e:
-            logger.error(f"批量提交工单报错，错误信息：{traceback.format_exc()}")
-            raise serializers.ValidationError({"errors": str(e)})
+            logger.error(f"批量提交工单失败: {e}", exc_info=True)
+            raise serializers.ValidationError(
+                {"errors": "批量提交工单失败，请联系管理员"}
+            )
 
         return workflow_contents
 

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -20,6 +20,7 @@ from django.db import transaction
 from sql.engines import get_engine
 from sql.utils.workflow_audit import Audit, get_auditor
 from sql.utils.resource_group import user_instances
+from sql.utils.sql_utils import filter_db_list
 from common.utils.const import WorkflowType, WorkflowStatus
 from common.config import SysConfig
 import traceback
@@ -462,6 +463,74 @@ class WorkflowSerializer(serializers.ModelSerializer):
         }
 
 
+def _get_submit_user(request_user, engineer):
+    # 管理员可以指定提交人信息，其他用户只能替自己提交。
+    if request_user.is_superuser and engineer:
+        try:
+            return Users.objects.get(username=engineer)
+        except Users.DoesNotExist:
+            raise serializers.ValidationError({"errors": f"不存在用户：{engineer}"})
+    return request_user
+
+
+def _normalize_db_resource_value(item):
+    if isinstance(item, dict):
+        return str(item.get("value"))
+    if isinstance(item, (list, tuple)) and len(item) == 1:
+        return str(item[0])
+    return str(item)
+
+
+def _visible_db_names(instance):
+    query_engine = get_engine(instance=instance)
+    resource = query_engine.get_all_databases()
+    if getattr(resource, "error", None):
+        raise serializers.ValidationError(
+            {"errors": f"{instance.instance_name}: {resource.error}"}
+        )
+    db_list = filter_db_list(
+        db_list=resource.rows,
+        db_name_regex=instance.show_db_name_regex,
+        is_match_regex=True,
+    )
+    db_list = filter_db_list(
+        db_list=db_list,
+        db_name_regex=instance.denied_db_name_regex,
+        is_match_regex=False,
+    )
+    return {_normalize_db_resource_value(db) for db in db_list}
+
+
+def _build_batch_workflow_name(base_name, instance_name, db_name):
+    suffix = f"-{instance_name}-{db_name}"
+    if len(suffix) >= 50:
+        return suffix[:50]
+    return f"{base_name[: 50 - len(suffix)]}{suffix}"
+
+
+def _create_workflow_content(workflow_data, sql_content, check_result):
+    try:
+        with transaction.atomic():
+            workflow = SqlWorkflow(**workflow_data)
+            workflow.save()
+            workflow_content = SqlWorkflowContent.objects.create(
+                workflow=workflow,
+                sql_content=sql_content,
+                review_content=check_result.json(),
+            )
+            auditor = get_auditor(workflow=workflow)
+            auditor.create_audit()
+            if auditor.audit.current_status == WorkflowStatus.REJECTED:
+                auditor.workflow.status = "workflow_autoreviewwrong"
+            elif auditor.audit.current_status == WorkflowStatus.PASSED:
+                auditor.workflow.status = "workflow_review_pass"
+            auditor.workflow.save()
+            return workflow_content
+    except Exception as e:
+        logger.error(f"提交工单报错，错误信息：{traceback.format_exc()}")
+        raise serializers.ValidationError({"errors": str(e)})
+
+
 class WorkflowContentSerializer(serializers.ModelSerializer):
     workflow = WorkflowSerializer()
 
@@ -471,17 +540,9 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
         instance = workflow_data["instance"]
         sql_content = validated_data["sql_content"].strip()
         group = ResourceGroup.objects.get(pk=workflow_data["group_id"])
-        engineer = workflow_data.get("engineer")
-
-        # 管理员可以指定提交人信息
-        if self.context["request"].user.is_superuser and engineer:
-            try:
-                user = Users.objects.get(username=engineer)
-            except Users.DoesNotExist:
-                raise serializers.ValidationError({"errors": f"不存在用户：{engineer}"})
-        # 提交人只能是自己
-        else:
-            user = self.context["request"].user
+        user = _get_submit_user(
+            self.context["request"].user, workflow_data.get("engineer")
+        )
 
         # 验证提交用户的组权限（用户是否在该组、该组是否有指定实例）
         tag_codes = (
@@ -528,27 +589,7 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
             group_name=group.group_name,
             audit_auth_groups="",
         )
-        try:
-            with transaction.atomic():
-                workflow = SqlWorkflow(**workflow_data)
-                validated_data["review_content"] = check_result.json()
-                workflow.save()
-                workflow_content = SqlWorkflowContent.objects.create(
-                    workflow=workflow, **validated_data
-                )
-                # 自动创建工作流
-                auditor = get_auditor(workflow=workflow)
-                auditor.create_audit()
-        except Exception as e:
-            logger.error(f"提交工单报错，错误信息：{traceback.format_exc()}")
-            raise serializers.ValidationError({"errors": str(e)})
-        # 有时候提交后自动审批通过, 在这里改写一下 workflow 状态
-        if auditor.audit.current_status == WorkflowStatus.REJECTED:
-            auditor.workflow.status = "workflow_autoreviewwrong"
-        elif auditor.audit.current_status == WorkflowStatus.PASSED:
-            auditor.workflow.status = "workflow_review_pass"
-        auditor.workflow.save()
-        return workflow_content
+        return _create_workflow_content(workflow_data, sql_content, check_result)
 
     class Meta:
         model = SqlWorkflowContent
@@ -561,6 +602,169 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
             "execute_result",
         )
         read_only_fields = ["review_content", "execute_result"]
+
+
+class BatchWorkflowSubmitSerializer(serializers.Serializer):
+    workflow = serializers.DictField()
+    sql_content = serializers.CharField(label="SQL内容")
+
+    @staticmethod
+    def _dedupe_check(values, field_name):
+        normalized = [str(value) for value in values]
+        if len(normalized) != len(set(normalized)):
+            raise serializers.ValidationError({"errors": f"{field_name} 存在重复项"})
+        return normalized
+
+    def validate(self, attrs):
+        workflow_payload = attrs["workflow"].copy()
+        sql_content = attrs["sql_content"].strip()
+        if not sql_content:
+            raise serializers.ValidationError({"errors": "SQL内容不能为空"})
+
+        instance_ids = workflow_payload.pop("instances", None)
+        db_names = workflow_payload.pop("db_names", None)
+        if not instance_ids:
+            raise serializers.ValidationError({"errors": "请选择实例"})
+        if not db_names:
+            raise serializers.ValidationError({"errors": "请选择数据库"})
+
+        try:
+            instance_ids = [int(value) for value in instance_ids]
+        except (TypeError, ValueError):
+            raise serializers.ValidationError({"errors": "实例ID格式错误"})
+        self._dedupe_check(instance_ids, "实例")
+        db_names = self._dedupe_check(db_names, "数据库")
+
+        workflow_payload.setdefault("is_offline_export", 0)
+        if int(workflow_payload.get("is_offline_export") or 0) != 0:
+            raise serializers.ValidationError({"errors": "批量提交不支持离线导出工单"})
+
+        instances_by_id = Instance.objects.in_bulk(instance_ids)
+        missing_ids = [pk for pk in instance_ids if pk not in instances_by_id]
+        if missing_ids:
+            raise serializers.ValidationError(
+                {"errors": f"不存在实例：{','.join(str(pk) for pk in missing_ids)}"}
+            )
+        instances = [instances_by_id[pk] for pk in instance_ids]
+        if len({instance.db_type for instance in instances}) > 1:
+            raise serializers.ValidationError(
+                {"errors": "批量提交实例必须属于同一数据库类型"}
+            )
+
+        single_payload = workflow_payload.copy()
+        single_payload["instance"] = instances[0].id
+        single_payload["db_name"] = db_names[0]
+        workflow_serializer = WorkflowSerializer(data=single_payload)
+        workflow_serializer.is_valid(raise_exception=True)
+        base_workflow_data = workflow_serializer.validated_data
+        group = ResourceGroup.objects.get(pk=base_workflow_data["group_id"])
+        user = _get_submit_user(
+            self.context["request"].user, base_workflow_data.get("engineer")
+        )
+
+        accessible_instances = user_instances(user, tag_codes=["can_write"]).filter(
+            id__in=instance_ids
+        )
+        accessible_ids = set(accessible_instances.values_list("id", flat=True))
+        for instance in instances:
+            if instance.id not in accessible_ids:
+                raise serializers.ValidationError({"errors": "你所在组未关联该实例！"})
+            if not group.instance_set.filter(id=instance.id).exists():
+                raise serializers.ValidationError(
+                    {"errors": f"资源组未关联实例：{instance.instance_name}"}
+                )
+
+        for instance in instances:
+            visible_db_names = _visible_db_names(instance)
+            invisible_db_names = [
+                db_name for db_name in db_names if db_name not in visible_db_names
+            ]
+            if invisible_db_names:
+                raise serializers.ValidationError(
+                    {
+                        "errors": "{} 不存在或无权限访问数据库：{}".format(
+                            instance.instance_name, ",".join(invisible_db_names)
+                        )
+                    }
+                )
+
+        attrs["sql_content"] = sql_content
+        attrs["base_workflow_data"] = base_workflow_data
+        attrs["instances"] = instances
+        attrs["db_names"] = db_names
+        attrs["group"] = group
+        attrs["submit_user"] = user
+        return attrs
+
+    def create(self, validated_data):
+        sql_content = validated_data["sql_content"]
+        instances = validated_data["instances"]
+        db_names = validated_data["db_names"]
+        group = validated_data["group"]
+        user = validated_data["submit_user"]
+        base_workflow_data = validated_data["base_workflow_data"]
+
+        first_instance = instances[0]
+        first_db_name = db_names[0]
+        try:
+            check_engine = get_engine(instance=first_instance)
+            check_result = check_engine.execute_check(
+                db_name=first_db_name, sql=sql_content
+            )
+        except Exception as e:
+            raise serializers.ValidationError({"errors": str(e)})
+
+        is_backup = base_workflow_data.get("is_backup", False)
+        sys_config = SysConfig()
+        if not sys_config.get("enable_backup_switch") and check_engine.auto_backup:
+            is_backup = True
+
+        target_count = len(instances) * len(db_names)
+        workflow_contents = []
+        try:
+            with transaction.atomic():
+                for instance in instances:
+                    for db_name in db_names:
+                        workflow_data = base_workflow_data.copy()
+                        if target_count > 1:
+                            workflow_data["workflow_name"] = _build_batch_workflow_name(
+                                base_workflow_data["workflow_name"],
+                                instance.instance_name,
+                                db_name,
+                            )
+                        workflow_data.update(
+                            group_name=group.group_name,
+                            instance=instance,
+                            db_name=db_name,
+                            status="workflow_manreviewing",
+                            is_backup=is_backup,
+                            is_manual=0,
+                            is_offline_export=0,
+                            syntax_type=check_result.syntax_type,
+                            engineer=user.username,
+                            engineer_display=user.display,
+                            audit_auth_groups="",
+                        )
+                        workflow = SqlWorkflow(**workflow_data)
+                        workflow.save()
+                        workflow_content = SqlWorkflowContent.objects.create(
+                            workflow=workflow,
+                            sql_content=sql_content,
+                            review_content=check_result.json(),
+                        )
+                        auditor = get_auditor(workflow=workflow)
+                        auditor.create_audit()
+                        if auditor.audit.current_status == WorkflowStatus.REJECTED:
+                            auditor.workflow.status = "workflow_autoreviewwrong"
+                        elif auditor.audit.current_status == WorkflowStatus.PASSED:
+                            auditor.workflow.status = "workflow_review_pass"
+                        auditor.workflow.save()
+                        workflow_contents.append(workflow_content)
+        except Exception as e:
+            logger.error(f"批量提交工单报错，错误信息：{traceback.format_exc()}")
+            raise serializers.ValidationError({"errors": str(e)})
+
+        return workflow_contents
 
 
 class AuditWorkflowSerializer(serializers.Serializer):
@@ -688,4 +892,44 @@ class ExecuteWorkflowSerializer(serializers.Serializer):
         except WorkflowAudit.DoesNotExist:
             raise serializers.ValidationError({"errors": "不存在该工单"})
 
+        return attrs
+
+
+class BatchWorkflowOperationSerializer(serializers.Serializer):
+    operation = serializers.ChoiceField(
+        choices=["audit", "execute", "cancel"], label="批量操作类型"
+    )
+    workflow_ids = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        allow_empty=False,
+        label="工单ID列表",
+    )
+    remark = serializers.CharField(required=False, allow_blank=True, default="")
+    mode = serializers.ChoiceField(
+        choices=["auto"], required=False, default="auto", label="执行模式"
+    )
+
+    def validate(self, attrs):
+        workflow_ids = attrs["workflow_ids"]
+        if len(workflow_ids) != len(set(workflow_ids)):
+            raise serializers.ValidationError({"errors": "工单ID存在重复项"})
+        if attrs["operation"] == "cancel" and not attrs.get("remark"):
+            raise serializers.ValidationError({"errors": "终止原因不能为空"})
+        workflows = list(
+            SqlWorkflow.objects.filter(id__in=workflow_ids).order_by(
+                "create_time", "id"
+            )
+        )
+        if len(workflows) != len(workflow_ids):
+            found_ids = {workflow.id for workflow in workflows}
+            missing_ids = [str(pk) for pk in workflow_ids if pk not in found_ids]
+            raise serializers.ValidationError(
+                {"errors": f"不存在工单：{','.join(missing_ids)}"}
+            )
+        statuses = {workflow.status for workflow in workflows}
+        if len(statuses) != 1:
+            raise serializers.ValidationError(
+                {"errors": "批量操作的工单必须处于同一状态"}
+            )
+        attrs["workflows"] = workflows
         return attrs

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -465,6 +465,7 @@ class WorkflowSerializer(serializers.ModelSerializer):
 
 
 def _get_submit_user(request_user, engineer):
+    """根据当前请求用户和指定用户名确定工单提交人。"""
     # 管理员可以指定提交人信息，其他用户只能替自己提交。
     if request_user.is_superuser and engineer:
         try:
@@ -475,6 +476,7 @@ def _get_submit_user(request_user, engineer):
 
 
 def _normalize_db_resource_value(item):
+    """将数据库资源列表中的不同返回格式统一转换为数据库名称字符串。"""
     if isinstance(item, dict):
         return str(item.get("value"))
     if isinstance(item, (list, tuple)) and len(item) == 1:
@@ -483,6 +485,7 @@ def _normalize_db_resource_value(item):
 
 
 def _visible_db_names(instance):
+    """获取实例中经过展示和屏蔽规则过滤后的可见数据库名称集合。"""
     query_engine = get_engine(instance=instance)
     resource = query_engine.get_all_databases()
     if getattr(resource, "error", None):
@@ -504,6 +507,7 @@ def _visible_db_names(instance):
 
 
 def _build_batch_workflow_name(base_name, instance_name, db_name):
+    """为批量提交的子工单生成包含实例名和数据库名的工单名称。"""
     suffix = f"-{instance_name}-{db_name}"
     if len(suffix) >= 50:
         return suffix[:50]
@@ -511,6 +515,7 @@ def _build_batch_workflow_name(base_name, instance_name, db_name):
 
 
 def _create_workflow_content(workflow_data, sql_content, check_result):
+    """创建单个 SQL 工单、保存 SQL 内容并初始化审批流程。"""
     try:
         with transaction.atomic():
             workflow = SqlWorkflow(**workflow_data)
@@ -608,17 +613,21 @@ class WorkflowContentSerializer(serializers.ModelSerializer):
 
 
 class BatchWorkflowSubmitSerializer(serializers.Serializer):
+    """批量提交 SQL 上线工单的参数校验和工单创建序列化器。"""
+
     workflow = serializers.DictField()
     sql_content = serializers.CharField(label="SQL内容")
 
     @staticmethod
     def _dedupe_check(values, field_name):
+        """校验列表字段是否存在重复值，并统一转换为字符串列表。"""
         normalized = [str(value) for value in values]
         if len(normalized) != len(set(normalized)):
             raise serializers.ValidationError({"errors": f"{field_name} 存在重复项"})
         return normalized
 
     def validate(self, attrs):
+        """校验批量提交参数、实例权限、资源组关系和数据库可见性。"""
         workflow_payload = attrs["workflow"].copy()
         sql_content = attrs["sql_content"].strip()
         if not sql_content:
@@ -700,6 +709,7 @@ class BatchWorkflowSubmitSerializer(serializers.Serializer):
         return attrs
 
     def create(self, validated_data):
+        """按实例和数据库组合批量创建 SQL 上线工单及其审批记录。"""
         sql_content = validated_data["sql_content"]
         instances = validated_data["instances"]
         db_names = validated_data["db_names"]
@@ -902,6 +912,8 @@ class ExecuteWorkflowSerializer(serializers.Serializer):
 
 
 class BatchWorkflowOperationSerializer(serializers.Serializer):
+    """批量审核、执行或终止 SQL 工单的参数校验序列化器。"""
+
     operation = serializers.ChoiceField(
         choices=["audit", "execute", "cancel"], label="批量操作类型"
     )
@@ -916,6 +928,7 @@ class BatchWorkflowOperationSerializer(serializers.Serializer):
     )
 
     def validate(self, attrs):
+        """校验批量操作工单是否存在、状态是否一致以及终止原因是否完整。"""
         workflow_ids = attrs["workflow_ids"]
         if len(workflow_ids) != len(set(workflow_ids)):
             raise serializers.ValidationError({"errors": "工单ID存在重复项"})

--- a/sql_api/tests.py
+++ b/sql_api/tests.py
@@ -7,9 +7,11 @@ from django.contrib.auth.models import Group, Permission
 from rest_framework.test import APITestCase
 from rest_framework import status
 from common.config import SysConfig
+from common.utils.const import WorkflowStatus
 from sql.utils.workflow_audit import AuditSetting
 from sql.engines import ReviewSet
 from sql.engines.models import ReviewResult
+from sql_api import serializers as api_serializers
 from sql.models import (
     ResourceGroup,
     Instance,
@@ -19,6 +21,7 @@ from sql.models import (
     SqlWorkflow,
     SqlWorkflowContent,
     WorkflowAudit,
+    WorkflowAuditDetail,
     WorkflowLog,
     InstanceTag,
     WorkflowAuditSetting,
@@ -600,6 +603,59 @@ class TestWorkflow(APITestCase):
         self.assertEqual(r.status_code, status.HTTP_200_OK)
         self.assertEqual(r.json()["count"], 1)
 
+    def test_get_disabled_workflow_sub_resources(self):
+        """测试待审核和日志接口不开放GET方法"""
+        audit_response = self.client.get("/api/v1/workflow/auditlist/", format="json")
+        log_response = self.client.get("/api/v1/workflow/log/", format="json")
+
+        self.assertEqual(audit_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(log_response.status_code, status.HTTP_200_OK)
+        self.assertIn("不被允许", audit_response.json()["detail"])
+        self.assertIn("不被允许", log_response.json()["detail"])
+
+    def test_workflow_api_invalid_payload_branches(self):
+        """测试工单审核、执行和日志接口参数错误分支"""
+        audit_response = self.client.post("/api/v1/workflow/audit/", {}, format="json")
+        execute_response = self.client.post(
+            "/api/v1/workflow/execute/", {}, format="json"
+        )
+        log_response = self.client.post("/api/v1/workflow/log/", {}, format="json")
+
+        self.assertEqual(audit_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(execute_response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(log_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_execute_archive_workflow_dispatches_async_task(self):
+        """测试数据归档工单执行分支提交异步任务"""
+        WorkflowAudit.objects.create(
+            group_id=1,
+            group_name="some_group",
+            workflow_id=self.wf1.id,
+            workflow_type=3,
+            workflow_title="归档工单",
+            workflow_remark="",
+            audit_auth_groups="1",
+            current_audit="-1",
+            next_audit="-1",
+            current_status=WorkflowStatus.PASSED,
+            create_user=self.user.username,
+            create_user_display=self.user.display,
+        )
+
+        response = self.client.post(
+            "/api/v1/workflow/execute/",
+            {"workflow_id": self.wf1.id, "workflow_type": 3},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.mock_async_task.assert_any_call(
+            "sql.archiver.archive",
+            self.wf1.id,
+            timeout=-1,
+            task_name=f"archive-{self.wf1.id}",
+        )
+
     def test_check_param_is_None(self):
         """测试工单检测，参数内容为空"""
         json_data = {
@@ -620,8 +676,9 @@ class TestWorkflow(APITestCase):
         }
         _get_engine.side_effect = RuntimeError("RuntimeError")
         r = self.client.post("/api/v1/workflow/sqlcheck/", json_data, format="json")
-        print(json.loads(r.content))
-        self.assertDictEqual(json.loads(r.content), {"errors": "RuntimeError"})
+        self.assertDictEqual(
+            json.loads(r.content), {"errors": "SQL检查失败，请联系管理员"}
+        )
 
     @patch("sql_api.api_workflow.get_engine")
     def test_check(self, _get_engine):
@@ -980,6 +1037,48 @@ class TestWorkflow(APITestCase):
         self.assertEqual(workflow2.status, "workflow_queuing")
         self.assertEqual(self.mock_async_task.call_count, 2)
 
+    def test_batch_cancel_allows_resource_group_executor(self):
+        """测试资源组执行人可批量终止审核通过/定时执行工单"""
+        executor = User.objects.create_user(
+            username="executor",
+            password="executor_password",
+            display="执行人",
+            is_active=True,
+        )
+        executor.user_permissions.add(
+            Permission.objects.get(codename="sql_execute_for_resource_group")
+        )
+        executor.resource_group.add(self.res_group)
+        r = self.client.post(
+            "/api/auth/token/",
+            {"username": "executor", "password": "executor_password"},
+            format="json",
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + r.data["access"])
+
+        for workflow_status in ["workflow_review_pass", "workflow_timingtask"]:
+            with self.subTest(workflow_status=workflow_status):
+                workflow = self._create_sql_workflow(
+                    f"batch_cancel_{workflow_status}", workflow_status, 1
+                )
+                json_data = {
+                    "operation": "cancel",
+                    "workflow_ids": [workflow.id],
+                    "remark": "批量终止",
+                }
+
+                r = self.client.post(
+                    "/api/v1/workflow/batch/operate/", json_data, format="json"
+                )
+
+                self.assertEqual(r.status_code, status.HTTP_200_OK)
+                workflow.refresh_from_db()
+                self.assertEqual(workflow.status, "workflow_abort")
+                audit = WorkflowAudit.objects.get(workflow_id=workflow.id)
+                audit_detail = WorkflowAuditDetail.objects.get(audit_id=audit.audit_id)
+                self.assertEqual(audit_detail.audit_user, executor.username)
+                self.assertEqual(audit_detail.audit_status, WorkflowStatus.ABORTED)
+
     def test_batch_operate_rejects_mixed_status(self):
         """测试批量操作拒绝混合状态工单"""
         workflow2 = self._create_sql_workflow("batch_mixed", "workflow_review_pass", 1)
@@ -999,3 +1098,405 @@ class TestWorkflow(APITestCase):
         workflow2.refresh_from_db()
         self.assertEqual(self.wf1.status, "workflow_manreviewing")
         self.assertEqual(workflow2.status, "workflow_review_pass")
+
+    def test_two_factor_serializers_validate_missing_user_and_required_fields(self):
+        """测试2FA序列化器校验用户和必填配置"""
+        cases = [
+            (
+                api_serializers.TwoFASerializer,
+                {"engineer": "missing", "auth_type": "totp", "enable": "false"},
+                "不存在该用户",
+            ),
+            (
+                api_serializers.TwoFASerializer,
+                {
+                    "engineer": self.user.username,
+                    "auth_type": "sms",
+                    "enable": "true",
+                },
+                "缺少 phone",
+            ),
+            (
+                api_serializers.TwoFAStateSerializer,
+                {"engineer": "missing"},
+                "不存在该用户",
+            ),
+            (
+                api_serializers.TwoFASaveSerializer,
+                {"engineer": self.user.username, "auth_type": "sms"},
+                "缺少 phone",
+            ),
+            (
+                api_serializers.TwoFASaveSerializer,
+                {"engineer": self.user.username, "auth_type": "totp"},
+                "缺少 key",
+            ),
+            (
+                api_serializers.TwoFAVerifySerializer,
+                {
+                    "engineer": self.user.username,
+                    "auth_type": "sms",
+                    "otp": 123456,
+                },
+                "缺少 phone",
+            ),
+        ]
+
+        for serializer_class, payload, expected_error in cases:
+            with self.subTest(serializer=serializer_class.__name__):
+                serializer = serializer_class(data=payload)
+                self.assertFalse(serializer.is_valid())
+                self.assertIn(expected_error, str(serializer.errors))
+
+    def test_query_resource_serializer_requires_locator_and_resource_scope(self):
+        """测试查询资源序列化器校验定位参数和资源层级"""
+        cases = [
+            ({"resource_type": "database"}, "instance_id 或 instance_name"),
+            (
+                {"instance_name": "some_ins", "resource_type": "table"},
+                "db_name 不能为空",
+            ),
+            (
+                {
+                    "instance_name": "some_ins",
+                    "resource_type": "column",
+                    "db_name": "test_db",
+                },
+                "column 查询需提供",
+            ),
+        ]
+
+        for payload, expected_error in cases:
+            serializer = api_serializers.SqlQueryResourceQuerySerializer(data=payload)
+            self.assertFalse(serializer.is_valid())
+            self.assertIn(expected_error, str(serializer.errors))
+
+        serializer = api_serializers.SqlQueryResourceQuerySerializer(
+            data={
+                "instance_name": "some_ins",
+                "resource_type": "column",
+                "db_name": "test_db",
+                "tb_name": "test_table",
+            }
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_simple_query_serializers_normalize_boolean_flags(self):
+        """测试查询日志和收藏序列化器将布尔字符串归一化"""
+        logs_serializer = api_serializers.SqlQueryLogsQuerySerializer(
+            data={"star": "TRUE"}
+        )
+        self.assertTrue(logs_serializer.is_valid(), logs_serializer.errors)
+        self.assertTrue(logs_serializer.validated_data["star"])
+
+        favorite_serializer = api_serializers.SqlQueryFavoriteSerializer(
+            data={"query_log_id": 1, "star": "false"}
+        )
+        self.assertTrue(favorite_serializer.is_valid(), favorite_serializer.errors)
+        self.assertFalse(favorite_serializer.validated_data["star"])
+
+    def test_workflow_serializer_normalizes_empty_run_dates_and_group_error(self):
+        """测试工单序列化器处理空执行时间和不存在资源组"""
+        serializer = api_serializers.WorkflowSerializer(
+            data={
+                "workflow_name": "定时上线",
+                "group_id": self.res_group.group_id,
+                "instance": self.ins.id,
+                "db_name": "test_db",
+                "is_backup": False,
+                "run_date_start": "",
+                "run_date_end": "",
+            }
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertIsNone(serializer.validated_data["run_date_start"])
+        self.assertIsNone(serializer.validated_data["run_date_end"])
+
+        serializer = api_serializers.WorkflowSerializer(
+            data={
+                "workflow_name": "定时上线",
+                "group_id": 99999,
+                "instance": self.ins.id,
+                "db_name": "test_db",
+                "is_backup": False,
+            }
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("不存在该资源组", str(serializer.errors))
+
+    def test_execute_check_and_instance_resource_serializers_reject_missing_instance(
+        self,
+    ):
+        """测试依赖实例的序列化器拒绝不存在实例"""
+        instance_resource = api_serializers.InstanceResourceSerializer(
+            data={"instance_id": 99999, "resource_type": "database"}
+        )
+        self.assertFalse(instance_resource.is_valid())
+        self.assertIn("不存在该实例", str(instance_resource.errors))
+
+        execute_check = api_serializers.ExecuteCheckSerializer(
+            data={"instance_id": 99999, "db_name": "test_db", "full_sql": "select 1"}
+        )
+        self.assertFalse(execute_check.is_valid())
+        self.assertIn("不存在该实例", str(execute_check.errors))
+
+    def test_submit_user_helper_uses_request_user_or_validates_superuser_override(self):
+        """测试提交用户选择逻辑"""
+        normal_user = User.objects.create_user(
+            username="normal_submitter", display="普通提交人", is_active=True
+        )
+        self.assertEqual(
+            api_serializers._get_submit_user(normal_user, self.user.username),
+            normal_user,
+        )
+        self.assertEqual(
+            api_serializers._get_submit_user(self.user, normal_user.username),
+            normal_user,
+        )
+        with self.assertRaisesMessage(Exception, "不存在用户"):
+            api_serializers._get_submit_user(self.user, "missing_user")
+
+    def test_db_resource_helpers_normalize_and_report_engine_errors(self):
+        """测试数据库资源辅助函数处理不同格式和引擎错误"""
+        self.assertEqual(
+            api_serializers._normalize_db_resource_value({"value": "test_db"}),
+            "test_db",
+        )
+        self.assertEqual(api_serializers._normalize_db_resource_value(["db2"]), "db2")
+        self.assertEqual(api_serializers._normalize_db_resource_value("db3"), "db3")
+        self.assertEqual(
+            api_serializers._build_batch_workflow_name(
+                "very-long-workflow-name" * 4,
+                "instance_with_long_name",
+                "database_with_long_name",
+            ),
+            "ve-instance_with_long_name-database_with_long_name",
+        )
+        self.assertEqual(
+            api_serializers._build_batch_workflow_name(
+                "base",
+                "instance_name_longer_than_fifty_characters_for_test",
+                "database_name_longer_than_fifty_characters_for_test",
+            ),
+            "-instance_name_longer_than_fifty_characters_for_test-database_name_longer_than_fifty_characters_for_test"[
+                :50
+            ],
+        )
+
+        self.mock_engine.get_all_databases.return_value = MagicMock(
+            rows=[], error="boom"
+        )
+        with self.assertRaisesMessage(Exception, "获取数据库列表失败"):
+            api_serializers._visible_db_names(self.ins)
+
+    def test_batch_submit_serializer_validation_error_branches(self):
+        """测试批量提交序列化器常见参数错误分支"""
+        base_workflow = {
+            "workflow_name": "批量上线",
+            "group_id": self.res_group.group_id,
+            "is_offline_export": 0,
+        }
+        request = MagicMock(user=self.user)
+        cases = [
+            (
+                {
+                    "workflow": {**base_workflow, "instances": [self.ins.id]},
+                    "sql_content": " ",
+                },
+                "该字段不能为空",
+            ),
+            (
+                {
+                    "workflow": {**base_workflow, "db_names": ["test_db"]},
+                    "sql_content": "select 1",
+                },
+                "请选择实例",
+            ),
+            (
+                {
+                    "workflow": {**base_workflow, "instances": [self.ins.id]},
+                    "sql_content": "select 1",
+                },
+                "请选择数据库",
+            ),
+            (
+                {
+                    "workflow": {
+                        **base_workflow,
+                        "instances": ["bad"],
+                        "db_names": ["test_db"],
+                    },
+                    "sql_content": "select 1",
+                },
+                "实例ID格式错误",
+            ),
+            (
+                {
+                    "workflow": {
+                        **base_workflow,
+                        "instances": [self.ins.id, self.ins.id],
+                        "db_names": ["test_db"],
+                    },
+                    "sql_content": "select 1",
+                },
+                "实例 存在重复项",
+            ),
+            (
+                {
+                    "workflow": {
+                        **base_workflow,
+                        "instances": [self.ins.id],
+                        "db_names": ["test_db", "test_db"],
+                    },
+                    "sql_content": "select 1",
+                },
+                "数据库 存在重复项",
+            ),
+            (
+                {
+                    "workflow": {
+                        **base_workflow,
+                        "instances": [self.ins.id],
+                        "db_names": ["test_db"],
+                        "is_offline_export": 1,
+                    },
+                    "sql_content": "select 1",
+                },
+                "批量提交不支持离线导出工单",
+            ),
+            (
+                {
+                    "workflow": {
+                        **base_workflow,
+                        "instances": [99999],
+                        "db_names": ["test_db"],
+                    },
+                    "sql_content": "select 1",
+                },
+                "不存在实例",
+            ),
+        ]
+
+        for payload, expected_error in cases:
+            with self.subTest(expected_error=expected_error):
+                serializer = api_serializers.BatchWorkflowSubmitSerializer(
+                    data=payload, context={"request": request}
+                )
+                self.assertFalse(serializer.is_valid())
+                self.assertIn(expected_error, str(serializer.errors))
+
+    def test_batch_submit_serializer_rejects_unlinked_group_and_invisible_db(self):
+        """测试批量提交拒绝未关联资源组实例和无权限数据库"""
+        other_group = ResourceGroup.objects.create(group_name="other")
+        unlinked_instance = Instance.objects.create(
+            instance_name="unlinked_ins",
+            type="master",
+            db_type="mysql",
+            host="some_host",
+            port=3306,
+            user="ins_user",
+            password="some_str",
+        )
+        unlinked_instance.instance_tag.add(self.ins_tag.id)
+        request = MagicMock(user=self.user)
+
+        serializer = api_serializers.BatchWorkflowSubmitSerializer(
+            data={
+                "workflow": {
+                    "workflow_name": "批量上线",
+                    "group_id": other_group.group_id,
+                    "instances": [unlinked_instance.id],
+                    "db_names": ["test_db"],
+                    "is_offline_export": 0,
+                },
+                "sql_content": "select 1",
+            },
+            context={"request": request},
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("资源组未关联实例", str(serializer.errors))
+
+        serializer = api_serializers.BatchWorkflowSubmitSerializer(
+            data={
+                "workflow": {
+                    "workflow_name": "批量上线",
+                    "group_id": self.res_group.group_id,
+                    "instances": [self.ins.id],
+                    "db_names": ["missing_db"],
+                    "is_offline_export": 0,
+                },
+                "sql_content": "select 1",
+            },
+            context={"request": request},
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("不存在或无权限访问数据库", str(serializer.errors))
+
+    def test_workflow_operation_serializers_validation_error_branches(self):
+        """测试审核、日志、执行和批量操作序列化器错误分支"""
+        cases = [
+            (
+                api_serializers.AuditWorkflowSerializer,
+                {
+                    "engineer": "missing",
+                    "workflow_id": self.wf1.id,
+                    "workflow_type": 2,
+                    "audit_remark": "test",
+                    "audit_type": "pass",
+                },
+                "不存在该用户",
+            ),
+            (
+                api_serializers.WorkflowAuditSerializer,
+                {"engineer": "missing"},
+                "不存在该用户",
+            ),
+            (
+                api_serializers.WorkflowLogSerializer,
+                {"workflow_id": 99999, "workflow_type": 2},
+                "不存在该工单",
+            ),
+            (
+                api_serializers.ExecuteWorkflowSerializer,
+                {"workflow_id": self.wf1.id, "workflow_type": 2},
+                "缺少 mode",
+            ),
+            (
+                api_serializers.ExecuteWorkflowSerializer,
+                {"workflow_id": self.wf1.id, "workflow_type": 2, "mode": "manual"},
+                "缺少 engineer",
+            ),
+            (
+                api_serializers.ExecuteWorkflowSerializer,
+                {
+                    "workflow_id": self.wf1.id,
+                    "workflow_type": 2,
+                    "mode": "manual",
+                    "engineer": "missing",
+                },
+                "不存在该用户",
+            ),
+        ]
+
+        for serializer_class, payload, expected_error in cases:
+            serializer = serializer_class(data=payload)
+            self.assertFalse(serializer.is_valid())
+            self.assertIn(expected_error, str(serializer.errors))
+
+        serializer = api_serializers.BatchWorkflowOperationSerializer(
+            data={"operation": "audit", "workflow_ids": [self.wf1.id, self.wf1.id]}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("工单ID存在重复项", str(serializer.errors))
+
+        serializer = api_serializers.BatchWorkflowOperationSerializer(
+            data={"operation": "cancel", "workflow_ids": [self.wf1.id]}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("终止原因不能为空", str(serializer.errors))
+
+        serializer = api_serializers.BatchWorkflowOperationSerializer(
+            data={"operation": "audit", "workflow_ids": [99999]}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("不存在工单", str(serializer.errors))

--- a/sql_api/tests.py
+++ b/sql_api/tests.py
@@ -505,8 +505,13 @@ class TestWorkflow(APITestCase):
             ],
         )
         mock_get_engine.return_value = mock_engine
+        mock_engine.get_all_databases.return_value = MagicMock(
+            rows=["test_db", "db2"], error=None
+        )
+        self.mock_get_engine = mock_get_engine
+        self.mock_engine = mock_engine
         self.async_task_patcher = patch("sql_api.api_workflow.async_task")
-        self.async_task_patcher.start()
+        self.mock_async_task = self.async_task_patcher.start()
         self.notify_patcher = patch("sql.notify.auto_notify")
         self.notify_patcher.start()
 
@@ -521,6 +526,56 @@ class TestWorkflow(APITestCase):
         self.get_engine_patcher.stop()
         self.async_task_patcher.stop()
         self.notify_patcher.stop()
+
+    def _create_instance(self, instance_name, db_type="mysql"):
+        instance = Instance.objects.create(
+            instance_name=instance_name,
+            type="master",
+            db_type=db_type,
+            host="some_host",
+            port=3306,
+            user="ins_user",
+            password="some_str",
+        )
+        instance.resource_group.add(self.res_group)
+        instance.instance_tag.add(self.ins_tag.id)
+        return instance
+
+    def _create_sql_workflow(self, workflow_name, workflow_status, audit_status):
+        workflow = SqlWorkflow.objects.create(
+            workflow_name=workflow_name,
+            group_id=1,
+            group_name=self.res_group.group_name,
+            engineer=self.user.username,
+            engineer_display=self.user.display,
+            audit_auth_groups=str(self.group.id),
+            status=workflow_status,
+            is_backup=False,
+            instance=self.ins,
+            db_name="test_db",
+            syntax_type=1,
+        )
+        SqlWorkflowContent.objects.create(
+            workflow=workflow,
+            sql_content="alter table abc add column note varchar(64);",
+            review_content="[]",
+            execute_result="",
+        )
+        WorkflowAudit.objects.create(
+            group_id=1,
+            group_name=self.res_group.group_name,
+            workflow_id=workflow.id,
+            workflow_type=2,
+            workflow_title=workflow.workflow_name,
+            workflow_remark="",
+            audit_auth_groups=str(self.group.id),
+            current_audit=str(self.group.id) if audit_status == 0 else "-1",
+            next_audit="-1",
+            current_status=audit_status,
+            create_user=self.user.username,
+            create_user_display=self.user.display,
+        )
+        return workflow
 
     def test_get_sql_workflow_list(self):
         """测试获取SQL上线工单列表"""
@@ -649,6 +704,64 @@ class TestWorkflow(APITestCase):
         self.assertEqual(r.json()["workflow"]["workflow_name"], "上线工单1")
         self.assertEqual(r.json()["workflow"]["engineer"], self.user.username)
         self.assertEqual(r.json()["workflow"]["engineer_display"], self.user.display)
+
+    def test_batch_submit_workflow_creates_cross_product_and_checks_once(self):
+        """测试批量提交生成实例和数据库笛卡尔积，且只检测一次"""
+        instance2 = self._create_instance("second_ins")
+        json_data = {
+            "workflow": {
+                "workflow_name": "批量上线",
+                "demand_url": "test",
+                "group_id": 1,
+                "instances": [self.ins.id, instance2.id],
+                "db_names": ["test_db", "db2"],
+                "is_backup": False,
+                "is_offline_export": 0,
+            },
+            "sql_content": "alter table abc add column note varchar(64);",
+        }
+
+        r = self.client.post("/api/v1/workflow/batch/submit/", json_data, format="json")
+
+        self.assertEqual(r.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(r.json()["workflow_count"], 4)
+        self.mock_engine.execute_check.assert_called_once_with(
+            db_name="test_db", sql="alter table abc add column note varchar(64);"
+        )
+        workflows = SqlWorkflow.objects.exclude(id=self.wf1.id).order_by("id")
+        self.assertEqual(workflows.count(), 4)
+        self.assertEqual(
+            [(wf.instance.instance_name, wf.db_name) for wf in workflows],
+            [
+                ("some_ins", "test_db"),
+                ("some_ins", "db2"),
+                ("second_ins", "test_db"),
+                ("second_ins", "db2"),
+            ],
+        )
+        self.assertTrue(
+            all(wf.workflow_name.startswith("批量上线-") for wf in workflows)
+        )
+
+    def test_batch_submit_rejects_mixed_db_type(self):
+        """测试批量提交拒绝混合数据库类型实例"""
+        instance2 = self._create_instance("pgsql_ins", db_type="pgsql")
+        json_data = {
+            "workflow": {
+                "workflow_name": "批量上线",
+                "group_id": 1,
+                "instances": [self.ins.id, instance2.id],
+                "db_names": ["test_db"],
+                "is_offline_export": 0,
+            },
+            "sql_content": "alter table abc add column note varchar(64);",
+        }
+
+        r = self.client.post("/api/v1/workflow/batch/submit/", json_data, format="json")
+
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("同一数据库类型", str(r.json()["errors"]))
+        self.assertEqual(SqlWorkflow.objects.count(), 1)
 
     def test_submit_workflow_super(self):
         """测试管理员提交SQL上线工单，可以指定用户"""
@@ -820,3 +933,69 @@ class TestWorkflow(APITestCase):
         r = self.client.post("/api/v1/workflow/execute/", execute_data, format="json")
         self.assertEqual(r.status_code, status.HTTP_200_OK)
         self.assertEqual(r.json(), {"msg": "开始执行，执行结果请到工单详情页查看"})
+
+    def test_batch_audit_workflow(self):
+        """测试批量审核工单"""
+        workflow2 = self._create_sql_workflow(
+            "batch_review", "workflow_manreviewing", 0
+        )
+        json_data = {
+            "operation": "audit",
+            "workflow_ids": [self.wf1.id, workflow2.id],
+            "remark": "批量通过",
+        }
+
+        r = self.client.post(
+            "/api/v1/workflow/batch/operate/", json_data, format="json"
+        )
+
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertEqual(r.json()["processed_count"], 2)
+        self.wf1.refresh_from_db()
+        workflow2.refresh_from_db()
+        self.assertEqual(self.wf1.status, "workflow_review_pass")
+        self.assertEqual(workflow2.status, "workflow_review_pass")
+
+    def test_batch_execute_workflow(self):
+        """测试批量执行工单"""
+        workflow1 = self._create_sql_workflow(
+            "batch_execute_1", "workflow_review_pass", 1
+        )
+        workflow2 = self._create_sql_workflow(
+            "batch_execute_2", "workflow_review_pass", 1
+        )
+        json_data = {
+            "operation": "execute",
+            "workflow_ids": [workflow1.id, workflow2.id],
+        }
+
+        r = self.client.post(
+            "/api/v1/workflow/batch/operate/", json_data, format="json"
+        )
+
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        workflow1.refresh_from_db()
+        workflow2.refresh_from_db()
+        self.assertEqual(workflow1.status, "workflow_queuing")
+        self.assertEqual(workflow2.status, "workflow_queuing")
+        self.assertEqual(self.mock_async_task.call_count, 2)
+
+    def test_batch_operate_rejects_mixed_status(self):
+        """测试批量操作拒绝混合状态工单"""
+        workflow2 = self._create_sql_workflow("batch_mixed", "workflow_review_pass", 1)
+        json_data = {
+            "operation": "cancel",
+            "workflow_ids": [self.wf1.id, workflow2.id],
+            "remark": "批量终止",
+        }
+
+        r = self.client.post(
+            "/api/v1/workflow/batch/operate/", json_data, format="json"
+        )
+
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("同一状态", str(r.json()["errors"]))
+        self.wf1.refresh_from_db()
+        workflow2.refresh_from_db()
+        self.assertEqual(self.wf1.status, "workflow_manreviewing")
+        self.assertEqual(workflow2.status, "workflow_review_pass")

--- a/sql_api/urls.py
+++ b/sql_api/urls.py
@@ -55,6 +55,8 @@ urlpatterns = [
     path("v1/instance/tunnel/", api_instance.TunnelList.as_view()),
     path("v1/instance/rds/", api_instance.AliyunRdsList.as_view()),
     path("v1/workflow/", api_workflow.WorkflowList.as_view()),
+    path("v1/workflow/batch/submit/", api_workflow.BatchWorkflowSubmit.as_view()),
+    path("v1/workflow/batch/operate/", api_workflow.BatchWorkflowOperate.as_view()),
     path("v1/workflow/sqlcheck/", api_workflow.ExecuteCheck.as_view()),
     path("v1/workflow/audit/", api_workflow.AuditWorkflow.as_view()),
     path("v1/workflow/auditlist/", api_workflow.WorkflowAuditList.as_view()),


### PR DESCRIPTION
【批量操作】：在SQL上线模块，增加批量操作功能。

在提交SQL的页面（/submitsql/）更改内容：
1、多实例单库的场景：将当前的【请选择实例:】由单选改为多选，对应后端也改，最终可以生成多实例单库的多个工单。SQL检测，只检测第一个实例的SQL，其他实例不重复检测。
2、单实例多库的场景：将当前的【请选择数据库:】由单选改为多选，对应后端也改，最终可以生成单实例多库的多个工单。SQL检测，只检测第一个库的SQL，其他库不重复检测。
3、多实例多库的场景：生成的工单数就变成M*N了。SQL检测，只检测第一个实例，第一个库的SQL，不重复检测。

在工单流的查看页面（/sqlworkflow/）更改内容：
1、在每个工单名称前增加一列，勾选框，可多选多个工单。
2、在现有的【提交SQL】按钮右侧，增加选择操作，采用dropdown的形式折叠起来：批量审核SQL、批量执行SQL、批量终止工单。
批量功能，按照工单的提交顺序，先提交的先操作，后提交的后操作。注：这个批量顺序，只是触发顺序，最终的结束时间顺序是按照实例本身的执行情况，有可能后操作的，反而先执行成功。
要求：批量勾选的所有工单处于同一个状态，验证每个工单当前用户都有可操作权限（审核、执行、终止）。


和这个discussions[#1578](https://github.com/hhyo/Archery/discussions/1578)不同的地方是：
1、没有【提交批量SQL】按钮，而是通过多选实例和库的方式实现。
2、没有【提交批量回滚工单】按钮，回滚逻辑本来就有点复杂，而且当前也只支持mysql库的回滚。
相关回滚可以自行通过单个工单的回滚SQL提交，然后多选实例和库来批量提交。
