### PR TITLE
fix(oracle):修复oracledb强制要求使用全部关键字参数

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 pytest
-pytest-django
+pytest-django<4.9.0
 pytest-mock
 pytest-cov
 codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=4.2
+Django>=4.2,<5.1.0
 mysqlclient==2.*
 requests==2.31.0
 simplejson==3.17.2

--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -1368,7 +1368,7 @@ class MongoEngine(EngineBase):
         sql = re.sub(r"^\s*//.*$", "", sql, flags=re.MULTILINE)
         if sql.startswith("explain"):
             sql = sql[7:] + ".explain()"
-            sql = re.sub("[;\s]*.explain\(\)$", ".explain()", sql).strip()
+            sql = re.sub(r"[;\s]*.explain\(\)$", ".explain()", sql).strip()
         result = {"msg": "", "bad_query": False, "filtered_sql": sql, "has_star": False}
         pattern = re.compile(
             r"""^db\.(\w+\.?)+(?:\([\s\S]*\)(\s*;*)$)|^db\.getCollection\((?:\s*)(?:'|")(\w+\.?)+('|")(\s*)\)\.([A-Za-z]+)(\([\s\S]*\)(\s*;*)$)"""

--- a/sql/engines/odps.py
+++ b/sql/engines/odps.py
@@ -109,7 +109,7 @@ class ODPSEngine(EngineBase):
 
         # 存在limit，替换limit; 不存在，添加limit
         if re.search("limit", sql):
-            sql = re.sub("limit.+(\d+)", "limit " + str(limit_num), sql)
+            sql = re.sub(r"limit.+(\d+)", "limit " + str(limit_num), sql)
         else:
             if sql.strip()[-1] == ";":
                 sql = sql[:-1]

--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -37,10 +37,14 @@ class OracleEngine(EngineBase):
             return self.conn
         if self.sid:
             dsn = oracledb.makedsn(self.host, self.port, self.sid)
-            self.conn = oracledb.connect(self.user, self.password, dsn=dsn)
+            self.conn = oracledb.connect(
+                user=self.user, password=self.password, dsn=dsn
+            )
         elif self.service_name:
             dsn = oracledb.makedsn(self.host, self.port, service_name=self.service_name)
-            self.conn = oracledb.connect(self.user, self.password, dsn=dsn)
+            self.conn = oracledb.connect(
+                user=self.user, password=self.password, dsn=dsn
+            )
         else:
             raise ValueError("sid 和 dsn 均未填写, 请联系管理页补充该实例配置.")
         return self.conn


### PR DESCRIPTION
原升级[#3216](https://github.com/hhyo/Archery/pull/3216)，

1、在老版本 cx_Oracle 中： cx_Oracle.connect() 允许按顺序传入 user 和 password，然后再通过 dsn=dsn 指定数据源，代码能正确地将它们区分开。
2、在新版本 oracledb 中：未指明参数时，第一个位置参数 self.user 优先尝试映射到 dsn ，后面又有dsn=dsn ，导致出现重复报错。got multiple values for argument 'dsn'



CI/CD故障修复：
1、Django版本固定：防止升级到最新版，强制要求mysql8.4
2、正则修复：正则表达式警告修复
