### PR TITLE
fix(mysql):安全类修复

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ openpyxl==3.1.5
 parameterized
 pymemcache==4.0.0
 taos-ws-py==0.6.9
+regex==2026.5.9

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -35,6 +35,7 @@ MYSQL_PRIVILEGE_TABLES = {
     "procs_priv",
     "proxies_priv",
     "global_grants",
+    "global_priv",
     "default_roles",
     "role_edges",
     "password_history",
@@ -889,7 +890,7 @@ class MysqlEngine(EngineBase):
             2,
         ):
             support_account_lock = True
-            sql_get_user = "SELECT user, host, JSON_EXTRACT(priv, '$.account_locked') AS account_locked FROM mysql.global_priv;"
+            sql_get_user = "SELECT user, host, IF(JSON_EXTRACT(priv, '$.account_locked') = 'true', 'Y', 'N') AS account_locked FROM mysql.global_priv;"
         else:
             support_account_lock = False
             sql_get_user = sql_get_user_without_account_locked

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -1584,36 +1584,7 @@ class MysqlEngine(EngineBase):
     def trxandlocks(self):
         """获取锁等待信息"""
         server_version = self.server_version
-        if server_version < (8, 0, 1):
-            sql = """
-                SELECT
-                rtrx.`trx_state`                                                        AS "等待的状态",
-                rtrx.`trx_started`                                                      AS "等待事务开始时间",
-                rtrx.`trx_wait_started`                                                 AS "等待事务等待开始时间",
-                lw.`requesting_trx_id`                                                  AS "等待事务ID",
-                rtrx.trx_mysql_thread_id                                                AS "等待事务线程ID",
-                rtrx.`trx_query`                                                        AS "等待事务的sql",
-                CONCAT(rl.`lock_mode`, '-', rl.`lock_table`, '(', rl.`lock_index`, ')') AS "等待的表信息",
-                rl.`lock_id`                                                            AS "等待的锁id",
-                lw.`blocking_trx_id`                                                    AS "运行的事务id",
-                trx.trx_mysql_thread_id                                                 AS "运行的事务线程id",
-                CONCAT(l.`lock_mode`, '-', l.`lock_table`, '(', l.`lock_index`, ')')    AS "运行的表信息",
-                l.lock_id                                                               AS "运行的锁id",
-                trx.`trx_state`                                                         AS "运行事务的状态",
-                trx.`trx_started`                                                       AS "运行事务的时间",
-                trx.`trx_wait_started`                                                  AS "运行事务的等待开始时间",
-                trx.`trx_query`                                                         AS "运行事务的sql"
-                FROM information_schema.`INNODB_LOCKS` rl
-                , information_schema.`INNODB_LOCKS` l
-                , information_schema.`INNODB_LOCK_WAITS` lw
-                , information_schema.`INNODB_TRX` rtrx
-                , information_schema.`INNODB_TRX` trx
-                WHERE rl.`lock_id` = lw.`requested_lock_id`
-                    AND l.`lock_id` = lw.`blocking_lock_id`
-                    AND lw.requesting_trx_id = rtrx.trx_id
-                    AND lw.blocking_trx_id = trx.trx_id;"""
-
-        else:
+        if self.server_fork_type == MysqlForkType.MYSQL and server_version >= (8, 0, 1):
             sql = """
                 SELECT
                 rtrx.`trx_state`                                                           AS "等待的状态",
@@ -1641,6 +1612,35 @@ class MysqlEngine(EngineBase):
                     AND l.`ENGINE_LOCK_ID` = lw.`BLOCKING_ENGINE_LOCK_ID`
                     AND lw.REQUESTING_ENGINE_TRANSACTION_ID = rtrx.trx_id
                     AND lw.BLOCKING_ENGINE_TRANSACTION_ID = trx.trx_id;"""
+
+        else:
+            sql = """
+                SELECT
+                rtrx.`trx_state`                                                        AS "等待的状态",
+                rtrx.`trx_started`                                                      AS "等待事务开始时间",
+                rtrx.`trx_wait_started`                                                 AS "等待事务等待开始时间",
+                lw.`requesting_trx_id`                                                  AS "等待事务ID",
+                rtrx.trx_mysql_thread_id                                                AS "等待事务线程ID",
+                rtrx.`trx_query`                                                        AS "等待事务的sql",
+                CONCAT(rl.`lock_mode`, '-', rl.`lock_table`, '(', rl.`lock_index`, ')') AS "等待的表信息",
+                rl.`lock_id`                                                            AS "等待的锁id",
+                lw.`blocking_trx_id`                                                    AS "运行的事务id",
+                trx.trx_mysql_thread_id                                                 AS "运行的事务线程id",
+                CONCAT(l.`lock_mode`, '-', l.`lock_table`, '(', l.`lock_index`, ')')    AS "运行的表信息",
+                l.lock_id                                                               AS "运行的锁id",
+                trx.`trx_state`                                                         AS "运行事务的状态",
+                trx.`trx_started`                                                       AS "运行事务的时间",
+                trx.`trx_wait_started`                                                  AS "运行事务的等待开始时间",
+                trx.`trx_query`                                                         AS "运行事务的sql"
+                FROM information_schema.`INNODB_LOCKS` rl
+                , information_schema.`INNODB_LOCKS` l
+                , information_schema.`INNODB_LOCK_WAITS` lw
+                , information_schema.`INNODB_TRX` rtrx
+                , information_schema.`INNODB_TRX` trx
+                WHERE rl.`lock_id` = lw.`requested_lock_id`
+                    AND l.`lock_id` = lw.`blocking_lock_id`
+                    AND lw.requesting_trx_id = rtrx.trx_id
+                    AND lw.blocking_trx_id = trx.trx_id;"""
 
         return self.query("information_schema", sql)
 

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -6,6 +6,7 @@ import MySQLdb.cursors
 import MySQLdb.converters
 import pymysql
 import re
+import regex as safe_regex
 from enum import Enum
 
 import schemaobject
@@ -14,6 +15,7 @@ from MySQLdb.constants import FIELD_TYPE
 from schemaobject.connection import build_database_url
 
 from sql.engines.goinception import GoInceptionEngine
+from sql.utils.extract_tables import extract_tables
 from sql.utils.sql_utils import get_syntax_type, remove_comments
 from . import EngineBase
 from .models import ResultSet, ReviewResult, ReviewSet
@@ -21,6 +23,31 @@ from sql.utils.data_masking import data_masking
 from common.config import SysConfig
 
 logger = logging.getLogger("default")
