### PR TITLE
bulid(redis):redis依赖升级

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,8 @@ psycopg2-binary==2.*
 pymysql==0.9.3
 mysql-replication==0.22
 django-q2==1.9.0
-django-redis==5.2.0
-redis==3.5.3
-redis-py-cluster==2.1.3
+django-redis==6.0.0
+redis>=5.0.0,<6.0.0
 pyodbc==5.*
 gunicorn==22.0.0
 pyecharts==2.0.4

--- a/sql/engines/redis.py
+++ b/sql/engines/redis.py
@@ -11,7 +11,7 @@ import re
 import shlex
 
 import redis
-import rediscluster
+from redis.cluster import RedisCluster
 import logging
 import traceback
 
@@ -28,8 +28,9 @@ class RedisEngine(EngineBase):
     def get_connection(self, db_name=None):
         db_name = db_name or self.db_name
         if self.mode == "cluster":
-            return rediscluster.RedisCluster(
-                startup_nodes=[{"host": self.host, "port": self.port}],
+            return RedisCluster(
+                host=self.host,
+                port=self.port,
                 username=self.user,
                 password=self.password or None,
                 encoding_errors="ignore",

--- a/sql/engines/test_redis.py
+++ b/sql/engines/test_redis.py
@@ -96,20 +96,21 @@ def test_get_connection_standalone_with_db_name(mock_redis, redis_engine):
     assert kwargs["db"] == "3"
 
 
-@patch("sql.engines.redis.rediscluster.RedisCluster")
+@patch("sql.engines.redis.RedisCluster")
 def test_get_connection_cluster(mock_redis_cluster, redis_cluster_engine):
     """测试集群模式获取连接"""
     redis_cluster_engine.get_connection()
     mock_redis_cluster.assert_called_once()
     kwargs = mock_redis_cluster.call_args.kwargs
-    assert kwargs["startup_nodes"] == [{"host": "127.0.0.1", "port": 7001}]
+    assert kwargs["host"] == "127.0.0.1"
+    assert kwargs["port"] == 7001
     assert kwargs["username"] == "ins_user"
     assert kwargs["password"] == "some_str"
     assert kwargs["decode_responses"] is True
     assert kwargs["ssl"] is False
 
 
-@patch("sql.engines.redis.rediscluster.RedisCluster")
+@patch("sql.engines.redis.RedisCluster")
 def test_get_connection_cluster_ignores_db_name(
     mock_redis_cluster, redis_cluster_engine
 ):


### PR DESCRIPTION
redis依赖升级
1、redis更新到5.3.1版本，支持redis server Version 5.0 to 7.4。
2、移除redis-py-cluster，已统一集成到redis
3、django-redis升级到6.0.0