### PR TITLE
Add int_as_string_bitcount parameter to JSON renderer

### DIFF
--- a/sql_api/renderers.py
+++ b/sql_api/renderers.py
@@ -53,6 +53,7 @@ class SimpleJSONRenderer(JSONRenderer):
             allow_nan=not self.strict,
             separators=separators,
             default=self.default,
+            int_as_string_bitcount=53,
         )
         # Keep DRF's default escaping so JSON stays safe if embedded into script content.
         ret = ret.replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")


### PR DESCRIPTION
处理bigint类型字段数据返回时，丢失精度的问题，大于53的整数都转换为字符串