+
+CRITICAL_DDL_REGEX_MAX_LENGTH = 2048
+CRITICAL_DDL_REGEX_TIMEOUT = 0.1
+
+MYSQL_PRIVILEGE_TABLES = {
+    "user",
+    "db",
+    "tables_priv",
+    "columns_priv",
+    "procs_priv",
+    "proxies_priv",
+    "global_grants",
+    "default_roles",
+    "role_edges",
+    "password_history",
+}
+INFORMATION_SCHEMA_PRIVILEGE_TABLES = {
+    "user_privileges",
+    "schema_privileges",
+    "table_privileges",
+    "column_privileges",
+    "applicable_roles",
+    "enabled_roles",
+    "administrable_role_authorizations",
+}
 
 # https://github.com/mysql/mysql-connector-python/blob/master/lib/mysql/connector/constants.py#L168
 column_types_map = {
@@ -71,10 +98,234 @@ class MysqlEngine(EngineBase):
     _server_fork_type = None
     _server_info = None
 
+    GLOBAL_PRIVILEGES = {
+        "SELECT",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "FILE",
+        "CREATE",
+        "ALTER",
+        "INDEX",
+        "DROP",
+        "CREATE TEMPORARY TABLES",
+        "SHOW VIEW",
+        "CREATE ROUTINE",
+        "ALTER ROUTINE",
+        "EXECUTE",
+        "CREATE VIEW",
+        "EVENT",
+        "TRIGGER",
+        "GRANT",
+        "SUPER",
+        "PROCESS",
+        "RELOAD",
+        "SHUTDOWN",
+        "SHOW DATABASES",
+        "LOCK TABLES",
+        "REFERENCES",
+        "REPLICATION CLIENT",
+        "REPLICATION SLAVE",
+        "CREATE USER",
+    }
+    DB_PRIVILEGES = {
+        "SELECT",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "CREATE",
+        "ALTER",
+        "INDEX",
+        "DROP",
+        "CREATE TEMPORARY TABLES",
+        "SHOW VIEW",
+        "CREATE ROUTINE",
+        "ALTER ROUTINE",
+        "EXECUTE",
+        "CREATE VIEW",
+        "EVENT",
+        "TRIGGER",
+        "GRANT",
+        "LOCK TABLES",
+        "REFERENCES",
+    }
+    TABLE_PRIVILEGES = {
+        "SELECT",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "CREATE",
+        "ALTER",
+        "INDEX",
+        "DROP",
+        "SHOW VIEW",
+        "CREATE VIEW",
+        "TRIGGER",
+        "GRANT",
+        "REFERENCES",
+    }
+    COLUMN_PRIVILEGES = {"SELECT", "INSERT", "UPDATE", "REFERENCES"}
+    VARIABLE_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
     def __init__(self, instance=None):
         super().__init__(instance=instance)
         self.config = SysConfig()
         self.inc_engine = GoInceptionEngine()
+
+    @staticmethod
+    def _error_result(message, full_sql=""):
+        result = ResultSet(full_sql=full_sql)
+        result.error = message
+        return result
+
+    @staticmethod
+    def _quote_identifier(identifier):
+        if identifier is None:
+            raise ValueError("标识符不能为空")
+        identifier = str(identifier)
+        if identifier == "" or "\x00" in identifier:
+            raise ValueError("标识符不合法")
+        return f"`{identifier.replace('`', '``')}`"
+
+    @staticmethod
+    def _quote_literal(value):
+        if value is None:
+            raise ValueError("参数值不能为空")
+        value = str(value)
+        if "\x00" in value:
+            raise ValueError("参数值不合法")
+        return f"'{pymysql.escape_string(value)}'"
+
+    @staticmethod
+    def _quote_account_part(value):
+        if value is None:
+            raise ValueError("账号信息不能为空")
+        value = str(value)
+        if "\x00" in value:
+            raise ValueError("账号信息不合法")
+        return f"`{value.replace('`', '``')}`"
+
+    @classmethod
+    def _format_user_host(cls, user, host):
+        return f"{cls._quote_account_part(user)}@{cls._quote_account_part(host)}"
+
+    @classmethod
+    def _parse_account_part(cls, account, start):
+        length = len(account)
+        while start < length and account[start].isspace():
+            start += 1
+        if start >= length:
+            raise ValueError("账号格式不合法")
+
+        quote = account[start] if account[start] in ("`", "'", '"') else None
+        if not quote:
+            end = start
+            while end < length and account[end] != "@":
+                end += 1
+            value = account[start:end].strip()
+            if not value:
+                raise ValueError("账号格式不合法")
+            return value, end
+
+        start += 1
+        chars = []
+        while start < length:
+            ch = account[start]
+            if ch == "\\" and quote in ("'", '"') and start + 1 < length:
+                chars.append(account[start + 1])
+                start += 2
+                continue
+            if ch == quote:
+                if quote == "`" and start + 1 < length and account[start + 1] == "`":
+                    chars.append("`")
+                    start += 2
+                    continue
+                if (
+                    quote in ("'", '"')
+                    and start + 1 < length
+                    and account[start + 1] == quote
+                ):
+                    chars.append(quote)
+                    start += 2
+                    continue
+                return "".join(chars), start + 1
+            chars.append(ch)
+            start += 1
+        raise ValueError("账号格式不合法")
+
+    @classmethod
+    def _parse_user_host(cls, user_host):
+        if user_host is None:
+            raise ValueError("账号格式不合法")
+        user_host = str(user_host).strip()
+        user, pos = cls._parse_account_part(user_host, 0)
+        while pos < len(user_host) and user_host[pos].isspace():
+            pos += 1
+        if pos >= len(user_host) or user_host[pos] != "@":
+            raise ValueError("账号格式不合法")
+        host, pos = cls._parse_account_part(user_host, pos + 1)
+        if user_host[pos:].strip():
+            raise ValueError("账号格式不合法")
+        return user, host
+
+    @classmethod
+    def _normalize_user_host(cls, user_host):
+        user, host = cls._parse_user_host(user_host)
+        return cls._format_user_host(user, host)
+
+    @staticmethod
+    def _coerce_int(value, name, minimum=None):
+        if isinstance(value, bool):
+            raise ValueError(f"{name}不合法")
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            raise ValueError(f"{name}不合法")
+        if minimum is not None and value < minimum:
+            raise ValueError(f"{name}不合法")
+        return value
+
+    @classmethod
+    def _validate_thread_ids(cls, thread_ids):
+        if not isinstance(thread_ids, (list, tuple)):
+            raise ValueError("线程ID不合法")
+        safe_ids = []
+        for thread_id in thread_ids:
+            if isinstance(thread_id, bool) or not isinstance(thread_id, int):
+                raise ValueError("线程ID不合法")
+            safe_ids.append(thread_id)
+        return safe_ids
+
+    @classmethod
+    def _normalize_privileges(cls, privs, allowed_privs):
+        normalized = []
+        for priv in privs or []:
+            priv = str(priv).upper()
+            if priv not in allowed_privs:
+                raise ValueError("权限项不合法")
+            normalized.append("GRANT OPTION" if priv == "GRANT" else priv)
+        if not normalized:
+            raise ValueError("权限项不能为空")
+        return normalized
+
+    @staticmethod
+    def _as_list(value):
+        if value is None:
+            return []
+        if isinstance(value, (list, tuple)):
+            return list(value)
+        return [value]
+
+    @staticmethod
+    def _compile_safe_regex(pattern):
+        if not pattern:
+            return None
+        if len(pattern) > CRITICAL_DDL_REGEX_MAX_LENGTH:
+            raise ValueError("critical_ddl_regex长度超过2048，已拒绝执行")
+        try:
+            return safe_regex.compile(pattern)
+        except safe_regex.error as e:
+            raise ValueError(f"critical_ddl_regex配置不合法：{e}")
 
     def get_connection(self, db_name=None):
         # https://stackoverflow.com/questions/19256155/python-mysqldb-returning-x01-for-bit-values
@@ -183,7 +434,11 @@ class MysqlEngine(EngineBase):
 
     def kill_connection(self, thread_id):
         """终止数据库连接"""
-        self.query(sql=f"kill {thread_id}")
+        try:
+            thread_id = self._coerce_int(thread_id, "线程ID", minimum=0)
+        except ValueError as e:
+            return self._error_result(str(e))
+        return self.query(sql="kill %s", parameters=(thread_id,))
 
     # 禁止查询的数据库
     forbidden_databases = [
@@ -432,7 +687,9 @@ class MysqlEngine(EngineBase):
             "column_list": _meta.column_list,
             "rows": _meta.rows[0] if _meta.rows else [],
         }
-        _create = self.query(db_name, f"SHOW CREATE PROCEDURE `{proc_name}`;")
+        _create = self.query(
+            db_name, f"SHOW CREATE PROCEDURE {self._quote_identifier(proc_name)};"
+        )
         create_sql = _create.rows
         return {"meta_data": meta_data, "create_sql": create_sql}
 
@@ -476,7 +733,9 @@ class MysqlEngine(EngineBase):
             "column_list": _meta.column_list,
             "rows": _meta.rows[0] if _meta.rows else [],
         }
-        _create = self.query(db_name, f"SHOW CREATE FUNCTION `{func_name}`;")
+        _create = self.query(
+            db_name, f"SHOW CREATE FUNCTION {self._quote_identifier(func_name)};"
+        )
         create_sql = _create.rows
         return {"meta_data": meta_data, "create_sql": create_sql}
 
@@ -536,7 +795,9 @@ class MysqlEngine(EngineBase):
             "column_list": _meta.column_list,
             "rows": _meta.rows[0] if _meta.rows else [],
         }
-        _create = self.query(db_name, f"SHOW CREATE EVENT `{event_name}`;")
+        _create = self.query(
+            db_name, f"SHOW CREATE EVENT {self._quote_identifier(event_name)};"
+        )
         create_sql = _create.rows
         return {"meta_data": meta_data, "create_sql": create_sql}
 
@@ -563,11 +824,17 @@ class MysqlEngine(EngineBase):
             ]
             _meta["ENGINE_KEYS"] = engine_keys
             _meta["TABLE_INFO"] = tb
