### PR TITLE
fix(sqlquery):查询页面根据表名搜索实例功能优化

### DIFF
--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -83,6 +83,14 @@
                             </div>
                         </div>
                         <div class="col-md-3 column">
+                            <div class="form-group">
+                                <select id="table-locator-db-type" class="form-control selectpicker">
+                                    <option value="" selected="selected">请选择数据库类型</option>
+                                    {% for name, engine in engines.items %}
+                                        <option value="{{ name }}">{{ engine.name }}</option>
+                                    {%  endfor %}
+                                </select>
+                            </div>
                             <div class="form-group" id="div-table-locator">
                                 <input id="table-locator-input" type="text" class="form-control"
                                        placeholder="按表名定位实例（如 orders）" autocomplete="off"/>
@@ -1630,6 +1638,11 @@
         var _fillVersion = 0;   // 每次新的点击或搜索时自增，用于取消进行中的填充
 
         function locateTable() {
+            var dbType = $("#table-locator-db-type").val();
+            if (!dbType) {
+                alert("请选择数据库类型");
+                return;
+            }
             var tableName = $('#table-locator-input').val().trim();
             if (!tableName) {
                 $('#table-locator-results').empty();
@@ -1645,7 +1658,7 @@
                 url: '/api/v1/instance/table-instances/',
                 contentType: 'application/json',
                 dataType: 'json',
-                data: JSON.stringify({table_name: tableName}),
+                data: JSON.stringify({table_name: tableName,db_type: dbType}),
                 complete: function () {
                     $('#table-locator-loading').hide();
                     _locatorXHR = null;

--- a/sql_api/api_instance.py
+++ b/sql_api/api_instance.py
@@ -255,10 +255,13 @@ class TableInstanceLookup(views.APIView):
             msg = "参数校验失败"
             if "table_name" in errors:
                 msg = f"参数table_name错误: {errors['table_name'][0]}"
+            elif "db_type" in errors:
+                msg = f"参数db_type错误: {errors['db_type'][0]}"
             return Response({"status": 1, "msg": msg, "count": 0, "data": []})
 
+        db_type = serializer.validated_data["db_type"]
         table_name = serializer.validated_data["table_name"]
-        instances = user_instances(request.user)
+        instances = user_instances(request.user, db_type=[db_type])
 
         try:
             data = resolve_table_instances(

--- a/sql_api/serializers.py
+++ b/sql_api/serializers.py
@@ -287,6 +287,7 @@ class InstanceResourceListSerializer(serializers.Serializer):
 
 
 class TableInstanceLookupSerializer(serializers.Serializer):
+    db_type = serializers.CharField(label="数据库类型", max_length=32)
     table_name = serializers.CharField(label="表名", max_length=256)
 
 


### PR DESCRIPTION
基本不存在需要通过遍历所有实例来搜索表名的情况
添加一个可以选择数据库类型的下拉框，搜索之前先选择数据库类型
<img width="635" height="133" alt="image" src="https://github.com/user-attachments/assets/babff97c-1ac0-471b-9611-e12c9bb90150" />

如果未选择数据库类型，就填了表名，弹出alert
<img width="1491" height="243" alt="image" src="https://github.com/user-attachments/assets/4762e5bc-4991-4eba-942e-0cb5bd3ce8a6" />
