### PR TITLE
fix(mysql): 修复获取实例只读状态时因连接异常导致的 IndexError

### DIFF
--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -1394,7 +1394,24 @@ class MysqlEngine(EngineBase):
     def execute_workflow(self, workflow):
         """执行上线单，返回Review set"""
         # 判断实例是否只读
-        read_only = self.query(sql="SELECT @@global.read_only;").rows[0][0]
+        read_only_result = self.query(sql="SELECT @@global.read_only;")
+        if getattr(read_only_result, "error", None):
+            result = ReviewSet(
+                full_sql=workflow.sqlworkflowcontent.sql_content,
+                rows=[
+                    ReviewResult(
+                        id=1,
+                        errlevel=2,
+                        stagestatus="Execute Failed",
+                        errormessage=f"获取实例read_only状态失败: {read_only_result.error}",
+                        sql=workflow.sqlworkflowcontent.sql_content,
+                    )
+                ],
+            )
+            result.error = (f"获取实例read_only状态失败: {read_only_result.error}",)
+            return result
+
+        read_only = read_only_result.rows[0][0] if read_only_result.rows else None
         if read_only in (1, "ON"):
             result = ReviewSet(
                 full_sql=workflow.sqlworkflowcontent.sql_content,

--- a/sql/engines/mysql.py
+++ b/sql/engines/mysql.py
@@ -1395,7 +1395,8 @@ class MysqlEngine(EngineBase):
         """执行上线单，返回Review set"""
         # 判断实例是否只读
         read_only_result = self.query(sql="SELECT @@global.read_only;")
-        if getattr(read_only_result, "error", None):
+        if getattr(read_only_result, "error", None) or not read_only_result.rows:
+            error_msg = getattr(read_only_result, "error", None) or "查询结果为空"
             result = ReviewSet(
                 full_sql=workflow.sqlworkflowcontent.sql_content,
                 rows=[
@@ -1403,15 +1404,15 @@ class MysqlEngine(EngineBase):
                         id=1,
                         errlevel=2,
                         stagestatus="Execute Failed",
-                        errormessage=f"获取实例read_only状态失败: {read_only_result.error}",
+                        errormessage=f"获取实例read_only状态失败: {error_msg}",
                         sql=workflow.sqlworkflowcontent.sql_content,
                     )
                 ],
             )
-            result.error = (f"获取实例read_only状态失败: {read_only_result.error}",)
+            result.error = (f"获取实例read_only状态失败: {error_msg}",)
             return result
 
-        read_only = read_only_result.rows[0][0] if read_only_result.rows else None
+        read_only = read_only_result.rows[0][0]
         if read_only in (1, "ON"):
             result = ReviewSet(
                 full_sql=workflow.sqlworkflowcontent.sql_content,


### PR DESCRIPTION
当查询 @@global.read_only 发生连接超时等网络异常时，self.query 返回的 rows 为空。
原代码强依赖 rows[0][0] 会导致 IndexError，进而引起 django-q worker 任务崩溃。
通过增加获取状态失败的捕获与空结果判断，以优雅地返回带有失败信息的 ReviewSet 解决此问题。