-            sql_cols = f"""SELECT * FROM INFORMATION_SCHEMA.COLUMNS 
-                            WHERE TABLE_SCHEMA='{tb['TABLE_SCHEMA']}' AND TABLE_NAME='{tb['TABLE_NAME']}'
+            sql_cols = """SELECT * FROM INFORMATION_SCHEMA.COLUMNS
+                            WHERE TABLE_SCHEMA=%(table_schema)s AND TABLE_NAME=%(table_name)s
                             ORDER BY TABLE_SCHEMA,TABLE_NAME,ORDINAL_POSITION;"""
             _meta["COLUMNS"] = self.query(
-                sql=sql_cols, cursorclass=MySQLdb.cursors.DictCursor, close_conn=False
+                sql=sql_cols,
+                cursorclass=MySQLdb.cursors.DictCursor,
+                close_conn=False,
+                parameters={
+                    "table_schema": tb["TABLE_SCHEMA"],
+                    "table_name": tb["TABLE_NAME"],
+                },
             ).rows
             table_metas.append(_meta)
         return table_metas
@@ -611,22 +878,23 @@ class MysqlEngine(EngineBase):
     def get_instance_users_summary(self):
         """实例账号管理功能，获取实例所有账号信息"""
         server_version = self.server_version
-        sql_get_user_with_account_locked = "select concat('`', user, '`', '@', '`', host,'`') as query,user,host,account_locked from mysql.user;"
-        sql_get_user_without_account_locked = "select concat('`', user, '`', '@', '`', host,'`') as query,user,host from mysql.user;"
+        sql_get_user_without_account_locked = "select user, host from mysql.user;"
         # MySQL 5.7.6版本, mariadb 10.4.2  起支持ACCOUNT LOCK
-        if (
-            self.server_fork_type == MysqlForkType.MYSQL and server_version >= (5, 7, 6)
-        ) or (
-            self.server_fork_type == MysqlForkType.MARIADB
-            and self.server_version >= (10, 4, 2)
+        if self.server_fork_type == MysqlForkType.MYSQL and server_version >= (5, 7, 6):
+            support_account_lock = True
+            sql_get_user = "select user, host, account_locked from mysql.user;"
+        elif self.server_fork_type == MysqlForkType.MARIADB and self.server_version >= (
+            10,
+            4,
+            2,
         ):
             support_account_lock = True
-            sql_get_user = sql_get_user_with_account_locked
+            sql_get_user = "SELECT user, host, JSON_EXTRACT(priv, '$.account_locked') AS account_locked FROM mysql.global_priv;"
         else:
             support_account_lock = False
             sql_get_user = sql_get_user_without_account_locked
         query_result = self.query("mysql", sql_get_user)
-        if query_result.error and sql_get_user == sql_get_user_with_account_locked:
+        if query_result.error and "account_locked" in sql_get_user:
             # 查询出错了, fallback 到不带 lock 信息的 sql
             query_result = self.query("mysql", sql_get_user_without_account_locked)
         if not query_result.error:
@@ -634,19 +902,19 @@ class MysqlEngine(EngineBase):
             # 获取用户权限信息
             rows = []
             for db_user in db_users:
-                user_host = db_user[0]
+                user_host = self._format_user_host(db_user[0], db_user[1])
                 user_priv = self.query(
                     "mysql", "show grants for {};".format(user_host), close_conn=False
                 ).rows
                 row = {
                     "user_host": user_host,
-                    "user": db_user[1],
-                    "host": db_user[2],
+                    "user": db_user[0],
+                    "host": db_user[1],
                     "privileges": user_priv,
                     "saved": False,
                     "is_locked": (
-                        db_user[3]
-                        if support_account_lock and len(db_user) == 4
+                        db_user[2]
+                        if support_account_lock and len(db_user) == 3
                         else None
                     ),
                 }
@@ -656,52 +924,149 @@ class MysqlEngine(EngineBase):
 
     def create_instance_user(self, **kwargs):
         """实例账号管理功能，创建实例账号"""
-        # escape
-        user = self.escape_string(kwargs.get("user", ""))
-        host = self.escape_string(kwargs.get("host", ""))
-        password1 = self.escape_string(kwargs.get("password1", ""))
+        user = kwargs.get("user", "")
+        host = kwargs.get("host", "")
+        password1 = kwargs.get("password1", "")
         remark = kwargs.get("remark", "")
         # 在一个事务内执行
         hosts = host.split("|")
         create_user_cmd = ""
         accounts = []
-        for host in hosts:
-            create_user_cmd += (
-                f"create user '{user}'@'{host}' identified by '{password1}';"
-            )
-            accounts.append(
-                {
-                    "instance": self.instance,
-                    "user": user,
-                    "host": host,
-                    "password": password1,
-                    "remark": remark,
-                }
-            )
+        try:
+            password_literal = self._quote_literal(password1)
+            for host in hosts:
+                account = self._format_user_host(user, host)
+                create_user_cmd += (
+                    f"create user {account} identified by {password_literal};"
+                )
+                accounts.append(
+                    {
+                        "instance": self.instance,
+                        "user": user,
+                        "host": host,
+                        "password": password1,
+                        "remark": remark,
+                    }
+                )
+        except ValueError as e:
+            return self._error_result(str(e))
+        if not accounts:
+            return self._error_result("账号信息不能为空")
         exec_result = self.execute(db_name="mysql", sql=create_user_cmd)
         exec_result.rows = accounts
         return exec_result
 
+    def grant_instance_user(
+        self,
+        user_host,
+        op_type,
+        priv_type,
+        privs,
+        db_names=None,
+        tb_names=None,
+        col_names=None,
+    ):
+        """实例账号管理功能，授予/回收账号权限"""
+        try:
+            user_host = self._normalize_user_host(user_host)
+            op_type = self._coerce_int(op_type, "操作类型")
+            priv_type = self._coerce_int(priv_type, "权限类型")
+            if op_type == 0:
+                action, target = "GRANT", "TO"
+            elif op_type == 1:
+                action, target = "REVOKE", "FROM"
+            else:
+                raise ValueError("操作类型不合法")
+
+            grant_sql = ""
+            if priv_type == 0:
+                grant_privs = self._normalize_privileges(
+                    privs.get("global_privs", []), self.GLOBAL_PRIVILEGES
+                )
+                grant_sql = (
+                    f"{action} {','.join(grant_privs)} ON *.* {target} {user_host};"
+                )
+            elif priv_type == 1:
+                grant_privs = self._normalize_privileges(
+                    privs.get("db_privs", []), self.DB_PRIVILEGES
+                )
+                for db_name in self._as_list(db_names):
+                    grant_sql += (
+                        f"{action} {','.join(grant_privs)} ON "
+                        f"{self._quote_identifier(db_name)}.* {target} {user_host};"
+                    )
+            elif priv_type == 2:
+                grant_privs = self._normalize_privileges(
+                    privs.get("tb_privs", []), self.TABLE_PRIVILEGES
+                )
+                quoted_db = self._quote_identifier(self._as_list(db_names)[0])
+                for tb_name in self._as_list(tb_names):
+                    grant_sql += (
+                        f"{action} {','.join(grant_privs)} ON "
+                        f"{quoted_db}.{self._quote_identifier(tb_name)} {target} {user_host};"
+                    )
+            elif priv_type == 3:
+                grant_privs = self._normalize_privileges(
+                    privs.get("col_privs", []), self.COLUMN_PRIVILEGES
+                )
+                quoted_db = self._quote_identifier(self._as_list(db_names)[0])
+                quoted_tb = self._quote_identifier(self._as_list(tb_names)[0])
+                quoted_cols = ",".join(
+                    self._quote_identifier(col_name)
+                    for col_name in self._as_list(col_names)
+                )
+                if not quoted_cols:
+                    raise ValueError("列名不能为空")
+                for priv in grant_privs:
+                    grant_sql += (
+                        f"{action} {priv}({quoted_cols}) ON "
+                        f"{quoted_db}.{quoted_tb} {target} {user_host};"
+                    )
+            else:
+                raise ValueError("权限类型不合法")
+        except (AttributeError, IndexError, ValueError) as e:
+            return self._error_result(str(e))
+
+        if not grant_sql:
+            return self._error_result("授权语句不能为空")
+        return self.execute(db_name="mysql", sql=grant_sql)
+
+    def set_instance_user_lock(self, user_host, is_locked):
+        """实例账号管理功能，锁定/解锁账号"""
+        try:
+            user_host = self._normalize_user_host(user_host)
+        except ValueError as e:
+            return self._error_result(str(e))
+        if is_locked == "N":
+            lock_sql = f"ALTER USER {user_host} ACCOUNT LOCK;"
+        elif is_locked == "Y":
+            lock_sql = f"ALTER USER {user_host} ACCOUNT UNLOCK;"
+        else:
+            return self._error_result("锁定状态不合法")
+        return self.execute(db_name="mysql", sql=lock_sql)
+
     def drop_instance_user(self, user_host: str, **kwarg):
         """实例账号管理功能，删除实例账号"""
-        # escape
-        user_host = self.escape_string(user_host)
+        try:
+            user_host = self._normalize_user_host(user_host)
+        except ValueError as e:
+            return self._error_result(str(e))
         return self.execute(db_name="mysql", sql=f"DROP USER {user_host};")
 
     def reset_instance_user_pwd(self, user_host: str, reset_pwd: str, **kwargs):
         """实例账号管理功能，重置实例账号密码"""
-        # escape
-        user_host = self.escape_string(user_host)
-        reset_pwd = self.escape_string(reset_pwd)
+        try:
+            user_host = self._normalize_user_host(user_host)
+            reset_pwd = self._quote_literal(reset_pwd)
+        except ValueError as e:
+            return self._error_result(str(e))
         return self.execute(
-            db_name="mysql", sql=f"ALTER USER {user_host} IDENTIFIED BY '{reset_pwd}';"
+            db_name="mysql", sql=f"ALTER USER {user_host} IDENTIFIED BY {reset_pwd};"
         )
 
     def get_all_columns_by_tb(self, db_name, tb_name, **kwargs):
         """获取所有字段, 返回一个ResultSet"""
-        db_name = self.escape_string(db_name)
-        tb_name = self.escape_string(tb_name)
-        sql = f"""SELECT
+        sql = """SELECT
             COLUMN_NAME,
             COLUMN_TYPE,
             CHARACTER_SET_NAME,
@@ -712,13 +1077,13 @@ class MysqlEngine(EngineBase):
         FROM
             information_schema.COLUMNS
         WHERE
-            TABLE_SCHEMA = '{db_name}'
-                AND TABLE_NAME = '{tb_name}'
+            TABLE_SCHEMA = %(db_name)s
+                AND TABLE_NAME = %(tb_name)s
         ORDER BY ORDINAL_POSITION;"""
         result = self.query(
             db_name=db_name,
             sql=sql,
-            parameters=({"db_name": db_name, "tb_name": tb_name}),
+            parameters={"db_name": db_name, "tb_name": tb_name},
         )
         column_list = [row[0] for row in result.rows]
         result.rows = column_list
@@ -726,8 +1091,7 @@ class MysqlEngine(EngineBase):
 
     def describe_table(self, db_name, tb_name, **kwargs):
         """return ResultSet 类似查询"""
-        tb_name = self.escape_string(tb_name)
-        sql = f"show create table `{tb_name}`;"
+        sql = f"show create table {self._quote_identifier(tb_name)};"
         result = self.query(db_name=db_name, sql=sql)
         return result
 
@@ -800,6 +1164,69 @@ class MysqlEngine(EngineBase):
                 self.close()
         return result_set
 
