### PR TITLE
fix(mongo):mongo引擎优化

### DIFF
--- a/sql/engines/mongo.py
+++ b/sql/engines/mongo.py
@@ -13,6 +13,7 @@ from dateutil.parser import parse
 from bson.objectid import ObjectId
 from bson.int64 import Int64
 from bson.regex import Regex
+from bson.decimal128 import Decimal128
 
 from sql.utils.data_masking import data_masking
 
@@ -234,6 +235,7 @@ class JsonDecoder:
                     "ISODate",
                     "newISODate",
                     "NumberLong",
+                    "NumberDecimal",
                 ):  # ======类似的类型比较多还需单独处理，如int()等
                     data_type = outstr
                     for c in self.__remain_str():
@@ -273,6 +275,12 @@ class JsonDecoder:
                     id_str = re.findall(r"\(.*?\)", nuStr[0])
                     nlong = id_str[0].replace(" ", "")[2:-2]
                     return Int64(nlong)
+            elif data_type.replace(" ", "") in ("NumberDecimal",):
+                ndStr = re.findall(r"NumberDecimal\(.*?\)", outstr)
+                if len(ndStr) > 0:
+                    id_str = re.findall(r"\(.*?\)", ndStr[0])
+                    ndec = id_str[0].replace(" ", "")[2:-2].strip("'\"")
+                    return Decimal128(ndec)
             elif stripped:
                 return stripped
             raise Exception('Invalid symbol "%s"' % outstr)
@@ -817,6 +825,16 @@ class MongoEngine(EngineBase):
                         f"mongo语句执行报错，语句：{exec_sql}，错误信息{traceback.format_exc()}"
                     )
                     execute_result.error = str(e)
+                    line += 1
+                    result = ReviewResult(
+                        id=line,
+                        stage="Execute failed",
+                        errlevel=2,
+                        stagestatus="异常终止",
+                        errormessage=f"mongo语句执行报错: {str(e)}",
+                        sql=exec_sql,
+                    )
+                    execute_result.rows += [result]
             # result_set.column_list = [i[0] for i in fields] if fields else []
         return execute_result
 
@@ -832,8 +850,6 @@ class MongoEngine(EngineBase):
         sql = sql.strip()
         # sql 检查过滤注释语句
         sql = re.sub(r"^\s*//.*$", "", sql, flags=re.MULTILINE)
-        if sql.find(";") < 0:
-            raise Exception("提交的语句请以分号结尾")
         # 以；切分语句，逐句执行
         sp_sql = sql.split(";")
         # 执行语句

--- a/sql/engines/test_mongo.py
+++ b/sql/engines/test_mongo.py
@@ -107,6 +107,17 @@ class TestJsonDecoder:
         val = self.de.decode("{'a':-10}")
         assert val["a"] == -10
 
+    def test_decode_regex_multiline(self):
+        val = self.de.decode(r"{'name':/archery/m}")
+        assert val["name"].flags & re.MULTILINE
+
+    def test_decode_number_decimal(self):
+        from bson.decimal128 import Decimal128
+
+        val = self.de.decode("{'price': NumberDecimal('1299.99')}")
+        assert isinstance(val["price"], Decimal128)
+        assert str(val["price"]) == "1299.99"
+
     def test_decode_regex_literal(self):
         val = self.de.decode(r"{'name':/archery.*/im}")
         assert isinstance(val["name"], Regex)
@@ -774,10 +785,10 @@ class TestExecuteCheck:
     ):
         mock_get_tables.return_value = MagicMock(rows=["test"])
         mock_sys_config.return_value.get.return_value = False
-        with pytest.raises(Exception, match="请以分号结尾"):
-            mongo_engine.execute_check(
-                db_name="test_db", sql="db.test.insertOne({'a':1})"
-            )
+        result = mongo_engine.execute_check(
+            db_name="test_db", sql="db.test.insertOne({'a':1})"
+        )
+        assert result.error_count == 0
 
     @patch("sql.engines.mongo.SysConfig")
     @patch.object(MongoEngine, "get_all_tables")


### PR DESCRIPTION
1、优化分号检查：允许单条或最后一条语句不带分号。
2、增加NumberDecimal的解析：修复解析异常。
3、完善单元测试。

测试语句运行正常：
db.products.insertOne({ name: "Laptop", price: NumberDecimal("1299.99") }) 