### PR TITLE
查询结果支持复制为 Markdown

### DIFF
--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -593,6 +593,16 @@
             };
         }
 
+        function query_result_active_sql_cache() {
+            var tabs = document.querySelectorAll('#nav-tabs li');
+            for (var i = 0; i < tabs.length; i++) {
+                if (tabs[i].getAttribute('class') === 'active' && tabs[i].children[1]) {
+                    return tabs[i].children[1].getAttribute('sql_cache');
+                }
+            }
+            return '';
+        }
+
         function query_result_copy(content) {
             // 内网 HTTP 部署中 clipboard API 不可用时，回退到 execCommand 复制纯文本。
             if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -626,7 +636,7 @@
                 var markdown_rows = [];
                 var titles = [];
                 $.each(result.columns, function (index, column) {
-                    titles.push(query_result_cell_text(column.title).replace(/<[^>]*>/g, '').replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/[\r\n]+/g, ' '));
+                    titles.push(query_result_cell_text(column.title).replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/[\r\n]+/g, ' '));
                 });
                 markdown_rows.push('| ' + titles.join(' | ') + ' |');
                 markdown_rows.push('| ' + $.map(titles, function () { return '---'; }).join(' | ') + ' |');
@@ -639,6 +649,17 @@
                 });
                 query_result_copy(markdown_rows.join('\n')).then(function (copied) {
                     button.prop('disabled', false).text(copied === false ? '复制失败' : '已复制');
+                    if (copied !== false) {
+                        $.ajax({
+                            type: 'post',
+                            url: '/audit/input/',
+                            dataType: 'json',
+                            data: {
+                                action: '复制Markdown',
+                                extra_info: $('#instance_name').val() + '/' + $('#db_name').val() + '|' + query_result_active_sql_cache() + '|' + result.rows.length
+                            }
+                        });
+                    }
                     setTimeout(function () {
                         button.text('复制为Markdown');
                     }, 1500);
@@ -656,16 +677,21 @@
             }
         }
 
-        function query_result_build_buttons(query_result_id) {
+        function query_result_build_buttons(showExport, query_result_id) {
+            if (!showExport) {
+                return {};
+            }
             return {
                 copyMarkdown: {
                     html: '<button class="btn btn-default" type="button" name="copyMarkdown" title="复制查询结果为Markdown表格">复制为Markdown</button>',
                     event: function () {
                         var button = $(this.$toolbar).find('button[name="copyMarkdown"]');
                         button.prop('disabled', true).text('复制中…');
-                        setTimeout(function () {
+                        try {
                             query_result_copy_markdown(query_result_id, button);
-                        }, 50);
+                        } catch (e) {
+                            button.prop('disabled', false).text('复制失败');
+                        }
                     }
                 }
             };
@@ -931,6 +957,7 @@
                 $("#execute_result_tab"+n).append("<p style=\"display:none\">"+query_str+"</p>");
 
                 //显示查询结果
+                var can_download_flag = {{can_download}}===1;
                 if (result['column_list']) {
                     //异步获取要动态生成的列
                     let columns = [];
@@ -988,6 +1015,7 @@
                                     },
                                 }
                                 ],
+                                buttons: query_result_build_buttons(can_download_flag, "query_result" + n),
                                 locale: 'zh-CN'
                             }
                         );
@@ -998,7 +1026,7 @@
                         if (optgroup === 'Mongo' || optgroup === 'Redis') {
                             isdetail = true
                         }