+    @staticmethod
+    def _normalize_identifier(value):
+        if value is None:
+            return ""
+        value = str(value).strip()
+        if len(value) >= 2 and value[0] in ("`", "'", '"') and value[-1] == value[0]:
+            value = value[1:-1]
+        return value.replace("``", "`").lower()
+
+    @classmethod
+    def _sql_references_forbidden_privilege_object(cls, db_name, sql):
+        sql_lower = sql.lower()
+        for schema, tables in (
+            ("mysql", MYSQL_PRIVILEGE_TABLES),
+            ("information_schema", INFORMATION_SCHEMA_PRIVILEGE_TABLES),
+        ):
+            table_pattern = "|".join(re.escape(table) for table in sorted(tables))
+            if re.search(
+                rf"(?<![\w`])`?{schema}`?\s*\.\s*`?(?:{table_pattern})`?(?![\w`])",
+                sql_lower,
+            ):
+                return True
+
+        try:
+            table_refs = extract_tables(sql)
+        except Exception:
+            table_refs = ()
+
+        current_db = cls._normalize_identifier(db_name)
+        current_tables = None
+        if current_db == "mysql":
+            current_tables = MYSQL_PRIVILEGE_TABLES
+        elif current_db == "information_schema":
+            current_tables = INFORMATION_SCHEMA_PRIVILEGE_TABLES
+        if current_tables:
+            table_pattern = "|".join(
+                re.escape(table) for table in sorted(current_tables)
+            )
+            if re.search(
+                rf"\b(from|join|update|into|table)\s+`?(?:{table_pattern})`?(?![\w`])",
+                sql_lower,
+            ):
+                return True
+
+        for table_ref in table_refs:
+            schema = cls._normalize_identifier(table_ref.schema) or current_db
+            name = cls._normalize_identifier(table_ref.name)
+            if schema == "mysql" and name in MYSQL_PRIVILEGE_TABLES:
+                return True
+            if (
+                schema == "information_schema"
+                and name in INFORMATION_SCHEMA_PRIVILEGE_TABLES
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _sql_is_forbidden_account_statement(sql):
+        return bool(
+            re.match(r"^\s*show\s+grants\b", sql, re.I)
+            or re.match(r"^\s*show\s+create\s+user\b", sql, re.I)
+        )
+
     def query_check(self, db_name=None, sql=""):
         # 查询语句的检查、注释去除、切分
         result = {"msg": "", "bad_query": False, "filtered_sql": sql, "has_star": False}
@@ -817,24 +1244,18 @@ class MysqlEngine(EngineBase):
         if "*" in sql:
             result["has_star"] = True
             result["msg"] = "SQL语句中含有 * "
+        if self._sql_is_forbidden_account_statement(
+            sql
+        ) or self._sql_references_forbidden_privilege_object(db_name, sql):
+            result["bad_query"] = True
+            result["msg"] = "您无权查看该表"
+            return result
         # select语句先使用Explain判断语法是否正确
         if re.match(r"^select", sql, re.I):
             explain_result = self.query(db_name=db_name, sql=f"explain {sql}")
             if explain_result.error:
                 result["bad_query"] = True
                 result["msg"] = explain_result.error
-        # 不应该查看mysql.user表
-        if re.match(
-            ".*(\\s)+(mysql|`mysql`)(\\s)*\\.(\\s)*(user|`user`)((\\s)*|;).*",
-            sql.lower().replace("\n", ""),
-        ) or (
-            db_name == "mysql"
-            and re.match(
-                ".*(\\s)+(user|`user`)((\\s)*|;).*", sql.lower().replace("\n", "")
-            )
-        ):
-            result["bad_query"] = True
-            result["msg"] = "您无权查看该表"
 
         return result
 
@@ -905,7 +1326,17 @@ class MysqlEngine(EngineBase):
         # 禁用/高危语句检查
         critical_ddl_regex = self.config.get("critical_ddl_regex", "")
         ddl_dml_separation = self.config.get("ddl_dml_separation", False)
-        p = re.compile(critical_ddl_regex)
+        try:
+            p = self._compile_safe_regex(critical_ddl_regex)
+        except ValueError as e:
+            check_result.error_count += len(check_result.rows) or 1
+            for row in check_result.rows:
+                row.stagestatus = "驳回高危SQL"
+                row.errlevel = 2
+                row.errormessage = str(e)
+            if not check_result.rows:
+                check_result.error = str(e)
+            return check_result
         # 获取语句类型：DDL或者DML
         ddl_dml_flag = ""
         for row in check_result.rows:
@@ -921,7 +1352,30 @@ class MysqlEngine(EngineBase):
                 row.errlevel = 2
                 row.errormessage = "仅支持DML和DDL语句，查询语句请使用SQL查询功能！"
             # 高危语句
-            elif critical_ddl_regex and p.match(statement.strip().lower()):
+            elif critical_ddl_regex and p:
+                try:
+                    critical_match = p.match(
+                        statement.strip().lower(),
+                        timeout=CRITICAL_DDL_REGEX_TIMEOUT,
+                    )
+                except TimeoutError:
+                    check_result.error_count += 1
+                    row.stagestatus = "驳回高危SQL"
+                    row.errlevel = 2
+                    row.errormessage = (
+                        "critical_ddl_regex匹配超时，已拒绝执行以避免ReDoS"
+                    )
+                    continue
+                if not critical_match:
+                    if ddl_dml_separation and syntax_type in ("DDL", "DML"):
+                        if ddl_dml_flag == "":
+                            ddl_dml_flag = syntax_type
+                        elif ddl_dml_flag != syntax_type:
+                            check_result.error_count += 1
+                            row.stagestatus = "驳回不支持语句"
+                            row.errlevel = 2
+                            row.errormessage = "DDL语句和DML语句不能同时执行！"
+                    continue
                 check_result.error_count += 1
                 row.stagestatus = "驳回高危SQL"
                 row.errlevel = 2
@@ -988,20 +1442,20 @@ class MysqlEngine(EngineBase):
     def get_variables(self, variables=None):
         """获取实例参数"""
         if variables:
-            variables = (
-                "','".join(variables)
-                if isinstance(variables, list)
-                else "','".join(list(variables))
-            )
-            sql = f"""show global variables where variable_name in ('{variables}');"""
+            variables = self._as_list(variables)
+            placeholders = ",".join(["%s"] * len(variables))
+            sql = f"show global variables where variable_name in ({placeholders});"
+            return self.query(sql=sql, parameters=tuple(variables))
         else:
             sql = "show global variables;"
         return self.query(sql=sql)
 
     def set_variable(self, variable_name, variable_value):
         """修改实例参数值"""
-        sql = f"""set global {variable_name}={variable_value};"""
-        return self.query(sql=sql)
+        if not variable_name or not self.VARIABLE_NAME_RE.match(str(variable_name)):
+            return self._error_result("参数名称不合法")
+        sql = f"set global {variable_name}=%s;"
+        return self.query(sql=sql, parameters=(variable_value,))
 
     def osc_control(self, **kwargs):
         """控制osc执行，获取进度、终止、暂停、恢复等
@@ -1016,29 +1470,38 @@ class MysqlEngine(EngineBase):
         **kwargs,
     ):
         """获取连接信息"""
-        # escape
-        command_type = self.escape_string(command_type)
         if not command_type:
             command_type = "Query"
         if command_type == "All":
             sql = base_sql + ";"
+            parameters = None
         elif command_type == "Not Sleep":
-            sql = "{} where command<>'Sleep';".format(base_sql)
+            sql = "{} where command<>%s;".format(base_sql)
+            parameters = ("Sleep",)
         else:
-            sql = "{} where command= '{}';".format(base_sql, command_type)
+            sql = "{} where command=%s;".format(base_sql)
+            parameters = (command_type,)
 
-        return self.query("information_schema", sql)
+        return self.query("information_schema", sql, parameters=parameters)
 
     def get_kill_command(self, thread_ids, thread_ids_check=True):
         """由传入的线程列表生成kill命令"""
         # 校验传参
         if thread_ids_check:
-            if [i for i in thread_ids if not isinstance(i, int)]:
+            try:
+                thread_ids = self._validate_thread_ids(thread_ids)
+            except ValueError:
                 return None
-        sql = "select concat('kill ', id, ';') from information_schema.processlist where id in ({});".format(
-            ",".join(str(tid) for tid in thread_ids)
+        if not thread_ids:
+            return ""
+        placeholders = ",".join(["%s"] * len(thread_ids))
+        sql = (
+            "select concat('kill ', id, ';') from information_schema.processlist "
+            f"where id in ({placeholders});"
         )
-        all_kill_sql = self.query("information_schema", sql)
+        all_kill_sql = self.query(
+            "information_schema", sql, parameters=tuple(thread_ids)
+        )
         kill_sql = ""
         for row in all_kill_sql.rows:
             kill_sql = kill_sql + row[0]
@@ -1049,12 +1512,20 @@ class MysqlEngine(EngineBase):
         """kill线程"""
         # 校验传参
         if thread_ids_check:
-            if [i for i in thread_ids if not isinstance(i, int)]:
+            try:
+                thread_ids = self._validate_thread_ids(thread_ids)
+            except ValueError:
                 return ResultSet(full_sql="")
-        sql = "select concat('kill ', id, ';') from information_schema.processlist where id in ({});".format(
-            ",".join(str(tid) for tid in thread_ids)
+        if not thread_ids:
+            return ResultSet(full_sql="")
+        placeholders = ",".join(["%s"] * len(thread_ids))
+        sql = (
+            "select concat('kill ', id, ';') from information_schema.processlist "
+            f"where id in ({placeholders});"
         )
-        all_kill_sql = self.query("information_schema", sql)
+        all_kill_sql = self.query(
+            "information_schema", sql, parameters=tuple(thread_ids)
+        )
         kill_sql = ""
         for row in all_kill_sql.rows:
             kill_sql = kill_sql + row[0]
@@ -1062,12 +1533,17 @@ class MysqlEngine(EngineBase):
 
     def tablespace(self, offset=0, row_count=14, schema_search=""):
         """获取表空间信息"""
+        try:
+            offset = self._coerce_int(offset, "offset", minimum=0)
+            row_count = self._coerce_int(row_count, "row_count", minimum=0)
+        except ValueError as e:
+            return self._error_result(str(e))
         search_condition = ""
+        parameters = []
         if schema_search:
-            search_escaped = self.escape_string(schema_search)
-            search_condition = " AND (table_schema LIKE '%{keyword}%' OR table_name LIKE '%{keyword}%')".format(
-                keyword=search_escaped
-            )
+            search_condition = " AND (table_schema LIKE %s OR table_name LIKE %s)"
+            search_keyword = f"%{schema_search}%"
+            parameters.extend([search_keyword, search_keyword])
         sql = """
         SELECT
           table_schema AS table_schema,
@@ -1082,24 +1558,27 @@ class MysqlEngine(EngineBase):
         FROM information_schema.tables 
         WHERE table_schema NOT IN ('information_schema', 'performance_schema', 'mysql', 'test', 'sys'){search_condition}
           ORDER BY total_size DESC 
-        LIMIT {},{};""".format(offset, row_count, search_condition=search_condition)
-        return self.query("information_schema", sql)
+        LIMIT %s,%s;""".format(search_condition=search_condition)
+        parameters.extend([offset, row_count])
+        return self.query("information_schema", sql, parameters=tuple(parameters))
 
     def tablespace_count(self, schema_search=""):
         """获取表空间数量"""
         search_condition = ""
+        parameters = []
         if schema_search:
-            search_escaped = self.escape_string(schema_search)
-            search_condition = " AND (table_schema LIKE '%{keyword}%' OR table_name LIKE '%{keyword}%')".format(
-                keyword=search_escaped
-            )
+            search_condition = " AND (table_schema LIKE %s OR table_name LIKE %s)"
+            search_keyword = f"%{schema_search}%"
+            parameters.extend([search_keyword, search_keyword])
         sql = """
         SELECT count(*)
         FROM information_schema.tables 
         WHERE table_schema NOT IN ('information_schema', 'performance_schema', 'mysql', 'test', 'sys'){search_condition}""".format(
             search_condition=search_condition
         )
-        return self.query("information_schema", sql)
+        return self.query(
+            "information_schema", sql, parameters=tuple(parameters) or None
+        )
 
     def trxandlocks(self):
         """获取锁等待信息"""

--- a/sql/engines/test_mysql.py
+++ b/sql/engines/test_mysql.py
@@ -1159,6 +1159,7 @@ class TestMysql(SimpleTestCase):
         query.return_value = ResultSet()
         engine = MysqlEngine(instance=self.ins1)
         engine._server_version = (8, 0, 1)
+        engine._server_info = "MySQL 8.0.1"
 
         engine.trxandlocks()
 

--- a/sql/engines/test_mysql.py
+++ b/sql/engines/test_mysql.py
@@ -1340,3 +1340,541 @@ class TestMysql(SimpleTestCase):
             user_host="`u`@`%`", is_locked="N"
         )
         engine.execute.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    #  _quote_identifier / _quote_literal / _quote_account_part 错误分支   #
