### PR TITLE
fix(my2sql):修复binlog.py的部分异常

### DIFF
--- a/sql/binlog.py
+++ b/sql/binlog.py
@@ -104,8 +104,9 @@ def del_binlog(request):
 
     if binlog:
         query_engine = get_engine(instance=instance)
-        binlog = query_engine.escape_string(binlog)
-        query_result = query_engine.query(sql=rf"purge master logs to '{binlog}';")
+        query_result = query_engine.query(
+            sql="purge master logs to %s;", parameters=(binlog,)
+        )
         if query_result.error is None:
             result = {"status": 0, "msg": "清理成功", "data": ""}
         else:
@@ -268,8 +269,8 @@ def my2sql(request):
         async_task(
             my2sql_file,
             args=args,
-            user=request.user,
-            hook=notify_for_my2sql,
+            user=request.user.username,
+            hook="sql.notify.notify_for_my2sql",
             timeout=-1,
             task_name=f"my2sql-{time.time()}",
         )
@@ -290,20 +291,38 @@ def my2sql_file(args, user):
     """
     my2sql = My2SQL()
     instance = args.pop("instance")
+
+    # 应该获取解密后的账号密码
+    username, password = instance.get_username_password()
+
     args.update(
         {
             "host": instance.host,
-            "user": instance.user,
-            "password": instance.password,
+            "user": username,
+            "password": password,
             "port": instance.port,
         }
     )
-    path = os.path.join(settings.BASE_DIR, "downloads/my2sql/")
+
+    # 每次生成唯一的目录，避免目录非空导致 my2sql 失败
+    dir_name = f"{instance.host}_{int(time.time())}"
+    path = os.path.join(settings.BASE_DIR, "downloads", "my2sql", dir_name)
     os.makedirs(path, exist_ok=True)
 
     # 参数转换
     args["output-dir"] = path
     cmd_args = my2sql.generate_args2cmd(args)
     # 使用output-dir参数执行命令保存sql
-    my2sql.execute_cmd(cmd_args)
+    p = my2sql.execute_cmd(cmd_args)
+    stdout, stderr = p.communicate()
+
+    if p.returncode != 0:
+        logger.error(f"my2sql_file execute failed, stderr: {stderr}, stdout: {stdout}")
+        raise RuntimeError(f"my2sql执行失败，错误信息: {stderr or stdout}")
+
+    # 如果执行成功，但目录下没有任何文件，可能是 my2sql 工具校验失败（比如参数错误、目录权限等）导致静默退出
+    if not os.listdir(path):
+        logger.error(f"my2sql_file output empty, stderr: {stderr}, stdout: {stdout}")
+        raise RuntimeError(f"my2sql执行成功但未生成文件，可能静默失败，输出: {stdout}")
+
     return user, path

--- a/sql/templates/my2sql.html
+++ b/sql/templates/my2sql.html
@@ -85,6 +85,7 @@
                         </div>
                         <div class="form-group">
                             <select id="start_file" class="selectpicker form-control"
+                                    data-live-search="true"
                                     title="起始解析文件:"
                                     required>
                             </select>
@@ -95,6 +96,7 @@
                         </div>
                         <div class="form-group">
                             <select id="end_file" class="selectpicker form-control"
+                                    data-live-search="true"
                                     title="终止解析文件(可选):"
                                     required>
                             </select>

--- a/sql/test_binlog.py
+++ b/sql/test_binlog.py
@@ -303,7 +303,6 @@ def test_del_binlog_no_binlog_selected(client_with_super_user, db_instance):
 def test_del_binlog_success(mock_get_engine, client_with_super_user, db_instance):
     """清理binlog成功"""
     mock_engine = MagicMock()
-    mock_engine.escape_string.return_value = "mysql-bin.000001"
     mock_engine.query.return_value = _make_query_result(columns=[], rows=[], error=None)
     mock_get_engine.return_value = mock_engine
 
@@ -312,17 +311,16 @@ def test_del_binlog_success(mock_get_engine, client_with_super_user, db_instance
     result = json.loads(r.content)
     assert result["status"] == 0
     assert result["msg"] == "清理成功"
-    # 验证 escape_string 被调用
-    mock_engine.escape_string.assert_called_once_with("mysql-bin.000001")
     # 验证 purge 命令被正确执行
-    mock_engine.query.assert_called_once()
+    mock_engine.query.assert_called_once_with(
+        sql="purge master logs to %s;", parameters=("mysql-bin.000001",)
+    )
 
 
 @patch("sql.binlog.get_engine")
 def test_del_binlog_fail(mock_get_engine, client_with_super_user, db_instance):
     """清理binlog失败"""
     mock_engine = MagicMock()
-    mock_engine.escape_string.return_value = "mysql-bin.000001"
     mock_engine.query.return_value = _make_query_result(
         columns=[], rows=[], error="purge error"
     )

--- a/sql/test_binlog.py
+++ b/sql/test_binlog.py
@@ -796,7 +796,10 @@ def test_my2sql_file_success(mock_makedirs, mock_my2sql_cls, db_instance, settin
 
     mock_my2sql = MagicMock()
     mock_my2sql.generate_args2cmd.return_value = ["my2sql", "-output-dir", "/tmp"]
-    mock_my2sql.execute_cmd.return_value = MagicMock()
+    mock_process = MagicMock()
+    mock_process.communicate.return_value = ("stdout", "stderr")
+    mock_process.returncode = 0
+    mock_my2sql.execute_cmd.return_value = mock_process
     mock_my2sql_cls.return_value = mock_my2sql
 
     user = MagicMock()
@@ -806,8 +809,12 @@ def test_my2sql_file_success(mock_makedirs, mock_my2sql_cls, db_instance, settin
         "work-type": "2sql",
     }
 
-    result = my2sql_file(args, user)
-    assert result == (user, os.path.join("/tmp/archery_test", "downloads/my2sql/"))
+    # Patch os.listdir for test_my2sql_file_success
+    with patch("sql.binlog.os.listdir", return_value=["some_file.sql"]):
+        result = my2sql_file(args, user)
+    assert result[0] == user
+    expected_path_prefix = os.path.join("/tmp/archery_test", "downloads", "my2sql")
+    assert result[1].startswith(expected_path_prefix)
     # 验证参数中 instance 被弹出
     call_args = mock_my2sql.generate_args2cmd.call_args[0][0]
     assert "instance" not in call_args
@@ -826,7 +833,10 @@ def test_my2sql_file_args_updated(
 
     mock_my2sql = MagicMock()
     mock_my2sql.generate_args2cmd.return_value = ["my2sql"]
-    mock_my2sql.execute_cmd.return_value = MagicMock()
+    mock_process = MagicMock()
+    mock_process.communicate.return_value = ("stdout", "stderr")
+    mock_process.returncode = 0
+    mock_my2sql.execute_cmd.return_value = mock_process
     mock_my2sql_cls.return_value = mock_my2sql
 
     user = MagicMock()
@@ -836,7 +846,8 @@ def test_my2sql_file_args_updated(
         "work-type": "2sql",
     }
 
-    my2sql_file(args, user)
+    with patch("sql.binlog.os.listdir", return_value=["some_file.sql"]):
+        my2sql_file(args, user)
     # 验证 instance 的连接信息被重新放入 args
     call_args = mock_my2sql.generate_args2cmd.call_args[0][0]
     assert call_args["host"] == db_instance.host
@@ -853,7 +864,10 @@ def test_my2sql_file_execute_cmd_called(
 
     mock_my2sql = MagicMock()
     mock_my2sql.generate_args2cmd.return_value = ["my2sql", "-output-dir", "/tmp"]
-    mock_my2sql.execute_cmd.return_value = MagicMock()
+    mock_process = MagicMock()
+    mock_process.communicate.return_value = ("stdout", "stderr")
+    mock_process.returncode = 0
+    mock_my2sql.execute_cmd.return_value = mock_process
     mock_my2sql_cls.return_value = mock_my2sql
 
     user = MagicMock()
@@ -862,5 +876,6 @@ def test_my2sql_file_execute_cmd_called(
         "start-file": "mysql-bin.000001",
     }
 
-    my2sql_file(args, user)
+    with patch("sql.binlog.os.listdir", return_value=["some_file.sql"]):
+        my2sql_file(args, user)
     mock_my2sql.execute_cmd.assert_called_once_with(["my2sql", "-output-dir", "/tmp"])

--- a/sql/tests.py
+++ b/sql/tests.py
@@ -1505,9 +1505,10 @@ class TestBinLog(TestCase):
         r = self.client.post(path="/binlog/my2sql/", data=data)
         self.assertEqual(json.loads(r.content), {"status": 0, "msg": "ok", "data": []})
 
+    @patch("sql.binlog.os.listdir")
     @patch("builtins.open")
     @patch("sql.plugins.plugin.subprocess")
-    def test_my2sql_file(self, _open, _subprocess):
+    def test_my2sql_file(self, _subprocess, _open, _listdir):
         """
         测试保存文件
         :param _subprocess:
@@ -1517,6 +1518,8 @@ class TestBinLog(TestCase):
             "some_stdout",
             "some_stderr",
         )
+        _subprocess.Popen.return_value.returncode = 0
+        _listdir.return_value = ["some_file.sql"]
         self.sys_config.set("my2sql", "/opt/archery/src/plugins/my2sql")
         args = {
             "instance_name": "test_instance",


### PR DESCRIPTION
1、增加参数化表达：字符串拼接purge master logs改为参数化表达式。
2、异步通知任务修复：由于django-q框架升级到django-q2，函数对象会严格校验，修改hook参数为标准方式。
3、异步保存文件修复：生成带时间戳的独立my2sql目录；修复user对象参数异常；增加其他异常提示。
4、下拉筛选增加搜索输入框：起始解析文件和终止解析文件增加搜索功能，类似数据库过滤的搜索。