-                        var showExport = {{can_download}}===1
+                        var showExport = can_download_flag;
                         var query_result_id=(`query_result${n}`);
                         $(`#${query_result_id}`).bootstrapTable('destroy').bootstrapTable({
                             escape: true,
@@ -1007,7 +1035,7 @@
                             showExport: showExport,
                             exportDataType: "all",
                             exportTypes: ['json', 'sql', 'csv', 'txt', 'xml', 'xlsx'],
-                            buttons: query_result_build_buttons(query_result_id),
+                            buttons: query_result_build_buttons(showExport, query_result_id),
                             exportOptions: {
                                 //ignoreColumn: [0],  //忽略某些列的索引数组
                                 fileName: function () {

--- a/sql/templates/sqlquery.html
+++ b/sql/templates/sqlquery.html
@@ -574,6 +574,103 @@
             $("#nav-tabs a:last").tab('show');
         }
 
+        // null/undefined 与 bootstrap-table 的 undefinedText 保持一致，统一显示为 (null)
+        function query_result_cell_text(value) {
+            if (value === null || typeof value === 'undefined') {
+                return '(null)';
+            }
+            if (value instanceof Array || value instanceof Object) {
+                return JSON.stringify(value);
+            }
+            return String(value);
+        }
+
+        function query_result_data(query_result_id) {
+            var table = $("#" + query_result_id);
+            return {
+                columns: table.bootstrapTable('getVisibleColumns'),
+                rows: table.bootstrapTable('getData')
+            };
+        }
+
+        function query_result_copy(content) {
+            // 内网 HTTP 部署中 clipboard API 不可用时，回退到 execCommand 复制纯文本。
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                return navigator.clipboard.writeText(content).catch(function () {
+                    return query_result_copy_by_exec_command(content);
+                });
+            }
+            return query_result_copy_by_exec_command(content);
+        }
+
+        function query_result_copy_by_exec_command(content) {
+            var textarea = document.createElement('textarea');
+            var active_element = document.activeElement;
+            textarea.value = content;
+            textarea.setAttribute('readonly', '');
+            textarea.style.position = 'fixed';
+            textarea.style.opacity = '0';
+            document.body.appendChild(textarea);
+            textarea.select();
+            var copied = document.execCommand('copy');
+            document.body.removeChild(textarea);
+            if (active_element && active_element.isConnected) {
+                active_element.focus();
+            }
+            return Promise.resolve(copied);
+        }
+
+        function query_result_copy_markdown(query_result_id, button) {
+            try {
+                var result = query_result_data(query_result_id);
+                var markdown_rows = [];
+                var titles = [];
+                $.each(result.columns, function (index, column) {
+                    titles.push(query_result_cell_text(column.title).replace(/<[^>]*>/g, '').replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/[\r\n]+/g, ' '));
+                });
+                markdown_rows.push('| ' + titles.join(' | ') + ' |');
+                markdown_rows.push('| ' + $.map(titles, function () { return '---'; }).join(' | ') + ' |');
+                $.each(result.rows, function (row_index, row) {
+                    var values = [];
+                    $.each(result.columns, function (column_index, column) {
+                        values.push(query_result_cell_text(row[column.field]).replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/[\r\n]+/g, ' '));
+                    });
+                    markdown_rows.push('| ' + values.join(' | ') + ' |');
+                });
+                query_result_copy(markdown_rows.join('\n')).then(function (copied) {
+                    button.prop('disabled', false).text(copied === false ? '复制失败' : '已复制');
+                    setTimeout(function () {
+                        button.text('复制为Markdown');
+                    }, 1500);
+                }).catch(function () {
+                    button.prop('disabled', false).text('复制失败');
+                    setTimeout(function () {
+                        button.text('复制为Markdown');
+                    }, 1500);
+                });
+            } catch (e) {
+                button.prop('disabled', false).text('复制失败');
+                setTimeout(function () {
+                    button.text('复制为Markdown');
+                }, 1500);
+            }
+        }
+
+        function query_result_build_buttons(query_result_id) {
+            return {
+                copyMarkdown: {
+                    html: '<button class="btn btn-default" type="button" name="copyMarkdown" title="复制查询结果为Markdown表格">复制为Markdown</button>',
+                    event: function () {
+                        var button = $(this.$toolbar).find('button[name="copyMarkdown"]');
+                        button.prop('disabled', true).text('复制中…');
+                        setTimeout(function () {
+                            query_result_copy_markdown(query_result_id, button);
+                        }, 50);
+                    }
+                }
+            };
+        }
+
         //添加执行结果页面
         function tab_add(tab_title) {
             var tab_number = sessionStorage.getItem('tab_num');
@@ -910,6 +1007,7 @@
                             showExport: showExport,
                             exportDataType: "all",
                             exportTypes: ['json', 'sql', 'csv', 'txt', 'xml', 'xlsx'],
+                            buttons: query_result_build_buttons(query_result_id),
                             exportOptions: {
                                 //ignoreColumn: [0],  //忽略某些列的索引数组
                                 fileName: function () {


### PR DESCRIPTION
## 功能说明

SQL 查询页每个「执行结果」标签页的工具栏新增**「复制为Markdown」**按钮，一键将当前查询结果复制为 Markdown 表格文本，便于粘贴到 Wiki、邮件、IM 等场景。

## 实现说明

- 基于 bootstrap-table 1.22 的自定义 `buttons` 选项实现，按钮样式与工具栏原生按钮一致（按钮 HTML 通过 `html` 字段自定义，规避 `showButtonText` 默认关闭导致文本不渲染的问题）
- 取数口径与页面显示一致：`getVisibleColumns`（隐藏列不参与）+ `getData`（全量数据）；数组/对象值 `JSON.stringify`，null/undefined 显示为 `(null)`（与表格 `undefinedText` 口径一致）
- Markdown 转义：单元格中的 `\` 与 `|` 先后转义、换行替换为空格，保证粘贴后表格结构不被破坏
- **纯前端实现**：无后端/API 变更、无新增依赖，单文件改动

## 兼容性

- 复制优先使用 Clipboard API；HTTP 内网部署（非安全上下文）下自动回退 `document.execCommand(copy)`，并恢复页面焦点
- 生成与复制过程中的同步异常均有兜底，按钮状态始终可恢复（成功提示「已复制」/失败提示「复制失败」）

## 测试

- 本地部署实测：含 null、竖线、换行、JSON、中文样本数据，复制后 Markdown 表格渲染正常
- HTTP 非安全上下文（execCommand 回退路径）实测通过