### PR TITLE
fix(oracle):cx-Oracle升级到官方继任者oracledb

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -73,7 +73,7 @@ jobs:
         sudo apt-get update && sudo apt-get install libsasl2-dev libkrb5-dev libldap2-dev libssl-dev unixodbc unixodbc-dev
         python -m pip install --upgrade pip
         pip install "setuptools<82" wheel
-        pip install --no-build-isolation "cx-Oracle==8.3.0"
+        pip install "oracledb==4.0.1"
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyodbc==5.*
 gunicorn==22.0.0
 pyecharts==2.0.4
 aliyun-python-sdk-rds==2.1.1
-cx-Oracle==8.3.0
+oracledb==4.0.1
 supervisor==4.1.0
 phoenixdb==1.2.1
 django-mirage-field==1.4.0

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -16,7 +16,7 @@ from sql.utils.sql_utils import (
     get_exec_sqlitem_list,
 )
 from . import EngineBase
-import cx_Oracle
+import oracledb
 from .models import ResultSet, ReviewSet, ReviewResult
 from sql.utils.data_masking import simple_column_mask
 
@@ -36,16 +36,16 @@ class OracleEngine(EngineBase):
         if self.conn:
             return self.conn
         if self.sid:
-            dsn = cx_Oracle.makedsn(self.host, self.port, self.sid)
-            self.conn = cx_Oracle.connect(
-                self.user, self.password, dsn=dsn, encoding="UTF-8", nencoding="UTF-8"
+            dsn = oracledb.makedsn(self.host, self.port, self.sid)
+            self.conn = oracledb.connect(
+                self.user, self.password, dsn=dsn
             )
         elif self.service_name:
-            dsn = cx_Oracle.makedsn(
+            dsn = oracledb.makedsn(
                 self.host, self.port, service_name=self.service_name
             )
-            self.conn = cx_Oracle.connect(
-                self.user, self.password, dsn=dsn, encoding="UTF-8", nencoding="UTF-8"
+            self.conn = oracledb.connect(
+                self.user, self.password, dsn=dsn
             )
         else:
             raise ValueError("sid 和 dsn 均未填写, 请联系管理页补充该实例配置.")

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -695,9 +695,9 @@ class OracleEngine(EngineBase):
                 sql = f"select PLAN_TABLE_OUTPUT from table(dbms_xplan.display)"
             cursor.execute(sql, parameters or [])
             fields = cursor.description
-            if any(x[1] == cx_Oracle.CLOB for x in fields):
+            if any(x[1] == oracledb.CLOB for x in fields):
                 rows = [
-                    tuple([(c.read() if type(c) == cx_Oracle.LOB else c) for c in r])
+                    tuple([(c.read() if type(c) == oracledb.LOB else c) for c in r])
                     for r in cursor
                 ]
                 if int(limit_num) > 0:
@@ -1430,9 +1430,9 @@ class OracleEngine(EngineBase):
             )
             cursor.execute(get_task_sql, {"task_name": task_name})
             fields = cursor.description
-            if any(x[1] == cx_Oracle.CLOB for x in fields):
+            if any(x[1] == oracledb.CLOB for x in fields):
                 rows = [
-                    tuple([(c.read() if type(c) == cx_Oracle.LOB else c) for c in r])
+                    tuple([(c.read() if type(c) == oracledb.LOB else c) for c in r])
                     for r in cursor
                 ]
             else:

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -37,16 +37,10 @@ class OracleEngine(EngineBase):
             return self.conn
         if self.sid:
             dsn = oracledb.makedsn(self.host, self.port, self.sid)
-            self.conn = oracledb.connect(
-                self.user, self.password, dsn=dsn
-            )
+            self.conn = oracledb.connect(self.user, self.password, dsn=dsn)
         elif self.service_name:
-            dsn = oracledb.makedsn(
-                self.host, self.port, service_name=self.service_name
-            )
-            self.conn = oracledb.connect(
-                self.user, self.password, dsn=dsn
-            )
+            dsn = oracledb.makedsn(self.host, self.port, service_name=self.service_name)
+            self.conn = oracledb.connect(self.user, self.password, dsn=dsn)
         else:
             raise ValueError("sid 和 dsn 均未填写, 请联系管理页补充该实例配置.")
         return self.conn

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -695,7 +695,7 @@ class OracleEngine(EngineBase):
                 sql = f"select PLAN_TABLE_OUTPUT from table(dbms_xplan.display)"
             cursor.execute(sql, parameters or [])
             fields = cursor.description
-            if any(x[1] == oracledb.CLOB for x in fields):
+            if any(x[1] == oracledb.DB_TYPE_CLOB for x in fields):
                 rows = [
                     tuple([(c.read() if type(c) == oracledb.LOB else c) for c in r])
                     for r in cursor
@@ -1430,7 +1430,7 @@ class OracleEngine(EngineBase):
             )
             cursor.execute(get_task_sql, {"task_name": task_name})
             fields = cursor.description
-            if any(x[1] == oracledb.CLOB for x in fields):
+            if any(x[1] == oracledb.DB_TYPE_CLOB for x in fields):
                 rows = [
                     tuple([(c.read() if type(c) == oracledb.LOB else c) for c in r])
                     for r in cursor

--- a/sql/engines/test_oracle.py
+++ b/sql/engines/test_oracle.py
@@ -46,8 +46,8 @@ class TestOracle(TestCase):
         SqlWorkflow.objects.all().delete()
         SqlWorkflowContent.objects.all().delete()
 
-    @patch("cx_Oracle.makedsn")
-    @patch("cx_Oracle.connect")
+    @patch("oracledb.makedsn")
+    @patch("oracledb.connect")
     def test_get_connection(self, _connect, _makedsn):
         # 填写 sid 测试
         new_engine = OracleEngine(self.ins)
@@ -74,7 +74,7 @@ class TestOracle(TestCase):
         with self.assertRaises(ValueError):
             new_engine.get_connection()
 
-    @patch("cx_Oracle.connect")
+    @patch("oracledb.connect")
     def test_engine_base_info(self, _conn):
         new_engine = OracleEngine(instance=self.ins)
         self.assertEqual(new_engine.name, "Oracle")
@@ -82,9 +82,9 @@ class TestOracle(TestCase):
         _conn.return_value.version = "12.1.0.2.0"
         self.assertTupleEqual(new_engine.server_version, ("12", "1", "0"))
 
-    @patch("cx_Oracle.connect.cursor.execute")
-    @patch("cx_Oracle.connect.cursor")
-    @patch("cx_Oracle.connect")
+    @patch("oracledb.connect.cursor.execute")
+    @patch("oracledb.connect.cursor")
+    @patch("oracledb.connect")
     def test_query(self, _conn, _cursor, _execute):
         _conn.return_value.cursor.return_value.fetchmany.return_value = [(1,)]
         new_engine = OracleEngine(instance=self.ins)
@@ -94,9 +94,9 @@ class TestOracle(TestCase):
         self.assertIsInstance(query_result, ResultSet)
         self.assertListEqual(query_result.rows, [(1,)])
 
-    @patch("cx_Oracle.connect.cursor.execute")
-    @patch("cx_Oracle.connect.cursor")
-    @patch("cx_Oracle.connect")
+    @patch("oracledb.connect.cursor.execute")
+    @patch("oracledb.connect.cursor")
+    @patch("oracledb.connect")
     def test_query_not_limit(self, _conn, _cursor, _execute):
         _conn.return_value.cursor.return_value.fetchall.return_value = [(1,)]
         new_engine = OracleEngine(instance=self.ins)
@@ -368,9 +368,9 @@ end;"""
         self.assertIsInstance(check_result, ReviewSet)
         self.assertEqual(check_result.rows[0].__dict__, row.__dict__)
 
-    @patch("cx_Oracle.connect.cursor.execute")
-    @patch("cx_Oracle.connect.cursor")
-    @patch("cx_Oracle.connect")
+    @patch("oracledb.connect.cursor.execute")
+    @patch("oracledb.connect.cursor")
+    @patch("oracledb.connect")
     def test_execute_workflow_success(self, _conn, _cursor, _execute):
         sql = "update user set id=1"
         review_row = ReviewResult(
@@ -420,9 +420,9 @@ end;"""
             execute_result.rows[0].__dict__.keys(), execute_row.__dict__.keys()
         )
 
-    @patch("cx_Oracle.connect.cursor.execute")
-    @patch("cx_Oracle.connect.cursor")
-    @patch("cx_Oracle.connect", return_value=RuntimeError)
+    @patch("oracledb.connect.cursor.execute")
+    @patch("oracledb.connect.cursor")
+    @patch("oracledb.connect", return_value=RuntimeError)
     def test_execute_workflow_exception(self, _conn, _cursor, _execute):
         sql = "update user set id=1"
         row = ReviewResult(
@@ -462,9 +462,9 @@ end;"""
                 execute_result.rows[0].__dict__.keys(), row.__dict__.keys()
             )
 
-    @patch("cx_Oracle.connect.cursor.execute")
-    @patch("cx_Oracle.connect.cursor")
-    @patch("cx_Oracle.connect")
+    @patch("oracledb.connect.cursor.execute")
+    @patch("oracledb.connect.cursor")
+    @patch("oracledb.connect")
     def test_execute(self, _connect, _cursor, _execute):
         new_engine = OracleEngine(instance=self.ins)
         sql = "update abc set count=1 where id=1;"
@@ -492,9 +492,9 @@ end;"""
         )
 
     @patch("sql.engines.oracle.OracleEngine.query")
-    @patch("cx_Oracle.connect.cursor.execute")
-    @patch("cx_Oracle.connect.cursor")
-    @patch("cx_Oracle.connect")
+    @patch("oracledb.connect.cursor.execute")
+    @patch("oracledb.connect.cursor")
+    @patch("oracledb.connect")
     def test_kill_session(self, _query, _connect, _cursor, _execute):
         new_engine = OracleEngine(instance=self.ins)
         _query.return_value.rows = (

--- a/sql/engines/test_oracle.py
+++ b/sql/engines/test_oracle.py
@@ -82,10 +82,8 @@ class TestOracle(TestCase):
         _conn.return_value.version = "12.1.0.2.0"
         self.assertTupleEqual(new_engine.server_version, ("12", "1", "0"))
 
-    @patch("oracledb.connect.cursor.execute")
-    @patch("oracledb.connect.cursor")
     @patch("oracledb.connect")
-    def test_query(self, _conn, _cursor, _execute):
+    def test_query(self, _conn):
         _conn.return_value.cursor.return_value.fetchmany.return_value = [(1,)]
         new_engine = OracleEngine(instance=self.ins)
         query_result = new_engine.query(
@@ -94,10 +92,8 @@ class TestOracle(TestCase):
         self.assertIsInstance(query_result, ResultSet)
         self.assertListEqual(query_result.rows, [(1,)])
 
-    @patch("oracledb.connect.cursor.execute")
-    @patch("oracledb.connect.cursor")
     @patch("oracledb.connect")
-    def test_query_not_limit(self, _conn, _cursor, _execute):
+    def test_query_not_limit(self, _conn):
         _conn.return_value.cursor.return_value.fetchall.return_value = [(1,)]
         new_engine = OracleEngine(instance=self.ins)
         query_result = new_engine.query(db_name=0, sql="select 1", limit_num=0)
@@ -368,10 +364,8 @@ end;"""
         self.assertIsInstance(check_result, ReviewSet)
         self.assertEqual(check_result.rows[0].__dict__, row.__dict__)
 
-    @patch("oracledb.connect.cursor.execute")
-    @patch("oracledb.connect.cursor")
     @patch("oracledb.connect")
-    def test_execute_workflow_success(self, _conn, _cursor, _execute):
+    def test_execute_workflow_success(self, _conn):
         sql = "update user set id=1"
         review_row = ReviewResult(
             id=1,
@@ -420,10 +414,8 @@ end;"""
             execute_result.rows[0].__dict__.keys(), execute_row.__dict__.keys()
         )
 
-    @patch("oracledb.connect.cursor.execute")
-    @patch("oracledb.connect.cursor")
     @patch("oracledb.connect", return_value=RuntimeError)
-    def test_execute_workflow_exception(self, _conn, _cursor, _execute):
+    def test_execute_workflow_exception(self, _conn):
         sql = "update user set id=1"
         row = ReviewResult(
             id=1,
@@ -462,10 +454,8 @@ end;"""
                 execute_result.rows[0].__dict__.keys(), row.__dict__.keys()
             )
 
-    @patch("oracledb.connect.cursor.execute")
-    @patch("oracledb.connect.cursor")
     @patch("oracledb.connect")
-    def test_execute(self, _connect, _cursor, _execute):
+    def test_execute(self, _connect):
         new_engine = OracleEngine(instance=self.ins)
         sql = "update abc set count=1 where id=1;"
         execute_result = new_engine.execute(sql)
@@ -492,16 +482,14 @@ end;"""
         )
 
     @patch("sql.engines.oracle.OracleEngine.query")
-    @patch("oracledb.connect.cursor.execute")
-    @patch("oracledb.connect.cursor")
     @patch("oracledb.connect")
-    def test_kill_session(self, _query, _connect, _cursor, _execute):
+    def test_kill_session(self, _connect, _query):
         new_engine = OracleEngine(instance=self.ins)
         _query.return_value.rows = (
             ("alter system kill session '12,123';",),
             ("alter system kill session '34,345';",),
         )
-        _execute.return_value = ResultSet()
+        _connect.return_value.cursor.return_value.execute.return_value = ResultSet()
         r = new_engine.kill_session([[12, 123], [34, 345]])
         self.assertIsInstance(r, ResultSet)
 

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
     && apt-get install -yq --no-install-recommends nginx mariadb-client \
     && source venv4archery/bin/activate \
     && pip install --no-cache-dir "setuptools<82" wheel \
-    && pip install --no-build-isolation --no-cache-dir "cx-Oracle==8.3.0" \
+    && pip install --no-cache-dir "oracledb==4.0.1" \
     && pip install --no-cache-dir -r /opt/archery/requirements.txt \
     && cp -f /opt/archery/src/docker/nginx.conf /etc/nginx/ \
     && cp -f /opt/archery/src/docker/supervisord.conf /etc/ \


### PR DESCRIPTION
cx-Oracle长期不更新，并且只兼容到python3.10版本，更新替换为oracledb，可支持更高版本的python。

cx-Oracle==8.3.0
替换为
oracledb==4.0.1


[oracledb](https://pypi.org/project/oracledb/)