+    # ------------------------------------------------------------------ #
+    def test_quote_identifier_errors(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._quote_identifier(None)
+        with self.assertRaises(ValueError):
+            MysqlEngine._quote_identifier("")
+        with self.assertRaises(ValueError):
+            MysqlEngine._quote_identifier("ab\x00cd")
+
+    def test_quote_literal_errors(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._quote_literal(None)
+        with self.assertRaises(ValueError):
+            MysqlEngine._quote_literal("ab\x00cd")
+
+    def test_quote_account_part_errors(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._quote_account_part(None)
+        with self.assertRaises(ValueError):
+            MysqlEngine._quote_account_part("ab\x00cd")
+
+    # ------------------------------------------------------------------ #
+    #  _parse_account_part 各种引号/转义/边界                               #
+    # ------------------------------------------------------------------ #
+    def test_parse_account_part_unquoted(self):
+        value, pos = MysqlEngine._parse_account_part("user@host", 0)
+        self.assertEqual(value, "user")
+        self.assertEqual(pos, 4)
+
+    def test_parse_account_part_leading_space(self):
+        value, pos = MysqlEngine._parse_account_part("  user@host", 0)
+        self.assertEqual(value, "user")
+
+    def test_parse_account_part_empty_after_space(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._parse_account_part("   ", 0)
+
+    def test_parse_account_part_unquoted_empty_value(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._parse_account_part("@host", 0)
+
+    def test_parse_account_part_backtick_escaped(self):
+        # `us``er` -> user with embedded backtick
+        value, pos = MysqlEngine._parse_account_part("`us``er`@host", 0)
+        self.assertEqual(value, "us`er")
+
+    def test_parse_account_part_single_quoted(self):
+        value, pos = MysqlEngine._parse_account_part("'user'@host", 0)
+        self.assertEqual(value, "user")
+
+    def test_parse_account_part_single_quoted_escaped_backslash(self):
+        # 'us\'er' -> us'er (backslash escape for single-quoted)
+        value, pos = MysqlEngine._parse_account_part("'us\\'er'@host", 0)
+        self.assertEqual(value, "us'er")
+
+    def test_parse_account_part_single_quoted_doubled(self):
+        # 'us''er' -> us'er (doubled quote escape)
+        value, pos = MysqlEngine._parse_account_part("'us''er'@host", 0)
+        self.assertEqual(value, "us'er")
+
+    def test_parse_account_part_double_quoted(self):
+        value, pos = MysqlEngine._parse_account_part('"user"@host', 0)
+        self.assertEqual(value, "user")
+
+    def test_parse_account_part_double_quoted_escaped_backslash(self):
+        value, pos = MysqlEngine._parse_account_part('"us\\"er"@host', 0)
+        self.assertEqual(value, 'us"er')
+
+    def test_parse_account_part_double_quoted_doubled(self):
+        value, pos = MysqlEngine._parse_account_part('"us""er"@host', 0)
+        self.assertEqual(value, 'us"er')
+
+    def test_parse_account_part_unterminated_quote(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._parse_account_part("'user", 0)
+
+    # ------------------------------------------------------------------ #
+    #  _parse_user_host 边界                                              #
+    # ------------------------------------------------------------------ #
+    def test_parse_user_host_none(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._parse_user_host(None)
+
+    def test_parse_user_host_no_at(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._parse_user_host("user_only")
+
+    def test_parse_user_host_trailing_garbage(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._parse_user_host("`u`@`%` extra")
+
+    # ------------------------------------------------------------------ #
+    #  _coerce_int 错误分支                                               #
+    # ------------------------------------------------------------------ #
+    def test_coerce_int_bool_rejected(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._coerce_int(True, "test")
+
+    def test_coerce_int_non_numeric(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._coerce_int("abc", "test")
+
+    def test_coerce_int_below_minimum(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._coerce_int(-1, "test", minimum=0)
+
+    # ------------------------------------------------------------------ #
+    #  _validate_thread_ids 错误分支                                       #
+    # ------------------------------------------------------------------ #
+    def test_validate_thread_ids_not_list(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._validate_thread_ids("not_a_list")
+
+    def test_validate_thread_ids_bool_element(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._validate_thread_ids([True])
+
+    def test_validate_thread_ids_string_element(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._validate_thread_ids([1, "2"])
+
+    # ------------------------------------------------------------------ #
+    #  _normalize_privileges                                              #
+    # ------------------------------------------------------------------ #
+    def test_normalize_privileges_empty(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._normalize_privileges([], MysqlEngine.GLOBAL_PRIVILEGES)
+
+    def test_normalize_privileges_none(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._normalize_privileges(None, MysqlEngine.GLOBAL_PRIVILEGES)
+
+    # ------------------------------------------------------------------ #
+    #  _as_list 边界                                                      #
+    # ------------------------------------------------------------------ #
+    def test_as_list_none(self):
+        self.assertEqual(MysqlEngine._as_list(None), [])
+
+    def test_as_list_single_value(self):
+        self.assertEqual(MysqlEngine._as_list("single"), ["single"])
+
+    # ------------------------------------------------------------------ #
+    #  _compile_safe_regex                                                #
+    # ------------------------------------------------------------------ #
+    def test_compile_safe_regex_too_long(self):
+        with self.assertRaises(ValueError):
+            MysqlEngine._compile_safe_regex("a" * 2049)
+
+    # ------------------------------------------------------------------ #
+    #  escape_string                                                      #
+    # ------------------------------------------------------------------ #
+    def test_escape_string(self):
+        engine = MysqlEngine(instance=self.ins1)
+        self.assertEqual(engine.escape_string("it's"), "it\\'s")
+
+    # ------------------------------------------------------------------ #
+    #  kill_connection ValueError path                                     #
+    # ------------------------------------------------------------------ #
+    def test_kill_connection_invalid_thread_id(self):
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.kill_connection("abc")
+        self.assertIsNotNone(result.error)
+
+    # ------------------------------------------------------------------ #
+    #  get_bind_users                                                     #
+    # ------------------------------------------------------------------ #
+    @patch.object(MysqlEngine, "query")
+    def test_get_bind_users(self, query):
+        query.return_value = ResultSet(rows=[("'u'@'%'", "some_db")])
+        engine = MysqlEngine(instance=self.ins1)
+        rows = engine.get_bind_users("some_db")
+        self.assertEqual(rows, [("'u'@'%'", "some_db")])
+
+    # ------------------------------------------------------------------ #
+    #  get_instance_users_summary — MariaDB lock SQL branch               #
+    # ------------------------------------------------------------------ #
+    @patch("MySQLdb.connect")
+    @patch.object(MysqlEngine, "query")
+    def test_get_instance_users_summary_mariadb_lock(self, query, connect):
+        connect.return_value.get_server_info.return_value = "10.4.2-MariaDB"
+        result = ResultSet(rows=[("root", "localhost", "Y")])
+        grants = ResultSet(rows=[("GRANT ALL",)])
+        query.side_effect = [result, grants]
+        engine = MysqlEngine(instance=self.ins1)
+
+        summary = engine.get_instance_users_summary()
+
+        self.assertEqual(summary.rows[0]["is_locked"], "Y")
+        self.assertEqual(summary.rows[0]["user"], "root")
+        # 确认使用了 MariaDB 的 global_priv SQL
+        self.assertIn("global_priv", query.call_args_list[0].args[1])
+
+    # ------------------------------------------------------------------ #
+    #  create_instance_user — ValueError + empty accounts                  #
+    # ------------------------------------------------------------------ #
+    @patch.object(MysqlEngine, "execute")
+    def test_create_instance_user_null_byte_password(self, execute):
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.create_instance_user(
+            user="u", host="%", password1="pass\x00word", remark=""
+        )
+        self.assertIsNotNone(result.error)
+        execute.assert_not_called()
+
+    @patch.object(MysqlEngine, "execute")
+    def test_create_instance_user_null_byte_user(self, execute):
+        """覆盖 create_instance_user 的 ValueError catch (line 952-953)"""
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.create_instance_user(
+            user="u\x00x", host="%", password1="pwd", remark=""
+        )
+        self.assertIsNotNone(result.error)
+        execute.assert_not_called()
+
+    def test_parse_user_host_with_space_before_at(self):
+        """覆盖 _parse_user_host line 264 — 引号括起的 user 后面有空格再到 @"""
+        user, host = MysqlEngine._parse_user_host("`user` @`host`")
+        self.assertEqual(user, "user")
+        self.assertEqual(host, "host")
+
+    def test_reset_instance_user_pwd_null_byte(self):
+        """覆盖 reset_instance_user_pwd ValueError catch (lines 1062-1063)"""
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.reset_instance_user_pwd("`u`@`%`", "pwd\x00bad")
+        self.assertIsNotNone(result.error)
+
+    @patch.object(MysqlEngine, "execute")
+    def test_grant_instance_user_db_no_db_names(self, execute):
+        """覆盖 grant_instance_user 空 grant_sql 路径 (line 1032)"""
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.grant_instance_user(
+            user_host="`u`@`%`",
+            op_type=0,
+            priv_type=1,
+            privs={"db_privs": ["SELECT"]},
+            db_names=None,
+        )
+        self.assertEqual(result.error, "授权语句不能为空")
+        execute.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    #  grant_instance_user — global (priv_type=0)                          #
+    # ------------------------------------------------------------------ #
+    @patch.object(MysqlEngine, "execute")
+    def test_grant_instance_user_global_privileges(self, execute):
+        execute.return_value = ResultSet()
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.grant_instance_user(
+            user_host="`u`@`%`",
+            op_type=0,
+            priv_type=0,
+            privs={"global_privs": ["SELECT", "INSERT"]},
+        )
+        self.assertIsNone(result.error)
+        self.assertIn("ON *.*", execute.call_args.kwargs["sql"])
+        self.assertIn("TO", execute.call_args.kwargs["sql"])
+
+    # ------------------------------------------------------------------ #
+    #  grant_instance_user — revoke (op_type=1)                            #
+    # ------------------------------------------------------------------ #
+    @patch.object(MysqlEngine, "execute")
+    def test_grant_instance_user_revoke(self, execute):
+        execute.return_value = ResultSet()
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.grant_instance_user(
+            user_host="`u`@`%`",
+            op_type=1,
+            priv_type=0,
+            privs={"global_privs": ["SELECT"]},
+        )
+        self.assertIsNone(result.error)
+        self.assertIn("REVOKE", execute.call_args.kwargs["sql"])
+        self.assertIn("FROM", execute.call_args.kwargs["sql"])
+
+    # ------------------------------------------------------------------ #
+    #  grant_instance_user — invalid op_type                               #
+    # ------------------------------------------------------------------ #
+    def test_grant_instance_user_invalid_op_type(self):
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.grant_instance_user(
+            user_host="`u`@`%`",
+            op_type=99,
+            priv_type=0,
+            privs={"global_privs": ["SELECT"]},
+        )
+        self.assertEqual(result.error, "操作类型不合法")
+
+    # ------------------------------------------------------------------ #
+    #  grant_instance_user — table (priv_type=2)                           #
+    # ------------------------------------------------------------------ #
+    @patch.object(MysqlEngine, "execute")
+    def test_grant_instance_user_table_privileges(self, execute):
+        execute.return_value = ResultSet()
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.grant_instance_user(
+            user_host="`u`@`%`",
+            op_type=0,
+            priv_type=2,
+            privs={"tb_privs": ["SELECT"]},
+            db_names=["mydb"],
+            tb_names=["t1", "t2"],
+        )
+        self.assertIsNone(result.error)
+        sql = execute.call_args.kwargs["sql"]
+        self.assertIn("`mydb`.`t1`", sql)
+        self.assertIn("`mydb`.`t2`", sql)
+
+    # ------------------------------------------------------------------ #
+    #  grant_instance_user — column (priv_type=3)                          #
+    # ------------------------------------------------------------------ #
+    @patch.object(MysqlEngine, "execute")
+    def test_grant_instance_user_column_privileges(self, execute):
+        execute.return_value = ResultSet()
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.grant_instance_user(
+            user_host="`u`@`%`",
+            op_type=0,
+            priv_type=3,
+            privs={"col_privs": ["SELECT", "UPDATE"]},
+            db_names=["mydb"],
+            tb_names=["t1"],
+            col_names=["col1", "col2"],
+        )
+        self.assertIsNone(result.error)
+        sql = execute.call_args.kwargs["sql"]
+        self.assertIn("SELECT(`col1`,`col2`)", sql)
+        self.assertIn("UPDATE(`col1`,`col2`)", sql)
+
+    # ------------------------------------------------------------------ #
+    #  grant_instance_user — column with no col_names                      #
+    # ------------------------------------------------------------------ #
+    def test_grant_instance_user_column_empty_cols(self):
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.grant_instance_user(
+            user_host="`u`@`%`",
+            op_type=0,
+            priv_type=3,
+            privs={"col_privs": ["SELECT"]},
+            db_names=["mydb"],
+            tb_names=["t1"],
+            col_names=None,
+        )
+        self.assertEqual(result.error, "列名不能为空")
+
+    # ------------------------------------------------------------------ #
+    #  grant_instance_user — invalid priv_type                             #
+    # ------------------------------------------------------------------ #
+    def test_grant_instance_user_invalid_priv_type(self):
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.grant_instance_user(
+            user_host="`u`@`%`",
+            op_type=0,
+            priv_type=99,
+            privs={"global_privs": ["SELECT"]},
+        )
+        self.assertEqual(result.error, "权限类型不合法")
+
+    # ------------------------------------------------------------------ #
+    #  set_instance_user_lock — unlock + invalid status                    #
+    # ------------------------------------------------------------------ #
+    @patch.object(MysqlEngine, "execute")
+    def test_set_instance_user_lock_unlock(self, execute):
+        execute.return_value = ResultSet()
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.set_instance_user_lock("`u`@`%`", "Y")
+        self.assertIsNone(result.error)
+        self.assertIn("ACCOUNT UNLOCK", execute.call_args.kwargs["sql"])
+
+    def test_set_instance_user_lock_invalid_status(self):
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.set_instance_user_lock("`u`@`%`", "X")
+        self.assertEqual(result.error, "锁定状态不合法")
+
+    # ------------------------------------------------------------------ #
+    #  query — MariaDB max_statement_time branch                           #
+    # ------------------------------------------------------------------ #
+    @patch("MySQLdb.connect")
+    def test_query_mariadb_max_statement_time(self, connect):
+        cursor = Mock()
+        cursor.execute.return_value = 0
+        cursor.fetchall.return_value = []
+        cursor.description = None
+        connect.return_value.cursor.return_value = cursor
+        connect.return_value.get_server_info.return_value = "10.5.0-MariaDB"
+        engine = MysqlEngine(instance=self.ins1)
+
+        engine.query(sql="select 1")
+
+        # 第一个 execute 应该是 max_statement_time (MariaDB)
+        first_call_sql = cursor.execute.call_args_list[0].args[0]
+        self.assertIn("max_statement_time", first_call_sql)
+
+    # ------------------------------------------------------------------ #
+    #  _normalize_identifier                                               #
+    # ------------------------------------------------------------------ #
+    def test_normalize_identifier(self):
+        self.assertEqual(MysqlEngine._normalize_identifier(None), "")
+        self.assertEqual(MysqlEngine._normalize_identifier("`MyDB`"), "mydb")
+        self.assertEqual(MysqlEngine._normalize_identifier("'MyDB'"), "mydb")
+        self.assertEqual(MysqlEngine._normalize_identifier('"MyDB"'), "mydb")
+        self.assertEqual(MysqlEngine._normalize_identifier("plain"), "plain")
+        self.assertEqual(MysqlEngine._normalize_identifier("`my``db`"), "my`db")
+
+    # ------------------------------------------------------------------ #
+    #  _sql_references_forbidden_privilege_object — extract_tables 异常     #
+    # ------------------------------------------------------------------ #
+    @patch("sql.engines.mysql.extract_tables", side_effect=Exception("parse error"))
+    def test_sql_references_forbidden_extract_tables_error(self, _extract):
+        result = MysqlEngine._sql_references_forbidden_privilege_object(
+            "some_db", "select 1 from normal_table"
+        )
+        self.assertFalse(result)
+
+    def test_sql_references_forbidden_mysql_schema_via_regex(self):
+        result = MysqlEngine._sql_references_forbidden_privilege_object(
+            "some_db", "select * from mysql.user"
+        )
+        self.assertTrue(result)
+
+    def test_sql_references_forbidden_info_schema_via_regex(self):
+        result = MysqlEngine._sql_references_forbidden_privilege_object(
+            "some_db", "select * from information_schema.user_privileges"
+        )
+        self.assertTrue(result)
+
+    def test_sql_references_forbidden_via_extract_tables(self):
+        # 使用子查询方式，extract_tables 可以解析出 mysql.global_grants
+        result = MysqlEngine._sql_references_forbidden_privilege_object(
+            "some_db", "select * from (select * from mysql.global_grants) t"
+        )
+        self.assertTrue(result)
+
+    def test_sql_references_forbidden_info_schema_via_extract_tables(self):
+        result = MysqlEngine._sql_references_forbidden_privilege_object(
+            "some_db",
+            "select * from (select * from information_schema.user_privileges) t",
+        )
+        self.assertTrue(result)
+
+    # ------------------------------------------------------------------ #
+    #  _sql_is_forbidden_account_statement                                 #
+    # ------------------------------------------------------------------ #
+    def test_sql_is_forbidden_show_create_user(self):
+        self.assertTrue(
+            MysqlEngine._sql_is_forbidden_account_statement("SHOW CREATE USER `u`@`%`")
+        )
+        self.assertFalse(MysqlEngine._sql_is_forbidden_account_statement("SELECT 1"))
+
+    # ------------------------------------------------------------------ #
+    #  execute_check — invalid regex with empty rows                       #
+    # ------------------------------------------------------------------ #
+    @patch("sql.engines.mysql.GoInceptionEngine")
+    def test_execute_check_invalid_regex_empty_rows(self, inception):
+        inception.return_value.execute_check.return_value = ReviewSet(rows=[])
+        engine = MysqlEngine(instance=self.ins1)
+        config = {"critical_ddl_regex": "[", "ddl_dml_separation": False}
+        engine.config.get = Mock(
+            side_effect=lambda key, default=None: config.get(key, default)
+        )
+
+        result = engine.execute_check(db_name="archery", sql="update user set id=1")
+
+        self.assertIn("critical_ddl_regex配置不合法", result.error)
+
+    # ------------------------------------------------------------------ #
+    #  execute_check — DDL/DML separation with critical_ddl_regex (no match) #
+    # ------------------------------------------------------------------ #
+    @patch("sql.engines.mysql.GoInceptionEngine")
+    def test_execute_check_ddl_dml_separation_with_critical_regex(self, inception):
+        rows = [
+            ReviewResult(id=1, sql="create table t(id int)"),
+            ReviewResult(id=2, sql="insert into t values(1)"),
+        ]
+        inception.return_value.execute_check.return_value = ReviewSet(rows=rows)
+        engine = MysqlEngine(instance=self.ins1)
+        # critical_ddl_regex 有值但不匹配任何语句，同时开启 ddl_dml_separation
+        config = {"critical_ddl_regex": "^drop database", "ddl_dml_separation": True}
+        engine.config.get = Mock(
+            side_effect=lambda key, default=None: config.get(key, default)
+        )
+
+        result = engine.execute_check(
+            db_name="archery",
+            sql="create table t(id int);insert into t values(1);",
+        )
+
+        self.assertEqual(result.error_count, 1)
+        self.assertEqual(result.rows[1].errormessage, "DDL语句和DML语句不能同时执行！")
+
+    # ------------------------------------------------------------------ #
+    #  get_kill_command / kill — empty thread_ids                           #
+    # ------------------------------------------------------------------ #
+    @patch.object(MysqlEngine, "query")
+    def test_get_kill_command_empty_ids(self, query):
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.get_kill_command([], thread_ids_check=False)
+        self.assertEqual(result, "")
+        query.assert_not_called()
+
+    @patch.object(MysqlEngine, "query")
+    def test_kill_empty_ids(self, query):
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.kill([], thread_ids_check=False)
+        self.assertIsInstance(result, ResultSet)
+        query.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    #  tablespace — invalid offset/row_count                               #
+    # ------------------------------------------------------------------ #
+    def test_tablespace_invalid_offset(self):
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.tablespace(offset="abc")
+        self.assertIsNotNone(result.error)
+
+    def test_tablespace_negative_row_count(self):
+        engine = MysqlEngine(instance=self.ins1)
+        result = engine.tablespace(row_count=-1)
+        self.assertIsNotNone(result.error)
+
+    # ------------------------------------------------------------------ #
+    #  close                                                               #
+    # ------------------------------------------------------------------ #
+    def test_close_with_conn(self):
+        engine = MysqlEngine(instance=self.ins1)
+        mock_conn = Mock()
+        engine.conn = mock_conn
+        engine.close()
+        mock_conn.close.assert_called_once()
+        self.assertIsNone(engine.conn)
+
+    def test_close_without_conn(self):
+        engine = MysqlEngine(instance=self.ins1)
+        engine.conn = None
+        engine.close()  # should not raise
+        self.assertIsNone(engine.conn)

--- a/sql/engines/test_mysql.py
+++ b/sql/engines/test_mysql.py
@@ -1,11 +1,13 @@
+import json
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import patch, Mock, ANY
 
 import MySQLdb
-from django.test import SimpleTestCase
+from django.test import RequestFactory, SimpleTestCase
 
 from common.config import SysConfig
+from sql import instance_account
 from sql.engines import ResultSet, ReviewSet
 from sql.engines.models import ReviewResult
 from sql.engines.mysql import MysqlEngine, MysqlForkType
@@ -652,13 +654,23 @@ class TestMysql(SimpleTestCase):
         _connect.return_value.get_server_info.return_value = "5.7.20-16log"
         new_engine = MysqlEngine(instance=self.ins1)
         new_engine.get_variables(variables=["binlog_format"])
-        _query.assert_called()
+        _query.assert_called_once_with(
+            sql="show global variables where variable_name in (%s);",
+            parameters=("binlog_format",),
+        )
 
     @patch.object(MysqlEngine, "query")
     def test_set_variable(self, _query):
         new_engine = MysqlEngine(instance=self.ins1)
         new_engine.set_variable("binlog_format", "ROW")
-        _query.assert_called_once_with(sql="set global binlog_format=ROW;")
+        _query.assert_called_once_with(
+            sql="set global binlog_format=%s;", parameters=("ROW",)
+        )
+
+        _query.reset_mock()
+        result = new_engine.set_variable("binlog_format;drop user u", "ROW")
+        self.assertEqual(result.error, "参数名称不合法")
+        _query.assert_not_called()
 
     @patch("sql.engines.mysql.GoInceptionEngine")
     def test_osc_go_inception(self, _inception_engine):
@@ -680,7 +692,7 @@ class TestMysql(SimpleTestCase):
     def test_kill_connection(self, _query):
         new_engine = MysqlEngine(instance=self.ins1)
         new_engine.kill_connection(100)
-        _query.assert_called_once_with(sql="kill 100")
+        _query.assert_called_once_with(sql="kill %s", parameters=(100,))
 
     @patch("MySQLdb.connect")
     @patch.object(MysqlEngine, "query")
@@ -790,7 +802,7 @@ class TestMysql(SimpleTestCase):
         self.assertEqual(user_summary.error, "query error")
 
         result_with_lock = ResultSet()
-        result_with_lock.rows = [("'root'@'localhost'", "root", "localhost", "N")]
+        result_with_lock.rows = [("root", "localhost", "N")]
         _query.return_value = result_with_lock
         _connect.return_value.get_server_info.return_value = "5.7.20-16log"
         self.assertTupleEqual(new_engine.server_version, (5, 7, 20))
@@ -801,10 +813,10 @@ class TestMysql(SimpleTestCase):
                 {
                     "host": "localhost",
                     "is_locked": "N",
-                    "privileges": [("'root'@'localhost'", "root", "localhost", "N")],
+                    "privileges": [("root", "localhost", "N")],
                     "saved": False,
                     "user": "root",
-                    "user_host": "'root'@'localhost'",
+                    "user_host": "`root`@`localhost`",
                 }
             ],
         )
@@ -813,7 +825,7 @@ class TestMysql(SimpleTestCase):
     @patch.object(MysqlEngine, "query")
     def test_get_instance_users_summary_without_lock(self, _query, _connect):
         result_without_lock = ResultSet()
-        result_without_lock.rows = [("'root'@'localhost'", "root", "localhost")]
+        result_without_lock.rows = [("root", "localhost")]
         _query.return_value = result_without_lock
         mysql_engine = MysqlEngine(instance=self.ins1)
         _connect.return_value.get_server_info.return_value = "5.7.5-16log"
@@ -825,10 +837,10 @@ class TestMysql(SimpleTestCase):
                 {
                     "host": "localhost",
                     "is_locked": None,
-                    "privileges": [("'root'@'localhost'", "root", "localhost")],
+                    "privileges": [("root", "localhost")],
                     "saved": False,
                     "user": "root",
-                    "user_host": "'root'@'localhost'",
+                    "user_host": "`root`@`localhost`",
                 }
             ],
         )
@@ -997,6 +1009,16 @@ class TestMysql(SimpleTestCase):
         self.assertTrue(forbidden["bad_query"])
         self.assertEqual(forbidden["msg"], "您无权查看该表")
 
+        forbidden = engine.query_check(
+            db_name="information_schema", sql="select * from user_privileges"
+        )
+        self.assertTrue(forbidden["bad_query"])
+        self.assertEqual(forbidden["msg"], "您无权查看该表")
+
+        forbidden = engine.query_check(sql="show grants for `u`@`%`")
+        self.assertTrue(forbidden["bad_query"])
+        self.assertEqual(forbidden["msg"], "您无权查看该表")
+
     @patch("sql.engines.mysql.GoInceptionEngine")
     def test_execute_check_inception_error_and_ddl_dml_separation(self, inception):
         check_error = ReviewSet()
@@ -1025,6 +1047,43 @@ class TestMysql(SimpleTestCase):
 
         self.assertEqual(result.error_count, 1)
         self.assertEqual(result.rows[1].errormessage, "DDL语句和DML语句不能同时执行！")
+
+    @patch("sql.engines.mysql.GoInceptionEngine")
+    def test_execute_check_rejects_critical_regex_timeout(self, inception):
+        rows = [ReviewResult(id=1, sql="update user set id=1")]
+        inception.return_value.execute_check.return_value = ReviewSet(rows=rows)
+        engine = MysqlEngine(instance=self.ins1)
+        config = {"critical_ddl_regex": "(a+)+$", "ddl_dml_separation": False}
+        engine.config.get = Mock(
+            side_effect=lambda key, default=None: config.get(key, default)
+        )
+
+        with patch.object(engine, "_compile_safe_regex") as compile_safe_regex:
+            compiled = Mock()
+            compiled.match.side_effect = TimeoutError()
+            compile_safe_regex.return_value = compiled
+            result = engine.execute_check(db_name="archery", sql="update user set id=1")
+
+        self.assertEqual(result.error_count, 1)
+        self.assertEqual(
+            result.rows[0].errormessage,
+            "critical_ddl_regex匹配超时，已拒绝执行以避免ReDoS",
+        )
+
+    @patch("sql.engines.mysql.GoInceptionEngine")
+    def test_execute_check_rejects_invalid_critical_regex(self, inception):
+        rows = [ReviewResult(id=1, sql="update user set id=1")]
+        inception.return_value.execute_check.return_value = ReviewSet(rows=rows)
+        engine = MysqlEngine(instance=self.ins1)
+        config = {"critical_ddl_regex": "[", "ddl_dml_separation": False}
+        engine.config.get = Mock(
+            side_effect=lambda key, default=None: config.get(key, default)
+        )
+
+        result = engine.execute_check(db_name="archery", sql="update user set id=1")
+
+        self.assertEqual(result.error_count, 1)
+        self.assertIn("critical_ddl_regex配置不合法", result.rows[0].errormessage)
 
     @patch.object(MysqlEngine, "query")
     def test_execute_workflow_read_only(self, query):
@@ -1062,8 +1121,10 @@ class TestMysql(SimpleTestCase):
         engine.processlist("")
         engine.processlist("Query'")
 
-        self.assertIn("command= 'Query';", query.call_args_list[0].args[1])
-        self.assertIn("Query\\'", query.call_args_list[1].args[1])
+        self.assertIn("command=%s;", query.call_args_list[0].args[1])
+        self.assertEqual(query.call_args_list[0].kwargs["parameters"], ("Query",))
+        self.assertIn("command=%s;", query.call_args_list[1].args[1])
+        self.assertEqual(query.call_args_list[1].kwargs["parameters"], ("Query'",))
 
     @patch.object(MysqlEngine, "query")
     def test_get_kill_command_and_kill_reject_invalid_ids(self, query):
@@ -1083,8 +1144,15 @@ class TestMysql(SimpleTestCase):
         engine.tablespace(schema_search="app_'")
         engine.tablespace_count(schema_search="app_'")
 
-        self.assertIn("app_\\'", query.call_args_list[0].args[1])
-        self.assertIn("app_\\'", query.call_args_list[1].args[1])
+        self.assertIn("table_schema LIKE %s", query.call_args_list[0].args[1])
+        self.assertEqual(
+            query.call_args_list[0].kwargs["parameters"],
+            ("%app_'%", "%app_'%", 0, 14),
+        )
+        self.assertIn("table_schema LIKE %s", query.call_args_list[1].args[1])
+        self.assertEqual(
+            query.call_args_list[1].kwargs["parameters"], ("%app_'%", "%app_'%")
+        )
 
     @patch.object(MysqlEngine, "query")
     def test_trxandlocks_uses_performance_schema_for_mysql_8(self, query):
@@ -1102,7 +1170,7 @@ class TestMysql(SimpleTestCase):
         connect.return_value.get_server_info.return_value = "8.0.0"
         failed = ResultSet()
         failed.error = "unknown column account_locked"
-        fallback = ResultSet(rows=[("`u`@`%`", "u", "%")])
+        fallback = ResultSet(rows=[("u", "%")])
         grants = ResultSet(rows=[("grant usage",)])
         query.side_effect = [failed, fallback, grants]
         engine = MysqlEngine(instance=self.ins1)
@@ -1123,6 +1191,11 @@ class TestMysql(SimpleTestCase):
         self.assertEqual(execute.call_args_list[0].kwargs["sql"], "DROP USER `u`@`%`;")
         self.assertIn("new\\'pwd", execute.call_args_list[1].kwargs["sql"])
 
+        execute.reset_mock()
+        result = engine.drop_instance_user("`u`@`%`;DROP USER `x`@`%`")
+        self.assertEqual(result.error, "账号格式不合法")
+        execute.assert_not_called()
+
     @patch.object(MysqlEngine, "execute")
     def test_create_instance_user_multiple_hosts(self, execute):
         execute.return_value = ResultSet()
@@ -1136,5 +1209,134 @@ class TestMysql(SimpleTestCase):
         )
 
         self.assertEqual([row["host"] for row in result.rows], ["%", "localhost"])
-        self.assertIn("'some_user'@'%'", execute.call_args.kwargs["sql"])
-        self.assertIn("'some_user'@'localhost'", execute.call_args.kwargs["sql"])
+        self.assertIn("`some_user`@`%`", execute.call_args.kwargs["sql"])
+        self.assertIn("`some_user`@`localhost`", execute.call_args.kwargs["sql"])
+
+    @patch.object(MysqlEngine, "execute")
+    def test_instance_user_privilege_sql_is_validated_and_quoted(self, execute):
+        execute.return_value = ResultSet()
+        engine = MysqlEngine(instance=self.ins1)
+
+        result = engine.grant_instance_user(
+            user_host="`u`@`%`",
+            op_type=0,
+            priv_type=1,
+            privs={"db_privs": ["SELECT", "GRANT"]},
+            db_names=["app`db"],
+        )
+
+        self.assertIsNone(result.error)
+        self.assertEqual(
+            execute.call_args.kwargs["sql"],
+            "GRANT SELECT,GRANT OPTION ON `app``db`.* TO `u`@`%`;",
+        )
+
+        execute.reset_mock()
+        result = engine.grant_instance_user(
+            user_host="`u`@`%`",
+            op_type=0,
+            priv_type=1,
+            privs={"db_privs": ["SELECT;DROP USER"]},
+            db_names=["app"],
+        )
+
+        self.assertEqual(result.error, "权限项不合法")
+        execute.assert_not_called()
+
+    @patch.object(MysqlEngine, "execute")
+    def test_instance_user_lock_rejects_injected_user_host(self, execute):
+        execute.return_value = ResultSet()
+        engine = MysqlEngine(instance=self.ins1)
+
+        result = engine.set_instance_user_lock("`u`@`%`", "N")
+
+        self.assertIsNone(result.error)
+        self.assertEqual(
+            execute.call_args.kwargs["sql"], "ALTER USER `u`@`%` ACCOUNT LOCK;"
+        )
+
+        execute.reset_mock()
+        result = engine.set_instance_user_lock("`u`@`%`;DROP USER `x`@`%`", "N")
+
+        self.assertEqual(result.error, "账号格式不合法")
+        execute.assert_not_called()
+
+    @patch("sql.instance_account.get_engine")
+    @patch("sql.instance_account.user_instances")
+    def test_mysql_grant_view_delegates_to_engine_safe_method(
+        self, user_instances, get_engine
+    ):
+        request = RequestFactory().post(
+            "/instance/user/grant/",
+            data={
+                "instance_id": "1",
+                "user_host": "`u`@`%`",
+                "op_type": "0",
+                "priv_type": "1",
+                "privs": json.dumps(
+                    {
+                        "global_privs": [],
+                        "db_privs": ["SELECT"],
+                        "tb_privs": [],
+                        "col_privs": [],
+                    }
+                ),
+                "db_name[]": ["app"],
+            },
+        )
+        request.user = Mock()
+        request.user.has_perms.return_value = True
+        instance = Instance(id=1, db_type="mysql")
+        user_instances.return_value.get.return_value = instance
+        engine = Mock()
+        engine.grant_instance_user.return_value = ResultSet(
+            full_sql="GRANT SELECT ON `app`.* TO `u`@`%`;"
+        )
+        get_engine.return_value = engine
+
+        response = instance_account.grant(request)
+        data = json.loads(response.content)
+
+        self.assertEqual(data["status"], 0)
+        self.assertEqual(data["data"], "GRANT SELECT ON `app`.* TO `u`@`%`;")
+        engine.grant_instance_user.assert_called_once_with(
+            user_host="`u`@`%`",
+            op_type="0",
+            priv_type="1",
+            privs={
+                "global_privs": [],
+                "db_privs": ["SELECT"],
+                "tb_privs": [],
+                "col_privs": [],
+            },
+            db_names=["app"],
+            tb_names=None,
+            col_names=[],
+        )
+        engine.execute.assert_not_called()
+
+    @patch("sql.instance_account.get_engine")
+    @patch("sql.instance_account.user_instances")
+    def test_mysql_lock_view_delegates_to_engine_safe_method(
+        self, user_instances, get_engine
+    ):
+        request = RequestFactory().post(
+            "/instance/user/lock/",
+            data={"instance_id": "1", "user_host": "`u`@`%`", "is_locked": "N"},
+        )
+        request.user = Mock()
+        request.user.has_perms.return_value = True
+        instance = Instance(id=1, db_type="mysql")
+        user_instances.return_value.get.return_value = instance
+        engine = Mock()
+        engine.set_instance_user_lock.return_value = ResultSet()
+        get_engine.return_value = engine
+
+        response = instance_account.lock(request)
+        data = json.loads(response.content)
+
+        self.assertEqual(data["status"], 0)
+        engine.set_instance_user_lock.assert_called_once_with(
+            user_host="`u`@`%`", is_locked="N"
+        )
+        engine.execute.assert_not_called()

--- a/sql/instance_account.py
+++ b/sql/instance_account.py
@@ -179,76 +179,24 @@ def grant(request):
     engine = get_engine(instance=instance)
     if instance.db_type == "mysql":
         user_host = request.POST.get("user_host")
-        op_type = int(request.POST.get("op_type"))
-        priv_type = int(request.POST.get("priv_type"))
-        privs = json.loads(request.POST.get("privs"))
-
-        # escape
-        user_host = engine.escape_string(user_host)
-
-        # 全局权限
-        if priv_type == 0:
-            global_privs = privs["global_privs"]
-            if not all([global_privs]):
-                return JsonResponse(
-                    {"status": 1, "msg": "信息不完整，请确认后提交", "data": []}
-                )
-            global_privs = ["GRANT OPTION" if g == "GRANT" else g for g in global_privs]
-            if op_type == 0:
-                grant_sql = f"GRANT {','.join(global_privs)} ON *.* TO {user_host};"
-            elif op_type == 1:
-                grant_sql = f"REVOKE {','.join(global_privs)} ON *.* FROM {user_host};"
-
-        # 库权限
-        elif priv_type == 1:
-            db_privs = privs["db_privs"]
-            db_name = request.POST.getlist("db_name[]")
-            if not all([db_privs, db_name]):
-                return JsonResponse(
-                    {"status": 1, "msg": "信息不完整，请确认后提交", "data": []}
-                )
-            for db in db_name:
-                db_privs = ["GRANT OPTION" if d == "GRANT" else d for d in db_privs]
-                if op_type == 0:
-                    grant_sql += (
-                        f"GRANT {','.join(db_privs)} ON `{db}`.* TO {user_host};"
-                    )
-                elif op_type == 1:
-                    grant_sql += (
-                        f"REVOKE {','.join(db_privs)} ON `{db}`.* FROM {user_host};"
-                    )
-        # 表权限
-        elif priv_type == 2:
-            tb_privs = privs["tb_privs"]
-            db_name = request.POST.get("db_name")
-            tb_name = request.POST.getlist("tb_name[]")
-            if not all([tb_privs, db_name, tb_name]):
-                return JsonResponse(
-                    {"status": 1, "msg": "信息不完整，请确认后提交", "data": []}
-                )
-            for tb in tb_name:
-                tb_privs = ["GRANT OPTION" if t == "GRANT" else t for t in tb_privs]
-                if op_type == 0:
-                    grant_sql += f"GRANT {','.join(tb_privs)} ON `{db_name}`.`{tb}` TO {user_host};"
-                elif op_type == 1:
-                    grant_sql += f"REVOKE {','.join(tb_privs)} ON `{db_name}`.`{tb}` FROM {user_host};"
-        # 列权限
-        elif priv_type == 3:
-            col_privs = privs["col_privs"]
-            db_name = request.POST.get("db_name")
-            tb_name = request.POST.get("tb_name")
-            col_name = request.POST.getlist("col_name[]")
-            if not all([col_privs, db_name, tb_name, col_name]):
-                return JsonResponse(
-                    {"status": 1, "msg": "信息不完整，请确认后提交", "data": []}
-                )
-            for priv in col_privs:
-                if op_type == 0:
-                    grant_sql += f"GRANT {priv}(`{'`,`'.join(col_name)}`) ON `{db_name}`.`{tb_name}` TO {user_host};"
-                elif op_type == 1:
-                    grant_sql += f"REVOKE {priv}(`{'`,`'.join(col_name)}`) ON `{db_name}`.`{tb_name}` FROM {user_host};"
-        # 执行变更语句
-        exec_result = engine.execute(db_name="mysql", sql=grant_sql)
+        op_type = request.POST.get("op_type")
+        priv_type = request.POST.get("priv_type")
+        try:
+            privs = json.loads(request.POST.get("privs"))
+        except Exception:
+            return JsonResponse({"status": 1, "msg": "权限参数不合法", "data": []})
+        db_name = request.POST.getlist("db_name[]") or request.POST.get("db_name")
+        tb_name = request.POST.getlist("tb_name[]") or request.POST.get("tb_name")
+        col_name = request.POST.getlist("col_name[]")
+        exec_result = engine.grant_instance_user(
+            user_host=user_host,
+            op_type=op_type,
+            priv_type=priv_type,
+            privs=privs,
+            db_names=db_name,
+            tb_names=tb_name,
+            col_names=col_name,
+        )
     elif instance.db_type == "mongo":
         db_name_user = request.POST.get("db_name_user")
         roles = request.POST.getlist("roles[]")
@@ -266,6 +214,7 @@ def grant(request):
     engine.close()
     if exec_result.error:
         return JsonResponse({"status": 1, "msg": exec_result.error})
+    grant_sql = exec_result.full_sql
     return JsonResponse({"status": 0, "msg": "", "data": grant_sql})
 
 
@@ -346,16 +295,10 @@ def lock(request):
     except Instance.DoesNotExist:
         return JsonResponse({"status": 1, "msg": "你所在组未关联该实例", "data": []})
 
-    # escape
     engine = get_engine(instance=instance)
-    user_host = engine.escape_string(user_host)
-
-    if is_locked == "N":
-        lock_sql = f"ALTER USER {user_host} ACCOUNT LOCK;"
-    elif is_locked == "Y":
-        lock_sql = f"ALTER USER {user_host} ACCOUNT UNLOCK;"
-
-    exec_result = engine.execute(db_name="mysql", sql=lock_sql)
+    exec_result = engine.set_instance_user_lock(
+        user_host=user_host, is_locked=is_locked
+    )
     if exec_result.error:
         return JsonResponse({"status": 1, "msg": exec_result.error})
     return JsonResponse({"status": 0, "msg": "", "data": []})


### PR DESCRIPTION
1、修复sql注入问题：对原手动字符串拼接sql部分，增加参数化或者严格校验。
2、mysql权限管理移到引擎层：mysql engine 增加grant_instance_user方法。 
3、增加regex：高危语句使用regex正则判断，并增加超时，防止可能的Redos攻击问题。
4、修复mariadb兼容性：MariaDB 10.4.2版本之后引入的ACCOUNT LOCK功能需要查询mysql.global_priv表，而不是mysql.user表。
5、修复mariadb兼容性：trxandlocks获取锁信息一直采用的是旧表information_schema.INNODB_LOCKS